### PR TITLE
perf(html): cache selectors + single-pass whitespace normalization

### DIFF
--- a/crates/fleischwolf/Cargo.toml
+++ b/crates/fleischwolf/Cargo.toml
@@ -11,8 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
 # The 25 MB output-regression corpus under tests/ is dev-only — keep it out of
-# the published crate (and under crates.io's size limit).
-exclude = ["tests"]
+# the published crate (and under crates.io's size limit). benches/ reference that
+# corpus by path, so they're dev-only too.
+exclude = ["tests", "benches"]
 
 [dependencies]
 calamine = { version = "0.26", features = ["dates"] }
@@ -37,3 +38,10 @@ zip = { version = "2.2", default-features = false, features = ["deflate"] }
 [[example]]
 name = "convert"
 path = "examples/convert.rs"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "parse"
+harness = false

--- a/crates/fleischwolf/benches/parse.rs
+++ b/crates/fleischwolf/benches/parse.rs
@@ -1,0 +1,60 @@
+//! Parsing micro-benchmarks for the declarative backends (HTML, DOCX).
+//!
+//! Each backend is driven directly by reference (no per-iteration clone), so the
+//! numbers reflect parse + serialize work, not input copying. Inputs come from
+//! the committed corpus under `tests/data/`.
+//!
+//! Run:  cargo bench -p fleischwolf --bench parse
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use fleischwolf::backend::{DeclarativeBackend, DocxBackend, HtmlBackend};
+use fleischwolf::{InputFormat, SourceDocument};
+
+const CORPUS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/data");
+
+fn load(rel: &str, fmt: InputFormat) -> SourceDocument {
+    let bytes = std::fs::read(format!("{CORPUS}/{rel}")).unwrap_or_else(|e| panic!("{rel}: {e}"));
+    SourceDocument::from_bytes("bench", fmt, bytes)
+}
+
+fn html(c: &mut Criterion) {
+    let mut g = c.benchmark_group("html");
+    for (name, file) in [
+        // A large, realistic page: headings, lists, several tables, links.
+        ("wiki_duck", "html/sources/wiki_duck.html"),
+        // Table-cell heavy: exercises the per-cell rich/has_descendant path.
+        (
+            "rich_table_cells",
+            "html/sources/html_rich_table_cells.html",
+        ),
+    ] {
+        let src = load(file, InputFormat::Html);
+        g.bench_function(name, |b| {
+            b.iter(|| black_box(HtmlBackend.convert(black_box(&src)).unwrap()))
+        });
+    }
+    g.finish();
+}
+
+fn docx(c: &mut Criterion) {
+    let mut g = c.benchmark_group("docx");
+    for (name, file) in [
+        ("rich_tables", "docx/sources/docx_rich_tables_01.docx"),
+        ("tables", "docx/sources/word_tables.docx"),
+        (
+            "numbered_headers",
+            "docx/sources/unit_test_headers_numbered.docx",
+        ),
+    ] {
+        let src = load(file, InputFormat::Docx);
+        g.bench_function(name, |b| {
+            b.iter(|| black_box(DocxBackend.convert(black_box(&src)).unwrap()))
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, html, docx);
+criterion_main!(benches);

--- a/crates/fleischwolf/src/backend/html.rs
+++ b/crates/fleischwolf/src/backend/html.rs
@@ -18,6 +18,17 @@ use crate::backend::DeclarativeBackend;
 use crate::error::ConversionError;
 use crate::source::SourceDocument;
 
+/// Compile a CSS selector once per call site (mirrors `cached_regex!`), returning
+/// a `&'static Selector`. `Selector::parse` is comparatively expensive, so this
+/// matters for selectors evaluated per element — e.g. `has_descendant` runs per
+/// table cell.
+macro_rules! cached_selector {
+    ($sel:literal) => {{
+        static SEL: std::sync::OnceLock<Selector> = std::sync::OnceLock::new();
+        SEL.get_or_init(|| Selector::parse($sel).unwrap())
+    }};
+}
+
 pub struct HtmlBackend;
 
 impl DeclarativeBackend for HtmlBackend {
@@ -43,9 +54,7 @@ pub(crate) fn convert_html(name: &str, html: &str, images: &dyn ImageResolver) -
 pub(crate) fn append_fragment(html: &str, out: &mut Vec<Node>, images: &dyn ImageResolver) {
     let parsed = Html::parse_document(html);
     // Prefer <body>; fall back to the root element for fragments.
-    let body = Selector::parse("body")
-        .ok()
-        .and_then(|s| parsed.select(&s).next());
+    let body = parsed.select(cached_selector!("body")).next();
     let root = body.unwrap_or_else(|| parsed.root_element());
     walk_block(root, out, 0, Fmt::default(), images);
 }
@@ -586,9 +595,9 @@ fn serialize_run(text: &str, fmt: Fmt, hyperlink: Option<&str>) -> String {
 }
 
 fn extract_pre(pre: ElementRef) -> (Option<String>, String) {
-    let mut language = Selector::parse("code")
-        .ok()
-        .and_then(|sel| pre.select(&sel).next())
+    let mut language = pre
+        .select(cached_selector!("code"))
+        .next()
         .and_then(|code| code.value().attr("class").map(str::to_string))
         .and_then(|c| lang_from_class(&c));
     if language.is_none() {
@@ -785,8 +794,7 @@ fn lone_code(p: ElementRef) -> Option<String> {
 /// caption (its non-empty `alt`) and `src`. Used to pull `<a><img></a>` out as a
 /// Picture.
 fn image_wrapper(elem: ElementRef) -> Option<(Option<String>, Option<String>)> {
-    let img_sel = Selector::parse("img").ok()?;
-    let mut imgs = elem.select(&img_sel);
+    let mut imgs = elem.select(cached_selector!("img"));
     let img = imgs.next()?;
     if imgs.next().is_some() || !elem.text().collect::<String>().trim().is_empty() {
         return None;
@@ -802,15 +810,22 @@ fn image_wrapper(elem: ElementRef) -> Option<(Option<String>, Option<String>)> {
 
 /// The `src` of a `<figure>`'s first `<img>`, for image extraction.
 fn figure_img_src(fig: ElementRef) -> Option<String> {
-    Selector::parse("img")
-        .ok()
-        .and_then(|s| fig.select(&s).next())
+    fig.select(cached_selector!("img"))
+        .next()
         .and_then(|img| img.value().attr("src"))
         .map(str::to_string)
 }
 
 fn has_descendant(elem: ElementRef, name: &str) -> bool {
-    Selector::parse(name).is_ok_and(|s| elem.select(&s).next().is_some())
+    // Callers pass a small fixed set of tags; cache those selectors (this runs
+    // per table cell). Anything else falls back to an on-demand parse.
+    let sel = match name {
+        "br" => cached_selector!("br"),
+        "img" => cached_selector!("img"),
+        "input" => cached_selector!("input"),
+        _ => return Selector::parse(name).is_ok_and(|s| elem.select(&s).next().is_some()),
+    };
+    elem.select(sel).next().is_some()
 }
 
 /// Count the inline text runs in `cell` and whether any carries formatting,
@@ -858,41 +873,53 @@ fn cell_richness(cell: ElementRef) -> (usize, bool) {
 }
 
 fn figure_caption(fig: ElementRef) -> Option<String> {
-    if let Some(cap) = Selector::parse("figcaption")
-        .ok()
-        .and_then(|s| fig.select(&s).next())
-    {
+    if let Some(cap) = fig.select(cached_selector!("figcaption")).next() {
         // A figure caption is plain text (formatting/links are stripped).
         let text = normalize_ws(&cap.text().collect::<String>());
         if !text.is_empty() {
             return Some(text);
         }
     }
-    Selector::parse("img")
-        .ok()
-        .and_then(|s| fig.select(&s).next())
+    fig.select(cached_selector!("img"))
+        .next()
         .and_then(|img| img.value().attr("alt"))
         .filter(|a| !a.is_empty())
         .map(str::to_string)
 }
 
-/// Sanitize typographic Unicode to ASCII (docling's HTML text cleanup) and then
-/// collapse all runs of whitespace to single spaces, trimming the ends.
+/// Sanitize typographic Unicode to ASCII (docling's HTML text cleanup) and
+/// collapse all runs of whitespace to single spaces, trimming the ends — in a
+/// single pass (this runs once per text run, so it stays allocation-light).
 fn normalize_ws(s: &str) -> String {
-    let mut clean = String::with_capacity(s.len());
+    let mut out = String::with_capacity(s.len());
+    // A space is pending between emitted words; flushed only before the next
+    // non-space char, so leading/trailing whitespace is trimmed and runs collapse.
+    let mut pending_space = false;
     for ch in s.chars() {
         match ch {
-            '\u{00a0}' | '\u{202f}' => clean.push(' '), // (narrow) non-breaking space
-            '\u{2010}'..='\u{2015}' => clean.push('-'), // hyphens, dashes, horizontal bar
-            '\u{2018}' | '\u{2019}' => clean.push('\''), // single quotation marks
-            '\u{201c}' | '\u{201d}' => clean.push('"'), // double quotation marks
-            '\u{2026}' => clean.push_str("..."),        // ellipsis
-            // Zero-width / soft / joiner characters are dropped.
+            // Zero-width / soft / joiner characters are dropped outright.
             '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{00ad}' | '\u{feff}' | '\u{2060}' => {}
-            _ => clean.push(ch),
+            // Any whitespace (incl. the (narrow) non-breaking spaces, which are
+            // Unicode-whitespace) collapses to a single pending space.
+            c if c.is_whitespace() => {
+                pending_space = !out.is_empty();
+            }
+            c => {
+                if pending_space {
+                    out.push(' ');
+                    pending_space = false;
+                }
+                match c {
+                    '\u{2010}'..='\u{2015}' => out.push('-'), // hyphens, dashes, horizontal bar
+                    '\u{2018}' | '\u{2019}' => out.push('\''), // single quotation marks
+                    '\u{201c}' | '\u{201d}' => out.push('"'), // double quotation marks
+                    '\u{2026}' => out.push_str("..."),        // ellipsis
+                    _ => out.push(c),
+                }
+            }
         }
     }
-    clean.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Profiling-driven optimisation of the HTML/DOCX/PDF parsing paths, with a new
criterion bench harness for before/after numbers. **Output is byte-identical**
(the regression suite is unchanged).

## Bench harness
`crates/fleischwolf/benches/parse.rs` (criterion) drives the backends directly
by reference (no per-iteration clone) over corpus fixtures:
`cargo bench -p fleischwolf --bench parse`.

## HTML — two real hotspots fixed
1. **Recompiled CSS selectors.** `Selector::parse` was called on every
   invocation — including `has_descendant`, which runs **per table cell**. Added
   a `cached_selector!` macro (mirrors the existing `cached_regex!`) and cached
   all 7 sites.
2. **Triple-allocating whitespace normalization.** `normalize_ws` did a
   translate pass → `split_whitespace` → `Vec` → `join` (3 allocations) for every
   text run. Rewrote it as a single pass (one allocation).

### Measured (controlled A/B — revert only `html.rs`, same machine window)
| Bench | Δ |
|---|---|
| `html/rich_table_cells` | **−15%** (CI [−15.7, −14.3], p=0.00) |
| `html/wiki_duck` | **−4%** (p=0.00) |
| `docx/*` (code unchanged) | within noise (±1–2%) — validates the deltas aren't drift |

> Table-heavy HTML benefits most (the per-cell `has_descendant` selector). The
> earlier raw cross-run numbers looked larger but were contaminated by the noisy
> WSL2 machine speeding up mid-session; the A/B above is the honest figure.

## DOCX & PDF — profiled, left as-is (already efficient)
- **DOCX** parses `styles`/`numbering`/`document.xml` **once** (no re-parse), and
  its string-building is per-paragraph; no per-char allocation hotspot. Its bench
  deltas above are pure noise (code untouched).
- **PDF** Rust path is thin: `pdfium_backend` delegates to the pdfium **C**
  library, and wall-time is dominated by pdfium + ONNX layout/OCR inference
  (out of scope per the brief). The geometric assembly is O(regions×cells) with
  small region counts — not a bottleneck.

## Caveat
A sampling profiler (`perf`/`samply`) wasn't usable in the sandbox
(`perf_event_paranoid=2`, no sudo), so this is **criterion-measurement-driven**
plus code inspection rather than flamegraph-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)