### PR TITLE
fix(scripts): add fleischwolf-asr to the crates.io publish order

### DIFF
--- a/scripts/ci_publish.sh
+++ b/scripts/ci_publish.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # Dependency order: a crate must be published before anything that depends on it.
-CRATES=(fleischwolf-core fleischwolf-pdf fleischwolf fleischwolf-cli)
+CRATES=(fleischwolf-core fleischwolf-pdf fleischwolf-asr fleischwolf fleischwolf-cli)
 
 UA="fleischwolf-ci (https://github.com/artiz/fleischwolf)"
 


### PR DESCRIPTION
## Summary
The v0.12.0 release failed at `cargo publish -p fleischwolf`: its new dependency `fleischwolf-asr` was missing from `ci_publish.sh`'s hardcoded dependency-ordered crate list, so the publish reached `fleischwolf` before `fleischwolf-asr` existed on crates.io.

**Fix**: insert `fleischwolf-asr` after `fleischwolf-core` (its only workspace dep) and before `fleischwolf`:
```
CRATES=(fleischwolf-core fleischwolf-pdf fleischwolf-asr fleischwolf fleischwolf-cli)
```

## Recovery path
The script is idempotent (skips versions already on crates.io — core@0.12.0 and pdf@0.12.0 uploaded before the failure). After merging, either:
- let this `fix(...)` commit trigger a normal **v0.12.1** release (publishes the complete set; the half-published 0.12.0 stays as-is), or
- re-run the release workflow with **`FORCE_VERSION=0.12.0`** to finish 0.12.0 exactly (the tag/commit already exist; the script re-publishes only the missing crates).

## Verification
`cargo publish -p fleischwolf-asr --dry-run` packages and verify-builds cleanly against the already-published `fleischwolf-core@0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01StCE48TQ4sw2kQ2zxveNa2)_