### PR TITLE
fix(pdf): stream pages + use available cores for large multi-page PDFs

### DIFF
--- a/crates/fleischwolf-pdf/examples/snapshot.rs
+++ b/crates/fleischwolf-pdf/examples/snapshot.rs
@@ -28,6 +28,10 @@ fn find_pdfs(dir: &Path, out: &mut Vec<PathBuf>) {
     entries.sort();
     for p in entries {
         if p.is_dir() {
+            // Skip `large/` — big perf-test inputs with no conformance baseline.
+            if p.file_name().is_some_and(|n| n == "large") {
+                continue;
+            }
             find_pdfs(&p, out);
         } else if is_supported(&p) {
             out.push(p);

--- a/crates/fleischwolf-pdf/src/layout.rs
+++ b/crates/fleischwolf-pdf/src/layout.rs
@@ -56,8 +56,12 @@ impl LayoutModel {
     pub fn load() -> Result<Self, String> {
         let path = std::env::var("DOCLING_LAYOUT_ONNX")
             .unwrap_or_else(|_| "models/layout_heron.onnx".to_string());
-        let mut builder = Session::builder().map_err(|e| format!("layout: builder: {e}"))?;
-        let session = builder
+        let session = Session::builder()
+            .map_err(|e| format!("layout: builder: {e}"))?
+            // Let inference use the available cores (ort otherwise defaults low);
+            // a large PDF runs this model once per page.
+            .with_intra_threads(crate::intra_threads())
+            .map_err(|e| format!("layout: intra_threads: {e}"))?
             .commit_from_file(&path)
             .map_err(|e| format!("layout: load {path}: {e}"))?;
         Ok(Self { session })

--- a/crates/fleischwolf-pdf/src/lib.rs
+++ b/crates/fleischwolf-pdf/src/lib.rs
@@ -45,6 +45,27 @@ impl fmt::Display for PdfError {
 
 impl std::error::Error for PdfError {}
 
+impl From<pdfium_render::prelude::PdfiumError> for PdfError {
+    fn from(e: pdfium_render::prelude::PdfiumError) -> Self {
+        PdfError::Pdfium(e.to_string())
+    }
+}
+
+/// Threads ONNX inference may use, capped by `FLEISCHWOLF_PDF_THREADS` if set.
+/// Defaults to the available parallelism (ort otherwise picks a low number).
+pub(crate) fn intra_threads() -> usize {
+    if let Some(n) = std::env::var("FLEISCHWOLF_PDF_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+    {
+        return n;
+    }
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
 /// A reusable PDF pipeline: the layout model is loaded once and reused across
 /// documents; OCR loads lazily the first time a scanned page is seen.
 pub struct Pipeline {
@@ -70,9 +91,15 @@ impl Pipeline {
         password: Option<&str>,
         name: &str,
     ) -> Result<DoclingDocument, PdfError> {
-        let parsed =
-            PdfDocument::open(bytes, password).map_err(|e| PdfError::Pdfium(e.to_string()))?;
-        self.process_pages(parsed.pages, name)
+        // Stream pages: render → process → drop one at a time, so a large PDF
+        // holds ~one page bitmap (~5 MB) rather than every page at once (which
+        // is gigabytes for a multi-thousand-page document and drives the machine
+        // into swap).
+        let mut doc = DoclingDocument::new(name);
+        pdfium_backend::for_each_page(bytes, password, |n, _total, mut page| {
+            self.process_one_page(n, &mut page, &mut doc)
+        })?;
+        Ok(doc)
     }
 
     /// Convert a standalone image (PNG/JPEG/TIFF/WebP/…) as a single page —
@@ -94,7 +121,38 @@ impl Pipeline {
         self.process_pages(vec![page], name)
     }
 
-    /// Run layout (+ OCR for cell-less pages) and assemble each page.
+    /// Run layout (+ OCR for cell-less pages) and assemble one page into `doc`.
+    fn process_one_page(
+        &mut self,
+        n: usize,
+        page: &mut PdfPage,
+        doc: &mut DoclingDocument,
+    ) -> Result<(), PdfError> {
+        let regions = self
+            .layout
+            .predict(&page.image, page.width, page.height)
+            .map_err(|e| PdfError::Layout(format!("page {}: {e}", n + 1)))?;
+        // Resolve overlapping detections once, before OCR.
+        let regions = assemble::resolve(regions);
+        // No text layer → recognise text from the page image via OCR.
+        if page.cells.is_empty() {
+            if self.ocr.is_none() {
+                self.ocr = Some(ocr::OcrModel::load().map_err(PdfError::Ocr)?);
+            }
+            let cells = self
+                .ocr
+                .as_mut()
+                .unwrap()
+                .ocr_page(&page.image, &regions, page.scale)
+                .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+            page.cells = cells;
+        }
+        assemble::assemble_page(page, regions, doc);
+        Ok(())
+    }
+
+    /// Run layout (+ OCR for cell-less pages) and assemble each already-rendered
+    /// page (image / METS inputs, which are small and already materialised).
     fn process_pages(
         &mut self,
         mut pages: Vec<PdfPage>,
@@ -102,26 +160,7 @@ impl Pipeline {
     ) -> Result<DoclingDocument, PdfError> {
         let mut doc = DoclingDocument::new(name);
         for (n, page) in pages.iter_mut().enumerate() {
-            let regions = self
-                .layout
-                .predict(&page.image, page.width, page.height)
-                .map_err(|e| PdfError::Layout(format!("page {}: {e}", n + 1)))?;
-            // Resolve overlapping detections once, before OCR.
-            let regions = assemble::resolve(regions);
-            // No text layer → recognise text from the page image via OCR.
-            if page.cells.is_empty() {
-                if self.ocr.is_none() {
-                    self.ocr = Some(ocr::OcrModel::load().map_err(PdfError::Ocr)?);
-                }
-                let cells = self
-                    .ocr
-                    .as_mut()
-                    .unwrap()
-                    .ocr_page(&page.image, &regions, page.scale)
-                    .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
-                page.cells = cells;
-            }
-            assemble::assemble_page(page, regions, &mut doc);
+            self.process_one_page(n, page, &mut doc)?;
         }
         Ok(doc)
     }

--- a/crates/fleischwolf-pdf/src/ocr.rs
+++ b/crates/fleischwolf-pdf/src/ocr.rs
@@ -47,8 +47,10 @@ impl OcrModel {
             std::env::var("DOCLING_OCR_REC_ONNX").unwrap_or_else(|_| "models/ocr_rec.onnx".into());
         let dict_path =
             std::env::var("DOCLING_OCR_DICT").unwrap_or_else(|_| "models/ppocr_keys_v1.txt".into());
-        let mut builder = Session::builder().map_err(|e| format!("ocr: builder: {e}"))?;
-        let rec = builder
+        let rec = Session::builder()
+            .map_err(|e| format!("ocr: builder: {e}"))?
+            .with_intra_threads(crate::intra_threads())
+            .map_err(|e| format!("ocr: intra_threads: {e}"))?
             .commit_from_file(&rec_path)
             .map_err(|e| format!("ocr: load {rec_path}: {e}"))?;
         let dict = std::fs::read_to_string(&dict_path)

--- a/crates/fleischwolf-pdf/src/pdfium_backend.rs
+++ b/crates/fleischwolf-pdf/src/pdfium_backend.rs
@@ -56,6 +56,9 @@ fn bind() -> Result<Pdfium, PdfiumError> {
 
 impl PdfDocument {
     /// Parse a PDF from bytes, optionally decrypting with `password`.
+    ///
+    /// Note: this materialises **every** page's rendered bitmap in memory at
+    /// once. For large documents prefer [`for_each_page`], which streams.
     pub fn open(bytes: &[u8], password: Option<&str>) -> Result<Self, PdfiumError> {
         let pdfium = bind()?;
         let doc = pdfium.load_pdf_from_byte_slice(bytes, password)?;
@@ -65,6 +68,28 @@ impl PdfDocument {
         }
         Ok(PdfDocument { pages })
     }
+}
+
+/// Render + extract pages one at a time, handing each (owned) [`PdfPage`] to `f`.
+/// Only one page bitmap is resident at a time — a rendered page is ~5 MB, so a
+/// large PDF would otherwise hold gigabytes of bitmaps at once. `f` receives the
+/// zero-based page index and the total page count.
+///
+/// `E` is the caller's error type; pdfium errors convert into it via `From`.
+pub fn for_each_page<E, F>(bytes: &[u8], password: Option<&str>, mut f: F) -> Result<(), E>
+where
+    E: From<PdfiumError>,
+    F: FnMut(usize, usize, PdfPage) -> Result<(), E>,
+{
+    let pdfium = bind()?;
+    let doc = pdfium.load_pdf_from_byte_slice(bytes, password)?;
+    let pages = doc.pages();
+    let total = pages.len() as usize;
+    for (i, page) in pages.iter().enumerate() {
+        let extracted = extract_page(&page)?;
+        f(i, total, extracted)?;
+    }
+    Ok(())
 }
 
 fn extract_page(page: &pdfium_render::prelude::PdfPage<'_>) -> Result<PdfPage, PdfiumError> {


### PR DESCRIPTION
Converting a large PDF (the **1913-page** .NET C# language reference) took
**hours**. Root-caused and fixed.

## Root cause
`PdfDocument::open` rendered **every** page to a 2× RGB bitmap and held them
**all in memory at once** — ~10 GB for 1913 pages — driving the machine into
**swap**. On top of that, the layout ONNX session ran with ort's low default
thread count.

## Fix
- **Stream the PDF path** (`pdfium_backend::for_each_page`): render → process →
  drop one page at a time, so only ~one page bitmap (~5 MB) is resident.
- **Thread config**: set `with_intra_threads` on the layout + OCR sessions
  (capped by `FLEISCHWOLF_PDF_THREADS`, default = available parallelism).
- Housekeeping: the snapshot harness skips a `large/` dir (perf inputs have no
  baseline), and `tests/data/pdf/large/` is gitignored (37 MB, not a fixture).

## Result (1913-page reference, 32-core box)
| | Before | After |
|---|---|---|
| Peak RSS | ~10 GB (→ swap → hours) | **0.9 GB** |
| Wall time | hours (swap-bound) | **~33 min** (compute-bound) |
| CPU | ~290% | ~670% |

PDF snapshot conformance stays **76/76 exact** — output is byte-identical
(thread count doesn't perturb the model), verified before & after.

## Follow-up (not in this PR)
After the memory fix it's compute-bound, but the single layout session plateaus
at **~7 of 32 cores**. **Inter-page parallelism** over a small pool of layout
models (`Session` isn't `Clone`, so N instances ≈ N×~300 MB — still far under the
old 10 GB) would cut ~33 min → ~7 min. Worth its own PR for proper review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)