### PR TITLE
ci: publish a GitHub Release with a commit list on each crate release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,26 @@ jobs:
       # it satisfies the master ruleset) and carries [skip ci], so it does not
       # re-trigger CI.
       - name: Release & publish
+        id: release
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           FORCE_VERSION: ${{ github.event.inputs.force_version }}
         run: bash scripts/release.sh
+
+      # Cut a GitHub Release for the tag release.sh just pushed, using the commit
+      # list it assembled as the description. Skipped when the release step was a
+      # no-op (no release-worthy commits). Idempotent: if a release for the tag
+      # already exists (e.g. a forced re-publish), refresh its notes instead of
+      # failing.
+      - name: Create GitHub Release
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          tag="v${{ steps.release.outputs.version }}"
+          notes="${{ steps.release.outputs.notes_file }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release edit "$tag" --title "$tag" --notes-file "$notes"
+          else
+            gh release create "$tag" --title "$tag" --notes-file "$notes" --verify-tag
+          fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,9 +2,10 @@
 #
 # Master-only release step (run by .github/workflows/ci.yml after the lint/test
 # gates pass). Computes the next version from conventional commits; if there is
-# one, it bumps the workspace version, commits + tags it, pushes to master, and
-# publishes the changed crates. A clean no-op when no release-worthy commit
-# landed since the last tag.
+# one, it bumps the workspace version, commits + tags it, pushes to master,
+# publishes the changed crates, and assembles the GitHub Release notes (a commit
+# list since the previous tag) for the workflow to publish. A clean no-op when no
+# release-worthy commit landed since the last tag.
 #
 # The release commit is pushed with RELEASE_PAT (an admin token, so it satisfies
 # the master branch ruleset) and carries `[skip ci]`, so it does not re-trigger CI.
@@ -26,6 +27,24 @@ fi
 
 current="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 echo ">> releasing v$new (was v$current)"
+
+# Assemble the GitHub Release notes BEFORE the version-bump commit lands, so the
+# range is exactly the feature commits going into this release (everything since
+# the previous tag, the release chore commit excluded). The workflow turns this
+# into the Release description.
+prev_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
+notes_range="${prev_tag:+$prev_tag..}HEAD"
+notes_file="$(pwd)/release-notes.md"
+repo="${GITHUB_REPOSITORY:-artiz/fleischwolf}"
+{
+  echo "## What's changed"
+  echo
+  git log "$notes_range" --no-merges --format='- %s (%h)'
+  if [[ -n "$prev_tag" ]]; then
+    echo
+    echo "**Full changelog**: https://github.com/$repo/compare/$prev_tag...v$new"
+  fi
+} >"$notes_file"
 
 # Bump the single version key in the root manifest's [workspace.package].
 sed -i -E "0,/^version = \"[^\"]+\"/ s//version = \"$new\"/" Cargo.toml
@@ -57,5 +76,16 @@ git push origin "v$new"
 # Publish every crate at the new version (idempotent: skips any already on
 # crates.io), in dependency order.
 scripts/ci_publish.sh
+
+# Hand the released version + notes file to the workflow, which cuts the GitHub
+# Release for the tag we just pushed. Guarded so the script still runs locally
+# (where $GITHUB_OUTPUT is unset).
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "released=true"
+    echo "version=$new"
+    echo "notes_file=$notes_file"
+  } >>"$GITHUB_OUTPUT"
+fi
 
 echo ">> released v$new"


### PR DESCRIPTION
## What & why

When CI publishes a new crate version it already bumps the workspace version, commits and pushes a `v<x.y.z>` git **tag**, and uploads to crates.io — but it never cut a GitHub **Release**. This extends the pipeline to create a Release for that tag, with a nicely-joined commit list as its description.

## Changes

**`scripts/release.sh`**
- Assembles the Release notes *before* the version-bump commit lands, so the range is exactly the feature commits going into the release: every non-merge commit since the previous tag (`<prev_tag>..HEAD`), formatted as `- <subject> (<short-sha>)`, followed by a `Full changelog` compare link.
- Writes them to `release-notes.md` (an untracked CI artifact — only the manifests are staged for the release commit).
- Hands `released` / `version` / `notes_file` to the workflow via `$GITHUB_OUTPUT`, guarded with `${GITHUB_OUTPUT:-}` so the script still runs locally.

**`.github/workflows/ci.yml`**
- The `Release & publish` step gains `id: release`.
- New `Create GitHub Release` step (runs `gh release create`) that fires only when `steps.release.outputs.released == 'true'` — so it's skipped on a no-op release. It's idempotent: a forced re-publish whose tag already has a Release refreshes the notes (`gh release edit`) instead of failing.

## Notes
- The Release is created with `RELEASE_PAT` (already used for the tag push; has `contents: write`).
- No behavior change when there are no release-worthy commits — the whole publish job remains a clean no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdYPGMXtFwVDZySXhfz8ev)_