### PR TITLE
ci: release via admin PAT + force_version dispatch (unblock master ruleset)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,15 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  # Manual re-run from the Actions tab / `gh workflow run`. Runs lint + test only;
-  # the release job is gated to `push` events, so a manual run never publishes.
+  # Manual re-run from the Actions tab / `gh workflow run`. Left blank it runs lint
+  # + test only; set `force_version` to (re)publish that exact version — use it to
+  # release a version a failed/blocked run skipped (e.g. the master-ruleset reject).
   workflow_dispatch:
+    inputs:
+      force_version:
+        description: "Force a release at this exact version (e.g. 0.3.0). Blank = lint+test only, no publish."
+        required: false
+        default: ""
 
 # Cancel superseded PR runs, but never interrupt a master run (it may publish).
 concurrency:
@@ -62,7 +68,9 @@ jobs:
   publish:
     name: release & publish
     needs: [lint, test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.force_version != '')
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the version-bump commit + tag
@@ -70,17 +78,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history + tags, for the semantic version bump
+          # Push the release commit + tag as an admin PAT so it satisfies the
+          # `master` ruleset; the default GITHUB_TOKEN can't be granted a bypass.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
-      # Decide the next version from conventional commits since the last tag; if
-      # there is one, bump + commit + tag it, push to master, and publish the
-      # crates (in dependency order, skipping any already on crates.io). A no-op
-      # when no release-worthy commit landed. The release commit is pushed with
-      # GITHUB_TOKEN and carries [skip ci], so it does not re-trigger CI.
+      # Decide the next version from conventional commits since the last tag (or
+      # use force_version on a manual dispatch); if there is one, bump + commit +
+      # tag it, push to master, and publish the crates (in dependency order,
+      # skipping any already on crates.io). A no-op when no release-worthy commit
+      # landed. The release commit is pushed with RELEASE_PAT (an admin token, so
+      # it satisfies the master ruleset) and carries [skip ci], so it does not
+      # re-trigger CI.
       - name: Release & publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          FORCE_VERSION: ${{ github.event.inputs.force_version }}
         run: bash scripts/release.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,19 +6,23 @@
 # publishes the changed crates. A clean no-op when no release-worthy commit
 # landed since the last tag.
 #
-# The release commit is pushed with the workflow's GITHUB_TOKEN and carries
-# `[skip ci]`, so it does not re-trigger CI (no release loop).
+# The release commit is pushed with RELEASE_PAT (an admin token, so it satisfies
+# the master branch ruleset) and carries `[skip ci]`, so it does not re-trigger CI.
+#
+# Set FORCE_VERSION=X.Y.Z to (re)publish that exact version instead of computing it
+# from the commit history — used to release a version a failed/blocked run skipped.
 #
 # Requires: CARGO_REGISTRY_TOKEN (publish) and push access to master.
 # Usage: scripts/release.sh
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-new="$(scripts/bump_version.sh)"
+new="${FORCE_VERSION:-$(scripts/bump_version.sh)}"
 if [[ -z "$new" ]]; then
   echo "No release-worthy commits since the last tag — nothing to release."
   exit 0
 fi
+[[ -n "${FORCE_VERSION:-}" ]] && echo ">> forced release of v$new"
 
 current="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 echo ">> releasing v$new (was v$current)"
@@ -36,8 +40,17 @@ done
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add Cargo.toml crates/*/Cargo.toml
-git commit -m "chore(release): v$new [skip ci]"
-git tag -a "v$new" -m "v$new"
+# Commit only if the bump changed something — a forced re-publish of a version
+# whose manifests are already at $new has nothing to commit.
+if git diff --cached --quiet; then
+  echo ">> manifests already at v$new — re-tagging / re-publishing only"
+else
+  git commit -m "chore(release): v$new [skip ci]"
+fi
+# Tag only if it doesn't already exist (idempotent for a forced re-publish).
+if ! git rev-parse -q --verify "refs/tags/v$new" >/dev/null; then
+  git tag -a "v$new" -m "v$new"
+fi
 git push origin HEAD:master
 git push origin "v$new"
 


### PR DESCRIPTION
Fixes the release job hitting the new `master` ruleset (GH013).

- **Checkout the release job with `RELEASE_PAT`** (a repo secret = an admin PAT) so the version-bump push is authored by an admin and clears the existing *Repository admin* bypass — the default `GITHUB_TOKEN` can't be granted a ruleset bypass.
- **Add a `force_version` `workflow_dispatch` input** to (re)publish a version a failed run skipped (e.g. v0.3.0). `release.sh` commit/tag are now idempotent.

**Before merging:** create the `RELEASE_PAT` secret (see PR thread), else the release push still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)