### PR TITLE
PDF pipeline round 2: pool memory halved, KV-cache TableFormer export, 17× SIMD page downscale

### DIFF
--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -123,6 +123,8 @@ jobs:
           stage models/tableformer/encoder.onnx encoder.onnx
           stage models/tableformer/decoder.onnx decoder.onnx
           stage models/tableformer/decoder_int8.onnx decoder_int8.onnx
+          stage models/tableformer/decoder_kv.onnx decoder_kv.onnx
+          stage models/tableformer/decoder_kv_int8.onnx decoder_kv_int8.onnx
           stage models/tableformer/bbox.onnx bbox.onnx
           echo "staged:"
           ls -la release-assets/

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -244,9 +244,19 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
 
 ## 6. Extensions
 
+Shipped:
+
+- **`fleischwolf-rag`** — documents → chunking → embeddings → vector search,
+  with swappable embedders (Ollama/Gemini/local ONNX), stores
+  (SQLite+sqlite-vec / PostgreSQL+pgvector), LLM, sources and queues, plus an
+  eval harness and a REST API. See the crate README.
+- **`fleischwolf-node`** — Node.js/Bun N-API bindings (npm package).
+- **MHTML backend** — no docling analogue.
+
+Planned:
+
 - **PyO3 bindings** (`fleischwolf-py`) for a strangler-fig drop-in.
-- **C++** bindings
-- `fleischwolf-rag` - basic documents processing/chunking/vectorization/semantic-search system with pluggable DB support, PostgreSQL/SQLite, embedding with small ONNX local model (test options, dimensions >= 1024). 
+- **C++** bindings.
   
 ## 7. Testing
 
@@ -262,6 +272,9 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   latest published docling (installed from PyPI; see
   [`COMPARING.md`](./COMPARING.md)).
 - **Differential / perf** — `scripts/compare.sh`, `scripts/performance.sh`.
+  The PDF pipeline's profiling data, the INT8/SIMD optimization results
+  (4.3× warm vs Python docling on the ML pipeline), and the remaining
+  performance backlog live in [`PDF_PERFORMANCE.md`](./PDF_PERFORMANCE.md).
 
 CI (`.github/workflows/ci.yml`) gates every pull request and master push on
 `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and

--- a/PDF_PERFORMANCE.md
+++ b/PDF_PERFORMANCE.md
@@ -4,6 +4,31 @@ Post-migration review of the PDF processing path: where the time actually goes,
 what was measured, which optimizations are validated, and a ranked backlog of
 further ideas that do **not** trade away output quality.
 
+## Results at a glance
+
+Everything below was landed across two optimization rounds (PR #26, #27),
+each change gated on corpus conformance — groundtruth distance unchanged or
+better, byte-identical where the change is structural:
+
+| Optimization | Measured effect |
+|---|---|
+| INT8 layout model (Conv-only static QDQ, calibrated; **default**) | layout inference **2.4×** faster; **1.83× end-to-end** on a 1913-page PDF (0.74 → 0.40 s/page) |
+| INT8 TableFormer decoder (dynamic, **default**) | ~10% faster table decode, byte-identical |
+| SIMD page downscale (`fast_image_resize`, same kernel; **default**) | `image.resize` stage **17×** faster (2607 → 152 ms / 16 pages) |
+| TableFormer KV cache fed back as `ort` values (no per-step copy) | ~9% faster table-structure decode, byte-identical |
+| One shared lazy TableFormer across the worker pool | peak RSS **3.8 → 1.9 GB** (4 workers); table-free docs 682 → 331 MB |
+| Single shared line/word contraction pass | `--no-ocr` conversion ~1.25× faster, identical output |
+| Per-document font + form caches in the text parser | 3–10% off `textparse` here; far more on CJK/form-heavy PDFs |
+| True-KV-cache decoder export (`decoder_kv.onnx`, optional) | parity at corpus table sizes; O(past)/step for very large tables |
+
+Cumulative head-to-head vs Python docling (measured on an 8-thread desktop,
+`scripts/performance.sh`): **4.3× faster warm conversion, 4.7× end-to-end,
+2.3–2.6× less peak memory** on the PDF ML pipeline — up from ~1.2× warm
+before this work. Model sizes: layout 172 → 68 MB, TF decoder 78 → 50 MB.
+Also fixed along the way: the `"` show-text operator dropped its word/char
+spacing operands (real spec violation), and OCR/TableFormer sub-stages are
+now visible in `FLEISCHWOLF_TIMING` profiles.
+
 Measured on a 4-core AVX-512(+VNNI/AMX) Xeon, release build (`lto = "thin"`),
 models from `scripts/download_dependencies.sh`, `FLEISCHWOLF_TIMING=1`.
 

--- a/PDF_PERFORMANCE.md
+++ b/PDF_PERFORMANCE.md
@@ -153,10 +153,12 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
    byte order, so it is one memcpy + one 4→3-channel pass, ~1% of total.)
 5. **textparse font caching** (marginal for PDFs — textparse is ≤1% — but
    real for `no_ocr` mode where it becomes the bottleneck):
-   - fonts are fully re-parsed (ToUnicode CMap decompression + tokenization,
-     Type1 program scan, width maps) for **every page** and every Form-XObject
-     invocation (`textparse.rs:794`); cache parsed `Font`s per document keyed
-     by the font dict's `ObjectId`, and cache decoded Form XObject content.
+   - ~~fonts are fully re-parsed for **every page** and every Form-XObject
+     invocation; decoded form content re-inflated per `Do`.~~ **Done on this
+     branch:** per-document caches keyed by object id (fonts also by resource
+     name, which feeds the docling-parse font hash). Identical output across
+     the corpus; 3–10% off the `textparse` stage on the test fixtures (their
+     ToUnicode CMaps are small — CJK/form-heavy documents benefit far more).
    - ~~`line_cells` + `word_cells` run the identical build+contract twice per
      page; one pass can emit both.~~ **Done on this branch**
      (`dp_lines::line_and_word_cells`): ~1.25× faster `--no-ocr` conversion,

--- a/PDF_PERFORMANCE.md
+++ b/PDF_PERFORMANCE.md
@@ -139,17 +139,18 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
    batched (e.g. batch-4) per worker with one session — better core utilization
    and less framework overhead on wide machines. Output is per-image, so
    quality is unaffected. (Needs a re-export with a dynamic batch dim.)
-4. **Render → resize pipeline copies** (`pdfium_backend.rs:264-272`, ~15% on
-   text-heavy docs): pdfium's BGRA bitmap goes through `as_image()` (copy +
-   swizzle) then `.into_rgb8()` (second copy) before the 3×→2× CatmullRom
-   downsample (third buffer). A single BGRA→RGB pass into the resize source
-   removes one full-page copy + traversal per page. Keep the 1.5× supersample +
-   CatmullRom itself — it is deliberate PIL-BICUBIC parity for model input.
-   Also: when `layout.predict` is the only image consumer at 640×640, the
-   2×-page intermediate is only needed for TableFormer crops and OCR — a page
-   with no table regions and a text layer never needs it; rendering could be
-   deferred/skipped per page in a `no_ocr`-like fast path decided *after*
-   layout runs on a cheaper raster.
+4. **The 3×→2× page downscale** (~15% of a text-heavy conversion, ~25% after
+   INT8): ~~replace the scalar `image`-crate CatmullRom with a SIMD
+   convolution.~~ **Done on this branch:** `fast_image_resize` with the same
+   a=-0.5 Catmull-Rom kernel — `image.resize` drops **2607 → 152 ms (17×)**
+   on the 16-page doc. The SIMD fixed-point path differs from the scalar one
+   by ±1/255 on some pixels, which can flip borderline table cells, so it was
+   gated like INT8: groundtruth distance over the corpus is **817 (SIMD) vs
+   818 (scalar)** — conformance-neutral. `FLEISCHWOLF_SLOW_RESIZE=1` restores
+   the scalar path, and `pdf_conformance.sh`/`pdf_groundtruth.sh` pin it so
+   the committed snapshot baselines stay valid. (The render-side `as_image()`
+   copy turned out to be a non-issue: pdfium already renders with reversed
+   byte order, so it is one memcpy + one 4→3-channel pass, ~1% of total.)
 5. **textparse font caching** (marginal for PDFs — textparse is ≤1% — but
    real for `no_ocr` mode where it becomes the bottleneck):
    - fonts are fully re-parsed (ToUnicode CMap decompression + tokenization,

--- a/PDF_PERFORMANCE.md
+++ b/PDF_PERFORMANCE.md
@@ -122,10 +122,18 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
      the cache and the encoder's cross-K/V + `enc_out` stay owned `ort` values
      fed straight back into the next run (~9% faster structure decode,
      byte-identical output).
-   - The exported graph still re-embeds the **full tag sequence** every step
-     (`tags` grows each iteration) even though attention is KV-cached. Re-export
-     the decoder to take only the last tag (the cache carries the history) —
-     this is the remaining per-step cost; see `scripts/export_tableformer.py`.
+   - ~~The exported graph still re-embeds the **full tag sequence** every
+     step.~~ **Built and measured:** `scripts/export_tableformer.py` now also
+     exports `decoder_kv.onnx`, a true-KV-cache step (one tag in, projected
+     K/V cached per layer), verified argmax-identical over a 64-step rollout
+     and byte-identical on corpus output. Measured result: **parity** with
+     the legacy graph on corpus-sized tables (~100–300 tokens) — ONNX Runtime
+     executes the legacy graph's full-prefix re-projection as one efficient
+     batched GEMM, so the O(n²) FLOPs don't become O(n²) wall time until
+     tables get much larger. The Rust loop auto-detects either graph (input
+     names) and prefers the smaller legacy file by default; point
+     `DOCLING_TABLEFORMER_DECODER` at `decoder_kv(_int8).onnx` for
+     very-large-table workloads.
 3. **Layout batching for the parallel path**: the pool currently runs batch-1
    inference per page. RT-DETR's 640×640 input is fixed-shape, so pages can be
    batched (e.g. batch-4) per worker with one session — better core utilization

--- a/PDF_PERFORMANCE.md
+++ b/PDF_PERFORMANCE.md
@@ -168,6 +168,37 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
    still shave per-worker model-load latency; only worth it if pool spin-up
    shows up in a real deployment.
 
+## Memory
+
+Each pool worker used to own a full model set, so peak RSS scaled with the
+pool: on a 4-worker machine ~0.4 GB of TableFormer weights+arenas were
+duplicated four times even though tables appear on a minority of pages. The
+pool now shares **one lazily-loaded TableFormer** behind a mutex (loaded with
+the full intra-op budget, since tables serialise on it anyway; prediction is
+independent of which worker runs it). Measured on the 16-page table-heavy
+paper, INT8 stack:
+
+| pool | per-worker TF (before) | shared TF (after) |
+|---|---:|---:|
+| 4 workers | 3816 MB | **1880 MB** |
+| 2 workers | 2183 MB | **1517 MB** |
+| 4 workers, table-free doc | 682 MB | **331 MB** (TableFormer never loads) |
+
+`FLEISCHWOLF_PDF_WORKERS` remains the coarse memory knob on top.
+
+## Determinism note (pre-existing, worth knowing)
+
+Multi-threaded ONNX Runtime float reductions are **not deterministic
+run-to-run**: on `2203.01017v2.pdf` two identical invocations of the same
+binary can differ in a handful of borderline table cells (measured 0–20
+Markdown diff-lines between repeat runs, before any of this branch's
+changes). `ocr.rs` already pins its session to one thread for exactly this
+reason. Regression checks for structural changes should therefore compare
+outputs under `FLEISCHWOLF_PDF_THREADS=1` (single-thread inference is
+deterministic and byte-stable); multi-threaded corpus diffs of a few lines on
+table-dense fixtures are thread-scheduling jitter, not necessarily a real
+change.
+
 ## Correctness notes found during review (quality, not speed)
 
 - `textparse.rs` `"` operator: the `aw ac string "` form must set word/char

--- a/README.md
+++ b/README.md
@@ -451,6 +451,33 @@ The comparison scripts install the latest published Python `docling` from PyPI
 into `.venv-compare` automatically on first run. See
 [`COMPARING.md`](./COMPARING.md).
 
+## Install locally / in CI (one-liner)
+
+`scripts/install.sh` builds the CLI from source and installs a self-contained
+tree — for a dev box or a pipeline step:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/artiz/fleischwolf/master/scripts/install.sh | bash
+fleischwolf your.pdf > out.md
+```
+
+It checks for a Rust toolchain (installs one via rustup if `cargo` is
+missing), runs `cargo build --release -p fleischwolf-cli`, installs the
+binary + all models + pdfium under `/usr/local/fleischwolf`, symlinks
+`/usr/local/bin/fleischwolf`, and writes `/etc/profile.d/fleischwolf.sh` with
+the `DOCLING_*`/`PDFIUM_*` exports. The env file is a convenience for other
+consumers of the model tree — the CLI itself resolves `models/` and
+`.pdfium/` **relative to its own (symlink-resolved) location**, so the
+command works from any directory with no environment at all. ONNX Runtime is
+statically linked; nothing else lands outside the prefix.
+
+Knobs (env vars before the call): `FLEISCHWOLF_PREFIX` (default
+`/usr/local/fleischwolf`), `FLEISCHWOLF_BIN_DIR`, `FLEISCHWOLF_REF` (git ref
+to build), `FLEISCHWOLF_NO_ASR=1` (skip the ~150 MB Whisper models),
+`FLEISCHWOLF_SUDO=0` (never escalate). Re-running is idempotent — it only
+fetches missing model files. Uninstall:
+`rm -rf /usr/local/fleischwolf /usr/local/bin/fleischwolf /etc/profile.d/fleischwolf.sh`.
+
 ## Deploy in a container
 
 For a real-world service, bake the binary, native libs, and models into one image
@@ -515,8 +542,10 @@ on a 1913-page document — see [`PDF_PERFORMANCE.md`](./PDF_PERFORMANCE.md)).
 | `fleischwolf-core` | `DoclingDocument` model + serializers | `docling-core` |
 | `fleischwolf` | `DocumentConverter`, source loading, backends | `docling` |
 | `fleischwolf-pdf` | PDF/image ML pipeline (pdfium + ONNX layout/table/OCR) | `docling` PDF pipeline |
+| `fleischwolf-asr` | audio/ASR pipeline (symphonia + ONNX Whisper) | `docling` ASR pipeline |
 | `fleischwolf-cli` | command-line interface | `docling.cli` |
 | `fleischwolf-node` | Node.js / Bun N-API bindings (npm package) | — |
+| `fleischwolf-rag` | RAG layer: chunking, embeddings, vector search, REST API | — |
 
 ## License
 

--- a/crates/fleischwolf-asr/src/whisper.rs
+++ b/crates/fleischwolf-asr/src/whisper.rs
@@ -50,9 +50,27 @@ pub struct Transcriber {
 }
 
 fn model_path(var: &str, default: &str) -> std::path::PathBuf {
-    std::env::var(var)
-        .unwrap_or_else(|_| default.to_string())
-        .into()
+    if let Ok(p) = std::env::var(var) {
+        return p.into();
+    }
+    // Default is CWD-relative; fall back to the executable's directory and one
+    // level above it (the `scripts/install.sh` layout, reached through the
+    // /usr/local/bin symlink), mirroring fleischwolf-pdf's asset resolution.
+    if !std::path::Path::new(default).exists() {
+        if let Some(dir) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
+        {
+            for base in [Some(dir.as_path()), dir.parent()].into_iter().flatten() {
+                let p = base.join(default);
+                if p.exists() {
+                    return p;
+                }
+            }
+        }
+    }
+    default.to_string().into()
 }
 
 /// Whether the Whisper model files are present (so callers can fail with a

--- a/crates/fleischwolf-pdf/Cargo.toml
+++ b/crates/fleischwolf-pdf/Cargo.toml
@@ -21,6 +21,7 @@ flate2 = "1"
 tar = "0.4"
 regex = "1.11"
 lopdf = "0.34"
+fast_image_resize = "5.1.4"
 
 [lib]
 name = "fleischwolf_pdf"

--- a/crates/fleischwolf-pdf/src/lib.rs
+++ b/crates/fleischwolf-pdf/src/lib.rs
@@ -82,6 +82,33 @@ pub(crate) fn fp32_forced() -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve a default (CWD-relative) asset path. If it doesn't exist relative
+/// to the current directory, try next to the executable and one level above
+/// it (following symlinks — the layout `scripts/install.sh` produces:
+/// `/usr/local/bin/fleischwolf` → `/usr/local/fleischwolf/bin/fleischwolf`
+/// with `models/` and `.pdfium/` in `/usr/local/fleischwolf`). Lets an
+/// installed binary run from any working directory with no env vars; explicit
+/// env overrides never reach this. Returns `rel` unchanged when nothing
+/// exists anywhere, so callers' error messages keep the familiar path.
+pub(crate) fn resolve_asset(rel: &str) -> String {
+    if std::path::Path::new(rel).exists() {
+        return rel.to_string();
+    }
+    if let Some(dir) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.canonicalize().ok())
+        .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
+    {
+        for base in [Some(dir.as_path()), dir.parent()].into_iter().flatten() {
+            let p = base.join(rel);
+            if p.exists() {
+                return p.to_string_lossy().into_owned();
+            }
+        }
+    }
+    rel.to_string()
+}
+
 /// Resolve a model path: an explicit env override always wins; otherwise the
 /// INT8 variant of the default path when it exists on disk (the quantized
 /// models are conformance-validated — see PDF_PERFORMANCE.md — and load/run
@@ -91,10 +118,13 @@ pub(crate) fn model_path(env: &str, fp32_default: &str, int8_default: &str) -> S
     if let Ok(p) = std::env::var(env) {
         return p;
     }
-    if !fp32_forced() && std::path::Path::new(int8_default).exists() {
-        return int8_default.to_string();
+    if !fp32_forced() {
+        let p = resolve_asset(int8_default);
+        if std::path::Path::new(&p).exists() {
+            return p;
+        }
     }
-    fp32_default.to_string()
+    resolve_asset(fp32_default)
 }
 
 /// One page's assembled output: typed nodes plus the page's hyperlinks, kept

--- a/crates/fleischwolf-pdf/src/lib.rs
+++ b/crates/fleischwolf-pdf/src/lib.rs
@@ -101,24 +101,42 @@ pub(crate) fn model_path(env: &str, fp32_default: &str, int8_default: &str) -> S
 /// separate so pages processed out of order can be stitched back in page order.
 type PageOut = (Vec<Node>, Vec<(String, String)>);
 
-/// A self-contained set of the per-page models (layout, OCR, TableFormer). Each
-/// parallel page-worker owns its own `Worker` so inference runs concurrently
-/// without sharing an ONNX session (`ort`'s `Session::run` is `&mut self`).
+/// The pool-wide TableFormer slot: one instance shared by every worker, loaded
+/// lazily on the first table region any worker sees. Tables appear on a
+/// minority of pages, so per-worker copies mostly multiplied ~0.4 GB of
+/// weights+arenas by the pool size for nothing; a single shared instance keeps
+/// the peak flat regardless of pool width, and a table's structure prediction
+/// is independent of which worker runs it, so output is byte-identical. The
+/// mutex serialises concurrent tables — the shared instance is loaded with the
+/// full intra-op thread budget to compensate (one wide TableFormer instead of
+/// several narrow ones).
+enum TfSlot {
+    /// Not attempted yet (no table seen so far).
+    Unloaded,
+    /// Load attempted, graphs absent — geometric fallback (warned once).
+    Missing,
+    Ready(tableformer::TableFormer),
+}
+
+type SharedTables = Arc<Mutex<TfSlot>>;
+
+/// A self-contained set of the per-page models (layout, OCR). Each parallel
+/// page-worker owns its own `Worker` so inference runs concurrently without
+/// sharing an ONNX session (`ort`'s `Session::run` is `&mut self`); only the
+/// rarely-hit TableFormer is shared (see [`TfSlot`]).
 struct Worker {
     /// `None` when `no_ocr` skips layout entirely — no model load, no inference.
     layout: Option<layout::LayoutModel>,
     ocr: Option<ocr::OcrModel>,
-    /// TableFormer structure model; `None` when its ONNX graphs aren't present
-    /// (the assembler then falls back to geometric table reconstruction) or
-    /// when `no_table_former`/`no_ocr` skip it.
-    tables: Option<tableformer::TableFormer>,
+    /// Shared TableFormer slot; `None` when `no_table_former`/`no_ocr` skip it.
+    tables: Option<SharedTables>,
     /// Skip layout, OCR, and TableFormer; reconstruct text purely from the PDF's
     /// embedded text layer. See [`Pipeline::no_ocr`].
     no_ocr: bool,
 }
 
 impl Worker {
-    fn load(intra: usize, no_table_former: bool, no_ocr: bool) -> Result<Self, PdfError> {
+    fn load(intra: usize, tables: Option<SharedTables>, no_ocr: bool) -> Result<Self, PdfError> {
         Ok(Self {
             layout: if no_ocr {
                 None
@@ -126,11 +144,7 @@ impl Worker {
                 Some(layout::LayoutModel::load_with(intra).map_err(PdfError::Layout)?)
             },
             ocr: None,
-            tables: if no_table_former || no_ocr {
-                None
-            } else {
-                tableformer::TableFormer::load_with(intra)
-            },
+            tables,
             no_ocr,
         })
     }
@@ -180,21 +194,36 @@ impl Worker {
             .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
             page.cells = cells;
         }
-        // TableFormer structure per table region (else geometric fallback).
+        // TableFormer structure per table region (else geometric fallback). The
+        // shared slot is only locked (and lazily loaded) when the page actually
+        // has a table, so table-free documents never pay for TableFormer at all.
         let mut table_rows: Vec<Option<Vec<Vec<String>>>> = vec![None; regions.len()];
-        if let Some(tf) = self.tables.as_mut() {
-            timing::timed("tableformer", || {
-                for (i, r) in regions.iter().enumerate() {
-                    if r.label == "table" {
-                        table_rows[i] = tf.predict_table_rows(
-                            &page.image,
-                            page.height,
-                            [r.l, r.t, r.r, r.b],
-                            &page.word_cells,
-                        );
+        if let Some(slot) = self.tables.as_ref() {
+            if regions.iter().any(|r| r.label == "table") {
+                timing::timed("tableformer", || {
+                    let mut guard = slot.lock().unwrap();
+                    if matches!(*guard, TfSlot::Unloaded) {
+                        // Full intra-op width: tables serialise on this mutex, so
+                        // the one instance gets the whole thread budget.
+                        *guard = match tableformer::TableFormer::load_with(intra_threads()) {
+                            Some(tf) => TfSlot::Ready(tf),
+                            None => TfSlot::Missing,
+                        };
                     }
-                }
-            });
+                    if let TfSlot::Ready(tf) = &mut *guard {
+                        for (i, r) in regions.iter().enumerate() {
+                            if r.label == "table" {
+                                table_rows[i] = tf.predict_table_rows(
+                                    &page.image,
+                                    page.height,
+                                    [r.l, r.t, r.r, r.b],
+                                    &page.word_cells,
+                                );
+                            }
+                        }
+                    }
+                });
+            }
         }
         Ok(timing::timed("assemble_page", || {
             assemble::assemble_page(page, regions, &table_rows)
@@ -259,6 +288,8 @@ pub struct Pipeline {
     /// Narrower workers (≈cores/`target_workers` threads each) for the parallel
     /// path; loaded on first multi-page use and cached.
     pool: Vec<Worker>,
+    /// The single TableFormer instance every worker shares (see [`TfSlot`]).
+    tables: SharedTables,
     /// Desired pool size for multi-page documents.
     target_workers: usize,
     /// Page count at/above which the parallel pool is worth its load cost.
@@ -278,6 +309,7 @@ impl Pipeline {
         Ok(Self {
             primary: None,
             pool: Vec::new(),
+            tables: Arc::new(Mutex::new(TfSlot::Unloaded)),
             target_workers: pdf_worker_count(),
             parallel_min: pdf_parallel_min(),
             no_table_former: false,
@@ -309,12 +341,22 @@ impl Pipeline {
         self
     }
 
+    /// The shared TableFormer slot handed to each worker, or `None` when the
+    /// pipeline options skip TableFormer entirely.
+    fn tables_slot(&self) -> Option<SharedTables> {
+        if self.no_table_former || self.no_ocr {
+            None
+        } else {
+            Some(Arc::clone(&self.tables))
+        }
+    }
+
     /// The full-intra serial worker, loaded on first use.
     fn primary(&mut self) -> Result<&mut Worker, PdfError> {
         if self.primary.is_none() {
             self.primary = Some(Worker::load(
                 intra_threads(),
-                self.no_table_former,
+                self.tables_slot(),
                 self.no_ocr,
             )?);
         }
@@ -606,11 +648,14 @@ impl Pipeline {
             return Ok(());
         }
         let intra = pdf_intra();
-        let no_table_former = self.no_table_former;
         let no_ocr = self.no_ocr;
+        let tables = self.tables_slot();
         let loaded: Vec<Result<Worker, PdfError>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..need)
-                .map(|_| s.spawn(move || Worker::load(intra, no_table_former, no_ocr)))
+                .map(|_| {
+                    let tables = tables.clone();
+                    s.spawn(move || Worker::load(intra, tables, no_ocr))
+                })
                 .collect();
             handles.into_iter().map(|h| h.join().unwrap()).collect()
         });

--- a/crates/fleischwolf-pdf/src/ocr.rs
+++ b/crates/fleischwolf-pdf/src/ocr.rs
@@ -43,10 +43,10 @@ impl OcrModel {
     /// Load the recognition model (`DOCLING_OCR_REC_ONNX` / `models/ocr_rec.onnx`)
     /// and its character dictionary (`DOCLING_OCR_DICT` / `models/ppocr_keys_v1.txt`).
     pub fn load() -> Result<Self, String> {
-        let rec_path =
-            std::env::var("DOCLING_OCR_REC_ONNX").unwrap_or_else(|_| "models/ocr_rec.onnx".into());
-        let dict_path =
-            std::env::var("DOCLING_OCR_DICT").unwrap_or_else(|_| "models/ppocr_keys_v1.txt".into());
+        let rec_path = std::env::var("DOCLING_OCR_REC_ONNX")
+            .unwrap_or_else(|_| crate::resolve_asset("models/ocr_rec.onnx"));
+        let dict_path = std::env::var("DOCLING_OCR_DICT")
+            .unwrap_or_else(|_| crate::resolve_asset("models/ppocr_keys_v1.txt"));
         // Single-threaded: ORT's multi-threaded float-reduction order varies
         // across runs, which flips the CTC argmax on low-confidence characters
         // (e.g. noisy faxes) and makes the snapshot output non-deterministic. The

--- a/crates/fleischwolf-pdf/src/pdfium_backend.rs
+++ b/crates/fleischwolf-pdf/src/pdfium_backend.rs
@@ -267,9 +267,7 @@ fn extract_page(
         })?;
         let dw = (width * RENDER_SCALE).round().max(1.0) as u32;
         let dh = (height * RENDER_SCALE).round().max(1.0) as u32;
-        crate::timing::timed("image.resize", || {
-            image::imageops::resize(&big, dw, dh, image::imageops::FilterType::CatmullRom)
-        })
+        crate::timing::timed("image.resize", || fast_downscale(&big, dw, dh))
     } else {
         RgbImage::new(1, 1)
     };
@@ -284,6 +282,46 @@ fn extract_page(
         image,
         links: extract_links(page, height),
     })
+}
+
+/// The supersample→target downscale via `fast_image_resize` (SIMD convolution;
+/// the same a=-0.5 Catmull-Rom kernel as `image::imageops::resize(...,
+/// CatmullRom)` and PIL BICUBIC — see the render comment above). Set
+/// `FLEISCHWOLF_SLOW_RESIZE=1` to fall back to the `image`-crate scalar resize
+/// (byte-parity with the pre-SIMD pipeline, several times slower).
+fn fast_downscale(big: &RgbImage, dw: u32, dh: u32) -> RgbImage {
+    use fast_image_resize as fir;
+    static SLOW: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let slow = *SLOW.get_or_init(|| {
+        std::env::var("FLEISCHWOLF_SLOW_RESIZE")
+            .map(|v| v != "0")
+            .unwrap_or(false)
+    });
+    if !slow {
+        if let Some(out) = (|| {
+            let src = fir::images::ImageRef::new(
+                big.width(),
+                big.height(),
+                big.as_raw(),
+                fir::PixelType::U8x3,
+            )
+            .ok()?;
+            let mut dst = fir::images::Image::new(dw, dh, fir::PixelType::U8x3);
+            fir::Resizer::new()
+                .resize(
+                    &src,
+                    &mut dst,
+                    &fir::ResizeOptions::new()
+                        .resize_alg(fir::ResizeAlg::Convolution(fir::FilterType::CatmullRom)),
+                )
+                .ok()?;
+            RgbImage::from_raw(dw, dh, dst.into_vec())
+        })() {
+            return out;
+        }
+        // Unreachable in practice; fall through to the scalar path on any error.
+    }
+    image::imageops::resize(big, dw, dh, image::imageops::FilterType::CatmullRom)
 }
 
 /// Collect web/mail/tel hyperlink annotations on a page, mapping each link's

--- a/crates/fleischwolf-pdf/src/pdfium_backend.rs
+++ b/crates/fleischwolf-pdf/src/pdfium_backend.rs
@@ -119,7 +119,7 @@ fn bind() -> Result<Pdfium, PdfiumError> {
     // defaults — the layout `scripts/download_dependencies.sh` (and
     // `scripts/pdf_setup.sh`) produce, so a checkout with the dependencies
     // downloaded next to it needs no env var at all.
-    if let Some(b) = try_bind_dir(".pdfium/lib") {
+    if let Some(b) = try_bind_dir(&crate::resolve_asset(".pdfium/lib")) {
         return Ok(Pdfium::new(b));
     }
     Pdfium::bind_to_system_library().map(Pdfium::new)

--- a/crates/fleischwolf-pdf/src/tableformer.rs
+++ b/crates/fleischwolf-pdf/src/tableformer.rs
@@ -54,7 +54,31 @@ pub struct TableFormer {
     encoder: Session,
     decoder: Session,
     bbox: Session,
+    /// True when the decoder is the true-KV-cache export (`decoder_kv.onnx`:
+    /// inputs `tag`/`cache_k`/`cache_v`, one token per step); false for the
+    /// legacy layer-output-cache graph (`decoder.onnx`: full `tags` + `cache`).
+    /// Detected from the session's input names, so an explicit
+    /// `DOCLING_TABLEFORMER_DECODER` override works with either graph.
+    kv: bool,
 }
+
+/// KV-cache geometry fixed by the `decoder_kv.onnx` export
+/// (`[N_LAYERS, 1, KV_HEADS, past, KV_HEAD_DIM]`, `KV_HEADS × KV_HEAD_DIM = EMBED_DIM`).
+const KV_HEADS: usize = 8;
+const KV_HEAD_DIM: usize = 64;
+
+/// The autoregressive decode state: `a` is the legacy layer-output cache, or
+/// `cache_k` for the KV graph; `b` is `cache_v` (KV graph only). `None` = first
+/// step (the zero-`past` empties are allocated per table by [`TableFormer::empty_cache`]).
+#[derive(Default)]
+struct DecodeCache {
+    a: Option<DynValue>,
+    b: Option<DynValue>,
+}
+
+/// Zero-`past` first-step cache tensors: `(cache, None)` for the legacy graph,
+/// `(cache_k, Some(cache_v))` for the KV graph.
+type EmptyCache = (Tensor<f32>, Option<Tensor<f32>>);
 
 /// Encoder outputs that drive the cached decode loop: the per-layer cross-attention
 /// K/V (projected from the image memory once, constant across decode steps) and
@@ -80,13 +104,34 @@ impl TableFormer {
     pub fn load_with(intra: usize) -> Option<Self> {
         let enc = std::env::var("DOCLING_TABLEFORMER_ENCODER")
             .unwrap_or_else(|_| "models/tableformer/encoder.onnx".to_string());
-        // Prefer the INT8 decoder when present (byte-identical output, faster
-        // decode; FLEISCHWOLF_FP32=1 opts out) unless explicitly overridden.
-        let dec = crate::model_path(
-            "DOCLING_TABLEFORMER_DECODER",
-            "models/tableformer/decoder.onnx",
-            "models/tableformer/decoder_int8.onnx",
-        );
+        // Decoder preference (explicit override wins): INT8 variants first
+        // unless FLEISCHWOLF_FP32 opts out; within a precision the true-KV-cache
+        // export (`decoder_kv*`, one token per step) ranks behind the legacy
+        // layer-output-cache graph it matches byte-for-byte — measured parity on
+        // corpus-sized tables (ORT batches the legacy graph's prefix
+        // re-projection efficiently), so the smaller legacy file stays the
+        // default and `decoder_kv*` serves very-large-table workloads, where its
+        // O(past) step cost wins.
+        let dec = std::env::var("DOCLING_TABLEFORMER_DECODER").unwrap_or_else(|_| {
+            let candidates: &[&str] = if crate::fp32_forced() {
+                &[
+                    "models/tableformer/decoder.onnx",
+                    "models/tableformer/decoder_kv.onnx",
+                ]
+            } else {
+                &[
+                    "models/tableformer/decoder_int8.onnx",
+                    "models/tableformer/decoder_kv_int8.onnx",
+                    "models/tableformer/decoder.onnx",
+                    "models/tableformer/decoder_kv.onnx",
+                ]
+            };
+            candidates
+                .iter()
+                .find(|p| std::path::Path::new(p).exists())
+                .unwrap_or(&"models/tableformer/decoder.onnx")
+                .to_string()
+        });
         let bbx = std::env::var("DOCLING_TABLEFORMER_BBOX")
             .unwrap_or_else(|_| "models/tableformer/bbox.onnx".to_string());
         if [&enc, &dec, &bbx]
@@ -118,11 +163,15 @@ impl TableFormer {
                 .map_err(|e| format!("tableformer load {path}: {e}"))
         };
         match (build(&enc, true), build(&dec, false), build(&bbx, true)) {
-            (Ok(encoder), Ok(decoder), Ok(bbox)) => Some(Self {
-                encoder,
-                decoder,
-                bbox,
-            }),
+            (Ok(encoder), Ok(decoder), Ok(bbox)) => {
+                let kv = decoder.inputs().iter().any(|i| i.name() == "cache_k");
+                Some(Self {
+                    encoder,
+                    decoder,
+                    bbox,
+                    kv,
+                })
+            }
             _ => None,
         }
     }
@@ -160,18 +209,35 @@ impl TableFormer {
         &mut self,
         tags: &[i64],
         enc: &EncodeOut,
-        cache: &mut Option<DynValue>,
-        empty_cache: &Tensor<f32>,
+        cache: &mut DecodeCache,
+        empty: &EmptyCache,
     ) -> Result<(i64, Vec<f32>), String> {
-        let tags_t = Tensor::from_array(([tags.len(), 1usize], tags.to_vec()))
-            .map_err(|e| format!("tableformer: tags: {e}"))?;
-        let mut dout = match cache.as_ref() {
-            None => self.decoder.run(ort::inputs![
-                "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
-                "cache" => empty_cache]),
-            Some(c) => self.decoder.run(ort::inputs![
-                "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
-                "cache" => c]),
+        let mut dout = if self.kv {
+            // KV graph: feed only the newly emitted tag; the projected K/V for
+            // the whole prefix live in cache_k/cache_v and are fed back as-is.
+            let last = *tags.last().expect("decode starts from <start>");
+            let tag_t = Tensor::from_array(([1usize, 1usize], vec![last]))
+                .map_err(|e| format!("tableformer: tag: {e}"))?;
+            match (cache.a.as_ref(), cache.b.as_ref()) {
+                (Some(k), Some(v)) => self.decoder.run(ort::inputs![
+                    "tag" => tag_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                    "cache_k" => k, "cache_v" => v]),
+                _ => self.decoder.run(ort::inputs![
+                    "tag" => tag_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                    "cache_k" => &empty.0,
+                    "cache_v" => empty.1.as_ref().expect("kv empty cache has both halves")]),
+            }
+        } else {
+            let tags_t = Tensor::from_array(([tags.len(), 1usize], tags.to_vec()))
+                .map_err(|e| format!("tableformer: tags: {e}"))?;
+            match cache.a.as_ref() {
+                None => self.decoder.run(ort::inputs![
+                    "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                    "cache" => &empty.0]),
+                Some(c) => self.decoder.run(ort::inputs![
+                    "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                    "cache" => c]),
+            }
         }
         .map_err(|e| format!("tableformer: decode: {e}"))?;
         let (_, logits) = dout["logits"]
@@ -182,18 +248,40 @@ impl TableFormer {
             .try_extract_tensor::<f32>()
             .map_err(|e| format!("tableformer: hidden: {e}"))?;
         let hidden = hidden.to_vec();
-        *cache = Some(
-            dout.remove("out_cache")
-                .ok_or_else(|| "tableformer: decoder output out_cache missing".to_string())?,
-        );
+        if self.kv {
+            cache.a = Some(
+                dout.remove("out_cache_k")
+                    .ok_or_else(|| "tableformer: out_cache_k missing".to_string())?,
+            );
+            cache.b = Some(
+                dout.remove("out_cache_v")
+                    .ok_or_else(|| "tableformer: out_cache_v missing".to_string())?,
+            );
+        } else {
+            cache.a = Some(
+                dout.remove("out_cache")
+                    .ok_or_else(|| "tableformer: decoder output out_cache missing".to_string())?,
+            );
+        }
         Ok((raw, hidden))
     }
 
-    /// The zero-`past` first-step cache, allocated through the session allocator
-    /// (ort's array constructors reject a 0-length dim; the C API does allow it).
-    fn empty_cache(&self) -> Result<Tensor<f32>, String> {
-        Tensor::<f32>::new(self.decoder.allocator(), [N_LAYERS, 0usize, 1, EMBED_DIM])
-            .map_err(|e| format!("tableformer: empty cache: {e}"))
+    /// The zero-`past` first-step cache(s), allocated through the session
+    /// allocator (ort's array constructors reject a 0-length dim; the C API does
+    /// allow it).
+    fn empty_cache(&self) -> Result<EmptyCache, String> {
+        let alloc = self.decoder.allocator();
+        if self.kv {
+            let mk = || {
+                Tensor::<f32>::new(alloc, [N_LAYERS, 1, KV_HEADS, 0usize, KV_HEAD_DIM])
+                    .map_err(|e| format!("tableformer: empty kv cache: {e}"))
+            };
+            Ok((mk()?, Some(mk()?)))
+        } else {
+            let c = Tensor::<f32>::new(alloc, [N_LAYERS, 0usize, 1, EMBED_DIM])
+                .map_err(|e| format!("tableformer: empty cache: {e}"))?;
+            Ok((c, None))
+        }
     }
 
     /// Predict the OTSL structure-token sequence for a table-region image.
@@ -204,7 +292,7 @@ impl TableFormer {
         let mut tags: Vec<i64> = vec![START];
         let mut out: Vec<i64> = Vec::new();
         let mut prev_ucel = false;
-        let mut cache: Option<DynValue> = None;
+        let mut cache = DecodeCache::default();
         let empty = self.empty_cache()?;
         while out.len() < MAX_STEPS {
             let (raw, _hidden) = self.decode_step(&tags, &enc, &mut cache, &empty)?;
@@ -243,7 +331,7 @@ impl TableFormer {
         let mut bbox_ind = 0usize;
         let mut cur_bbox_ind = 0usize;
         let mut merge: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
-        let mut cache: Option<DynValue> = None;
+        let mut cache = DecodeCache::default();
         let empty = self.empty_cache()?;
         while otsl.len() < MAX_STEPS {
             let (raw, hidden) = self.decode_step(&tags, &enc, &mut cache, &empty)?;

--- a/crates/fleischwolf-pdf/src/tableformer.rs
+++ b/crates/fleischwolf-pdf/src/tableformer.rs
@@ -103,7 +103,7 @@ impl TableFormer {
     /// throughput comes from running pages concurrently, not from one fat model).
     pub fn load_with(intra: usize) -> Option<Self> {
         let enc = std::env::var("DOCLING_TABLEFORMER_ENCODER")
-            .unwrap_or_else(|_| "models/tableformer/encoder.onnx".to_string());
+            .unwrap_or_else(|_| crate::resolve_asset("models/tableformer/encoder.onnx"));
         // Decoder preference (explicit override wins): INT8 variants first
         // unless FLEISCHWOLF_FP32 opts out; within a precision the true-KV-cache
         // export (`decoder_kv*`, one token per step) ranks behind the legacy
@@ -128,12 +128,12 @@ impl TableFormer {
             };
             candidates
                 .iter()
+                .map(|p| crate::resolve_asset(p))
                 .find(|p| std::path::Path::new(p).exists())
-                .unwrap_or(&"models/tableformer/decoder.onnx")
-                .to_string()
+                .unwrap_or_else(|| "models/tableformer/decoder.onnx".to_string())
         });
         let bbx = std::env::var("DOCLING_TABLEFORMER_BBOX")
-            .unwrap_or_else(|_| "models/tableformer/bbox.onnx".to_string());
+            .unwrap_or_else(|_| crate::resolve_asset("models/tableformer/bbox.onnx"));
         if [&enc, &dec, &bbx]
             .iter()
             .any(|p| !std::path::Path::new(p).exists())

--- a/crates/fleischwolf-pdf/src/textparse.rs
+++ b/crates/fleischwolf-pdf/src/textparse.rs
@@ -14,10 +14,25 @@
 //! pages without one still fall back to OCR upstream.
 
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use lopdf::{Dictionary, Document, Object};
 
 use crate::pdfium_backend::Glyph;
+
+/// Per-document caches for the content-stream interpreter. Fonts are indirect
+/// objects shared by many pages, but were fully re-parsed — ToUnicode CMap
+/// decompression + tokenization, embedded Type1 program scan, width tables —
+/// for **every page and every Form XObject invocation**; decoded form content
+/// streams were likewise re-inflated on every `Do`. Cached per document,
+/// keyed by the referenced object id (fonts also by resource name, which
+/// feeds the docling-parse font hash). Inline (non-reference) dicts are rare
+/// and stay uncached.
+#[derive(Default)]
+struct DocCaches {
+    fonts: HashMap<(lopdf::ObjectId, Vec<u8>), Rc<Font>>,
+    forms: HashMap<lopdf::ObjectId, Rc<lopdf::content::Content>>,
+}
 
 /// A 2×3 affine matrix `[a b c d e f]`: maps `(x,y)` → `(a·x+c·y+e, b·x+d·y+f)`.
 #[derive(Clone, Copy)]
@@ -643,13 +658,14 @@ pub fn pdf_textlines(bytes: &[u8]) -> Vec<(f32, f32, Vec<crate::pdfium_backend::
     let Ok(doc) = Document::load_mem(bytes) else {
         return Vec::new();
     };
+    let mut caches = DocCaches::default();
     let mut pages: Vec<_> = doc.get_pages().into_iter().collect();
     pages.sort_by_key(|(n, _)| *n);
     pages
         .into_iter()
         .map(|(_, pid)| {
             let (w, h) = page_size(&doc, pid);
-            let glyphs = page_glyphs(&doc, pid);
+            let glyphs = page_glyphs_cached(&doc, pid, &mut caches);
             let cells = crate::dp_lines::line_cells(&glyphs, h, true);
             (w, h, cells)
         })
@@ -664,13 +680,14 @@ pub fn pdf_words(bytes: &[u8]) -> Vec<(f32, f32, Vec<crate::pdfium_backend::Text
     let Ok(doc) = Document::load_mem(bytes) else {
         return Vec::new();
     };
+    let mut caches = DocCaches::default();
     let mut pages: Vec<_> = doc.get_pages().into_iter().collect();
     pages.sort_by_key(|(n, _)| *n);
     pages
         .into_iter()
         .map(|(_, pid)| {
             let (w, h) = page_size(&doc, pid);
-            let glyphs = page_glyphs(&doc, pid);
+            let glyphs = page_glyphs_cached(&doc, pid, &mut caches);
             let cells = crate::dp_lines::word_cells(&glyphs, h, true);
             (w, h, cells)
         })
@@ -695,13 +712,14 @@ pub fn pdf_all_cells(bytes: &[u8]) -> Vec<PageParserCells> {
     let Ok(doc) = Document::load_mem(bytes) else {
         return Vec::new();
     };
+    let mut caches = DocCaches::default();
     let mut pages: Vec<_> = doc.get_pages().into_iter().collect();
     pages.sort_by_key(|(n, _)| *n);
     pages
         .into_iter()
         .map(|(_, pid)| {
             let (_w, h) = page_size(&doc, pid);
-            let glyphs = page_glyphs(&doc, pid);
+            let glyphs = page_glyphs_cached(&doc, pid, &mut caches);
             let (prose, words) = crate::dp_lines::line_and_word_cells(&glyphs, h, true);
             PageParserCells {
                 prose,
@@ -746,8 +764,14 @@ fn page_res(doc: &Document, page_id: lopdf::ObjectId) -> Option<&Dictionary> {
     ids.into_iter().find_map(|id| doc.get_dictionary(id).ok())
 }
 
-/// Build the code→[`Font`] map for a resources dictionary's `/Font` sub-dict.
-fn fonts_from_res(doc: &Document, res: &Dictionary) -> HashMap<Vec<u8>, Font> {
+/// Build the code→[`Font`] map for a resources dictionary's `/Font` sub-dict,
+/// reusing the per-document cache for fonts referenced indirectly (the common
+/// case — the same font objects recur on every page).
+fn fonts_from_res(
+    doc: &Document,
+    res: &Dictionary,
+    caches: &mut DocCaches,
+) -> HashMap<Vec<u8>, Rc<Font>> {
     let mut map = HashMap::new();
     let font_dict = res
         .get(b"Font")
@@ -756,9 +780,28 @@ fn fonts_from_res(doc: &Document, res: &Dictionary) -> HashMap<Vec<u8>, Font> {
         .and_then(|o| o.as_dict().ok());
     if let Some(fd) = font_dict {
         for (name, value) in fd.iter() {
-            if let Some(fdict) = deref(doc, value).and_then(|o| o.as_dict().ok()) {
-                map.insert(name.clone(), parse_font(doc, name, fdict));
-            }
+            let font = match value {
+                Object::Reference(id) => {
+                    let key = (*id, name.clone());
+                    if let Some(f) = caches.fonts.get(&key) {
+                        Rc::clone(f)
+                    } else if let Some(fdict) = deref(doc, value).and_then(|o| o.as_dict().ok()) {
+                        let f = Rc::new(parse_font(doc, name, fdict));
+                        caches.fonts.insert(key, Rc::clone(&f));
+                        f
+                    } else {
+                        continue;
+                    }
+                }
+                _ => {
+                    if let Some(fdict) = deref(doc, value).and_then(|o| o.as_dict().ok()) {
+                        Rc::new(parse_font(doc, name, fdict))
+                    } else {
+                        continue;
+                    }
+                }
+            };
+            map.insert(name.clone(), font);
         }
     }
     map
@@ -766,6 +809,16 @@ fn fonts_from_res(doc: &Document, res: &Dictionary) -> HashMap<Vec<u8>, Font> {
 
 /// Extract every glyph on a page as a native-coordinate [`Glyph`].
 pub(crate) fn page_glyphs(doc: &Document, page_id: lopdf::ObjectId) -> Vec<Glyph> {
+    page_glyphs_cached(doc, page_id, &mut DocCaches::default())
+}
+
+/// [`page_glyphs`] with an explicit per-document cache, so a multi-page walk
+/// parses each font / decodes each form once instead of once per page.
+fn page_glyphs_cached(
+    doc: &Document,
+    page_id: lopdf::ObjectId,
+    caches: &mut DocCaches,
+) -> Vec<Glyph> {
     let mut out = Vec::new();
     let Ok(content_bytes) = doc.get_page_content(page_id) else {
         return out;
@@ -774,7 +827,16 @@ pub(crate) fn page_glyphs(doc: &Document, page_id: lopdf::ObjectId) -> Vec<Glyph
         return out;
     };
     if let Some(res) = page_res(doc, page_id) {
-        run_content(doc, res, &content, Mat::ID, TextState::INIT, 0, &mut out);
+        run_content(
+            doc,
+            res,
+            &content,
+            Mat::ID,
+            TextState::INIT,
+            0,
+            caches,
+            &mut out,
+        );
     }
     out
 }
@@ -783,6 +845,7 @@ pub(crate) fn page_glyphs(doc: &Document, page_id: lopdf::ObjectId) -> Vec<Glyph
 /// Form XObjects on `Do` (bulk body text in heavy PDFs lives inside a form, not
 /// the page content stream). `res` is the resources dict in scope (the page's,
 /// or the form's own); `base_ctm` is the CTM at the point of invocation.
+#[allow(clippy::too_many_arguments)]
 fn run_content(
     doc: &Document,
     res: &Dictionary,
@@ -790,9 +853,10 @@ fn run_content(
     base_ctm: Mat,
     init: TextState,
     depth: u32,
+    caches: &mut DocCaches,
     out: &mut Vec<Glyph>,
 ) {
-    let fonts = fonts_from_res(doc, res);
+    let fonts = fonts_from_res(doc, res, caches);
     let xobjects = res
         .get(b"XObject")
         .ok()
@@ -804,11 +868,11 @@ fn run_content(
     // *not* the text matrix (that is reset by BT). Saving only the CTM let a Tc
     // set inside a `q…Q` block leak out and drift every later glyph.
     #[allow(clippy::type_complexity)]
-    let mut gstate_stack: Vec<(Mat, f64, f64, f64, f64, f64, f64, Option<&Font>)> = Vec::new();
+    let mut gstate_stack: Vec<(Mat, f64, f64, f64, f64, f64, f64, Option<&Rc<Font>>)> = Vec::new();
     let mut ctm = base_ctm;
     let mut tm = Mat::ID;
     let mut tlm = Mat::ID;
-    let mut font: Option<&Font> = None;
+    let mut font: Option<&Rc<Font>> = None;
     let mut fsize = init.fsize;
     let mut tc = init.tc; // char spacing
     let mut tw = init.tw; // word spacing
@@ -968,8 +1032,12 @@ fn run_content(
                 let Some(Object::Name(n)) = operands.first() else {
                     continue;
                 };
-                let stream = xobjects
-                    .and_then(|d| d.get(n.as_slice()).ok())
+                let obj = xobjects.and_then(|d| d.get(n.as_slice()).ok());
+                let form_id = match obj {
+                    Some(Object::Reference(id)) => Some(*id),
+                    _ => None,
+                };
+                let stream = obj
                     .and_then(|o| deref(doc, o))
                     .and_then(|o| o.as_stream().ok());
                 let Some(stream) = stream else { continue };
@@ -982,11 +1050,24 @@ fn run_content(
                 if !is_form {
                     continue;
                 }
-                let Ok(data) = stream.decompressed_content() else {
-                    continue;
-                };
-                let Ok(form_content) = lopdf::content::Content::decode(&data) else {
-                    continue;
+                // Decode the form's content once per document (headers/footers
+                // and bulk body text invoke the same form on every page).
+                let cached = form_id.and_then(|id| caches.forms.get(&id).cloned());
+                let form_content = match cached {
+                    Some(c) => c,
+                    None => {
+                        let Ok(data) = stream.decompressed_content() else {
+                            continue;
+                        };
+                        let Ok(c) = lopdf::content::Content::decode(&data) else {
+                            continue;
+                        };
+                        let c = Rc::new(c);
+                        if let Some(id) = form_id {
+                            caches.forms.insert(id, Rc::clone(&c));
+                        }
+                        c
+                    }
                 };
                 // The form's /Matrix maps form space into the CTM at invocation.
                 let form_mat = match stream.dict.get(b"Matrix").ok() {
@@ -1030,6 +1111,7 @@ fn run_content(
                     form_mat.then(ctm),
                     state,
                     depth + 1,
+                    caches,
                     out,
                 );
             }

--- a/scripts/export_tableformer.py
+++ b/scripts/export_tableformer.py
@@ -197,6 +197,53 @@ class Decode(nn.Module):
         return tt._fc(last), last, out_cache
 
 
+class DecodeKV(nn.Module):
+    # True-KV-cache step: feeds ONLY the newly emitted tag. The layer-output
+    # cache above still re-projects self-attention K/V over the whole cached
+    # prefix in every layer on every step (and re-embeds the full tag sequence
+    # for layer 0) — O(n^2) matmuls per table. Here each layer's projected
+    # K and V are the cache (cache_k/cache_v [L,1,H,past,head_dim], empty at
+    # past=0): a step embeds one tag at its absolute position (= past, read
+    # from the cache shape), projects q/k/v for that one token, appends k/v,
+    # and attends the single query over the cached keys — O(past) memory
+    # traffic per step, no re-projection. Mathematically identical to the
+    # layer-output cache (past tokens' K/V are linear projections of fixed
+    # layer inputs), verified argmax-identical step-by-step below.
+    def forward(self, tag, cross_k, cross_v, cache_k, cache_v):
+        e = EMBED_DIM_
+        pos = cache_k.shape[3]  # tokens already decoded = this tag's position
+        x = tt._embedding(tag)  # [1,1,e]
+        x = x + tt._positional_encoding.pe[pos]
+        out = x
+        new_ks, new_vs = [], []
+        for i, layer in enumerate(tt._decoder.layers):
+            sa = layer.self_attn
+            W, b = sa.in_proj_weight, sa.in_proj_bias
+            q = F.linear(out, W[:e], b[:e])
+            k = F.linear(out, W[e : 2 * e], b[e : 2 * e])
+            v = F.linear(out, W[2 * e :], b[2 * e :])
+            # [1,1,e] → [1,H,1,head_dim]
+            q = q.reshape(1, N_HEADS, HEAD_DIM).permute(1, 0, 2).unsqueeze(0)
+            k = k.reshape(1, N_HEADS, HEAD_DIM).permute(1, 0, 2).unsqueeze(0)
+            v = v.reshape(1, N_HEADS, HEAD_DIM).permute(1, 0, 2).unsqueeze(0)
+            new_ks.append(k)
+            new_vs.append(v)
+            kk = torch.cat([cache_k[i], k], dim=2)  # [1,H,past+1,hd]
+            vv = torch.cat([cache_v[i], v], dim=2)
+            t = F.scaled_dot_product_attention(q, kk, vv)
+            t = t.squeeze(0).permute(1, 0, 2).reshape(1, 1, e)
+            t = F.linear(t, sa.out_proj.weight, sa.out_proj.bias)
+            tgt_last = layer.norm1(out + t)
+            t = _cross_attn(layer, tgt_last, cross_k[i], cross_v[i])
+            tgt_last = layer.norm2(tgt_last + t)
+            t = layer.linear2(layer.activation(layer.linear1(tgt_last)))
+            out = layer.norm3(tgt_last + t)
+        out_cache_k = torch.cat([cache_k, torch.stack(new_ks, 0)], dim=3)
+        out_cache_v = torch.cat([cache_v, torch.stack(new_vs, 0)], dim=3)
+        last = out[-1]
+        return tt._fc(last), last, out_cache_k, out_cache_v
+
+
 def check(name, a, b):
     import numpy as np
 
@@ -267,6 +314,62 @@ bo = ort.InferenceSession(f"{OUT}/bbox.onnx").run(
 )
 check("boxes", bo[0], boxes.numpy())
 check("classes", bo[1], classes.numpy())
+
+# ---- decoder_kv.onnx: the true-KV-cache step (preferred by the Rust loop) ----
+# Verify against the layer-output-cache module by rolling both autoregressively
+# from <start> over the same encoder memory: greedy argmax must match at every
+# step (the two are the same math; only reduction shapes differ).
+print("verifying DecodeKV against the layer-output cache, 64-step rollout:")
+kv_k = torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM))
+kv_v = torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM))
+lc_cache = torch.zeros((N_LAYERS, 0, 1, EMBED_DIM))
+roll_tags = [start]
+max_dlogit = 0.0
+with torch.no_grad():
+    for step in range(64):
+        lc_logits, _, lc_cache = Decode()(
+            torch.tensor(roll_tags, dtype=torch.long).unsqueeze(1),
+            cross_k, cross_v, lc_cache,
+        )
+        kv_logits, _, kv_k, kv_v = DecodeKV()(
+            torch.tensor([[roll_tags[-1]]], dtype=torch.long),
+            cross_k, cross_v, kv_k, kv_v,
+        )
+        d = float((lc_logits - kv_logits).abs().max())
+        max_dlogit = max(max_dlogit, d)
+        a, b = int(lc_logits.argmax()), int(kv_logits.argmax())
+        assert a == b, f"step {step}: argmax diverged (layer-cache {a} vs kv {b})"
+        roll_tags.append(a)
+print(f"  64 steps argmax-identical, max|dlogits| = {max_dlogit:.2e}")
+
+tag1 = torch.tensor([[start]], dtype=torch.long)
+past_kv = Dim("past", min=0, max=1024)
+torch.onnx.export(
+    DecodeKV(), (tag1, cross_k, cross_v, kv_k, kv_v), f"{OUT}/decoder_kv.onnx",
+    input_names=["tag", "cross_k", "cross_v", "cache_k", "cache_v"],
+    output_names=["logits", "hidden", "out_cache_k", "out_cache_v"],
+    dynamo=True,
+    dynamic_shapes=({}, {}, {}, {3: past_kv}, {3: past_kv}),
+)
+print("decoder_kv.onnx (true-KV-cache step):")
+with torch.no_grad():
+    kl, kh, kck, kcv = DecodeKV()(tag1, cross_k, cross_v,
+                                  torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM)),
+                                  torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM)))
+ko = ort.InferenceSession(f"{OUT}/decoder_kv.onnx").run(
+    None,
+    {
+        "tag": tag1.numpy(),
+        "cross_k": cross_k.numpy(),
+        "cross_v": cross_v.numpy(),
+        "cache_k": torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM)).numpy(),
+        "cache_v": torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM)).numpy(),
+    },
+)
+check("logits", ko[0], kl.numpy())
+check("hidden", ko[1], kh.numpy())
+check("out_cache_k", ko[2], kck.numpy())
+check("out_cache_v", ko[3], kcv.numpy())
 
 # word map → tokens file for the Rust decode loop
 json.dump(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Local / CI installer for fleischwolf: build from source and install a
+# self-contained tree under /usr/local/fleischwolf with a `fleischwolf`
+# command on PATH. Designed for one-liner use in dev boxes and pipelines:
+#
+#   curl -fsSL https://raw.githubusercontent.com/artiz/fleischwolf/master/scripts/install.sh | bash
+#
+# or from a checkout:
+#
+#   scripts/install.sh
+#
+# What it does:
+#   1. Checks for a Rust toolchain (>= 1.82 for the PDF crate); installs one
+#      via rustup (non-interactive) if `cargo` is missing.
+#   2. Builds the CLI in release mode (`cargo build --release -p fleischwolf-cli`).
+#   3. Installs to $FLEISCHWOLF_PREFIX (default /usr/local/fleischwolf):
+#        bin/fleischwolf          the CLI (ONNX Runtime statically linked)
+#        models/…, .pdfium/…      fetched by scripts/download_dependencies.sh
+#      and symlinks it as /usr/local/bin/fleischwolf.
+#   4. Writes /etc/profile.d/fleischwolf.sh exporting the DOCLING_*/PDFIUM_*
+#      paths. This is belt-and-braces only: the binary also resolves models
+#      and pdfium relative to its own (symlink-resolved) location, so the
+#      symlink works in pipelines that never source profile.d.
+#
+# Options (env vars):
+#   FLEISCHWOLF_PREFIX=/opt/fleischwolf   install tree (default /usr/local/fleischwolf)
+#   FLEISCHWOLF_BIN_DIR=/usr/local/bin    where the symlink goes
+#   FLEISCHWOLF_REF=master                git ref to build when cloning
+#   FLEISCHWOLF_NO_ASR=1                  skip the Whisper ASR models (~150 MB)
+#   FLEISCHWOLF_SUDO=0                    never invoke sudo (fail instead)
+set -euo pipefail
+
+REPO_URL="https://github.com/artiz/fleischwolf"
+PREFIX="${FLEISCHWOLF_PREFIX:-/usr/local/fleischwolf}"
+BIN_DIR="${FLEISCHWOLF_BIN_DIR:-/usr/local/bin}"
+REF="${FLEISCHWOLF_REF:-master}"
+
+say() { printf '\033[1m[fleischwolf]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[fleischwolf]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is required"
+
+# Privilege helper: only used for the install/copy steps, never for the build.
+SUDO=""
+if [ ! -w "$(dirname "$PREFIX")" ] || { [ -e "$PREFIX" ] && [ ! -w "$PREFIX" ]; }; then
+  if [ "${FLEISCHWOLF_SUDO:-1}" = "0" ]; then
+    die "$PREFIX is not writable and FLEISCHWOLF_SUDO=0"
+  fi
+  command -v sudo >/dev/null 2>&1 || die "$PREFIX is not writable and sudo is unavailable"
+  SUDO="sudo"
+fi
+
+# --- 1. Rust toolchain -------------------------------------------------------
+if ! command -v cargo >/dev/null 2>&1; then
+  # Respect an existing rustup installation that just isn't on PATH yet.
+  if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+  fi
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  say "Rust toolchain not found — installing via rustup (stable, non-interactive)"
+  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal
+  # shellcheck disable=SC1091
+  . "$HOME/.cargo/env"
+fi
+command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1 \
+  || die "no C compiler (cc/gcc/clang) — install build-essential / clang first"
+say "using $(cargo --version)"
+
+# --- 2. Sources: use the checkout we're in, else clone ------------------------
+if [ -f Cargo.toml ] && [ -d crates/fleischwolf-cli ]; then
+  SRC_DIR="$(pwd)"
+  say "building from existing checkout: $SRC_DIR"
+else
+  SRC_DIR="$(mktemp -d)/fleischwolf"
+  say "cloning $REPO_URL ($REF) to $SRC_DIR"
+  if command -v git >/dev/null 2>&1; then
+    git clone --depth 1 --branch "$REF" "$REPO_URL" "$SRC_DIR"
+  else
+    mkdir -p "$SRC_DIR"
+    curl -fsSL "$REPO_URL/archive/refs/heads/$REF.tar.gz" | tar -xz -C "$SRC_DIR" --strip-components=1
+  fi
+  cd "$SRC_DIR"
+fi
+
+# --- 3. Build ------------------------------------------------------------------
+say "building the CLI (release)"
+cargo build --release -p fleischwolf-cli
+
+# --- 4. Install tree -----------------------------------------------------------
+say "installing to $PREFIX"
+$SUDO mkdir -p "$PREFIX/bin"
+$SUDO cp target/release/fleischwolf "$PREFIX/bin/fleischwolf"
+
+# Models + pdfium land inside the prefix; download_dependencies.sh fetches into
+# the *current* directory, so run it from there. It is idempotent (skips files
+# already present), so re-running the installer only fetches what's missing.
+DL_ARGS=""
+[ "${FLEISCHWOLF_NO_ASR:-0}" = "1" ] && DL_ARGS="--no-asr"
+say "fetching models + pdfium into $PREFIX (idempotent)"
+# shellcheck disable=SC2086
+(cd "$PREFIX" && $SUDO sh "$SRC_DIR/scripts/download_dependencies.sh" $DL_ARGS)
+
+say "linking $BIN_DIR/fleischwolf -> $PREFIX/bin/fleischwolf"
+$SUDO mkdir -p "$BIN_DIR"
+$SUDO ln -sfn "$PREFIX/bin/fleischwolf" "$BIN_DIR/fleischwolf"
+
+# --- 5. Environment (optional convenience) --------------------------------------
+# The binary resolves models/.pdfium next to its own location through the
+# symlink, so these exports are not required for `fleischwolf` itself — they
+# help other tools (scripts, the Node bindings) find the same assets.
+if [ -d /etc/profile.d ] && [ -n "$SUDO" -o -w /etc/profile.d ]; then
+  say "writing /etc/profile.d/fleischwolf.sh"
+  $SUDO tee /etc/profile.d/fleischwolf.sh >/dev/null <<EOF
+# fleischwolf (installed by scripts/install.sh) — not required by the CLI
+# itself (it resolves these relative to its own binary), provided for other
+# consumers of the same model tree.
+export PDFIUM_DYNAMIC_LIB_PATH="$PREFIX/.pdfium/lib"
+export DOCLING_OCR_REC_ONNX="$PREFIX/models/ocr_rec.onnx"
+export DOCLING_OCR_DICT="$PREFIX/models/ppocr_keys_v1.txt"
+export DOCLING_TABLEFORMER_ENCODER="$PREFIX/models/tableformer/encoder.onnx"
+export DOCLING_TABLEFORMER_BBOX="$PREFIX/models/tableformer/bbox.onnx"
+EOF
+fi
+
+# --- 6. Smoke test ---------------------------------------------------------------
+say "smoke test: converting a trivial Markdown document"
+TMP_MD="$(mktemp --suffix=.md 2>/dev/null || mktemp -t fleischwolf.XXXXXX.md)"
+printf '# fleischwolf\n\ninstalled.\n' > "$TMP_MD"
+"$BIN_DIR/fleischwolf" "$TMP_MD" >/dev/null || die "smoke test failed"
+rm -f "$TMP_MD"
+
+say "done. Try:  fleischwolf your.pdf > out.md"
+say "layout: $PREFIX  (binary, models/, .pdfium/); uninstall: rm -rf $PREFIX $BIN_DIR/fleischwolf /etc/profile.d/fleischwolf.sh"

--- a/scripts/pdf_conformance.sh
+++ b/scripts/pdf_conformance.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 cd "$(dirname "$0")/.."   # fleischwolf/
 
 export PDFIUM_DYNAMIC_LIB_PATH="${PDFIUM_DYNAMIC_LIB_PATH:-$(pwd)/.pdfium/lib}"
+# Pin the snapshot-baseline pixel path: the scalar image-crate resize (the
+# committed snapshots were generated with it; the SIMD default differs by
+# ±1/255 per pixel, enough to flip borderline table cells).
+export FLEISCHWOLF_SLOW_RESIZE="${FLEISCHWOLF_SLOW_RESIZE:-1}"
 export DOCLING_LAYOUT_ONNX="${DOCLING_LAYOUT_ONNX:-$(pwd)/models/layout_heron.onnx}"
 export DOCLING_OCR_REC_ONNX="${DOCLING_OCR_REC_ONNX:-$(pwd)/models/ocr_rec.onnx}"
 export DOCLING_OCR_DICT="${DOCLING_OCR_DICT:-$(pwd)/models/ppocr_keys_v1.txt}"

--- a/scripts/pdf_groundtruth.sh
+++ b/scripts/pdf_groundtruth.sh
@@ -11,6 +11,10 @@ set -euo pipefail
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 
 export PDFIUM_DYNAMIC_LIB_PATH="${PDFIUM_DYNAMIC_LIB_PATH:-$(pwd)/.pdfium/lib}"
+# Pin the snapshot-baseline pixel path: the scalar image-crate resize (the
+# committed snapshots were generated with it; the SIMD default differs by
+# ±1/255 per pixel, enough to flip borderline table cells).
+export FLEISCHWOLF_SLOW_RESIZE="${FLEISCHWOLF_SLOW_RESIZE:-1}"
 export DOCLING_LAYOUT_ONNX="${DOCLING_LAYOUT_ONNX:-$(pwd)/models/layout_heron.onnx}"
 export DOCLING_OCR_REC_ONNX="${DOCLING_OCR_REC_ONNX:-$(pwd)/models/ocr_rec.onnx}"
 export DOCLING_OCR_DICT="${DOCLING_OCR_DICT:-$(pwd)/models/ppocr_keys_v1.txt}"

--- a/scripts/quantize_models.py
+++ b/scripts/quantize_models.py
@@ -121,22 +121,28 @@ def quantize_tableformer_decoder():
     import onnx
     from onnxruntime.quantization import QuantType, quantize_dynamic
 
-    src = f"{MODELS}/tableformer/decoder.onnx"
-    tmp = f"{MODELS}/tableformer/decoder_clean.onnx"
-    dst = f"{MODELS}/tableformer/decoder_int8.onnx"
+    # Quantize the legacy layer-output-cache decoder and, when the export
+    # produced it, the true-KV-cache variant (decoder_kv.onnx — preferred by
+    # the Rust loop for very-large-table workloads).
+    for stem in ("decoder", "decoder_kv"):
+        src = f"{MODELS}/tableformer/{stem}.onnx"
+        if not os.path.exists(src):
+            continue
+        tmp = f"{MODELS}/tableformer/{stem}_clean.onnx"
+        dst = f"{MODELS}/tableformer/{stem}_int8.onnx"
 
-    # The export carries stale value_info shapes that break ORT's shape
-    # inference; strip them (external weights get folded into the output).
-    m = onnx.load(src)
-    del m.graph.value_info[:]
-    onnx.save(m, tmp, save_as_external_data=True, location="decoder_clean.onnx.data")
-    print("tableformer-decoder: dynamic INT8 quantization...", flush=True)
-    quantize_dynamic(
-        tmp, dst, weight_type=QuantType.QInt8, extra_options={"MatMulConstBOnly": True}
-    )
-    os.remove(tmp)
-    os.remove(f"{tmp}.data")
-    print(f"tableformer-decoder: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
+        # The export carries stale value_info shapes that break ORT's shape
+        # inference; strip them (external weights get folded into the output).
+        m = onnx.load(src)
+        del m.graph.value_info[:]
+        onnx.save(m, tmp, save_as_external_data=True, location=f"{stem}_clean.onnx.data")
+        print(f"tableformer-decoder: dynamic INT8 quantization ({stem})...", flush=True)
+        quantize_dynamic(
+            tmp, dst, weight_type=QuantType.QInt8, extra_options={"MatMulConstBOnly": True}
+        )
+        os.remove(tmp)
+        os.remove(f"{tmp}.data")
+        print(f"tableformer-decoder: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
 
 
 def main():


### PR DESCRIPTION
## Summary

Follow-up to #26 — the next items from the `PDF_PERFORMANCE.md` backlog plus install tooling, one commit each, every change regression-gated against the corpus.

- **Worker-pool memory halved** (`9d44ed5`): one lazily-loaded TableFormer shared behind a mutex instead of a copy per worker. Peak RSS on the 16-page table-heavy paper: **3816 → 1880 MB** (4 workers); table-free docs 682 → 331 MB (TableFormer never loads). Byte-identical output.
- **True-KV-cache TableFormer decoder** (`422812d`): `decoder_kv.onnx` export (one tag per step), argmax-identical at export, byte-identical in the pipeline. Honest result: parity at corpus table sizes — kept as an opt-in for very-large-table workloads; Rust auto-detects either graph.
- **SIMD page downscale** (`a995706`): `fast_image_resize`, same Catmull-Rom kernel: **`image.resize` 2607 → 152 ms (17×)**. Gated like INT8: groundtruth distance **817 (SIMD) vs 818 (scalar)**. `FLEISCHWOLF_SLOW_RESIZE=1` opts out; conformance scripts pin the scalar path so snapshots stay valid.
- **textparse caches** (`0d38da5`): fonts (ToUnicode/Type1/width parsing) and decoded Form XObjects cached per document instead of re-parsed per page / per `Do`. Identical output; 3–10% off `textparse` on this corpus, far more on CJK/form-heavy PDFs.
- **`scripts/install.sh` + exe-relative asset resolution** (`c4ae69c`): `curl | bash` installer for dev boxes and CI — checks/installs Rust, builds the CLI, installs `/usr/local/fleischwolf/{bin,models,.pdfium}`, symlinks `/usr/local/bin/fleischwolf`, writes `/etc/profile.d/fleischwolf.sh`. Default asset paths now also resolve next to the (symlink-canonicalized) binary, so the installed command works from any directory with no env vars. Docs: README install section, crate-table rows for `fleischwolf-asr`/`-rag`, MIGRATION extensions brought up to date, and a results-at-a-glance summary opening `PDF_PERFORMANCE.md`.

Also documented: multi-threaded ORT inference was already non-deterministic run-to-run in borderline table cells (0–20 diff-lines between identical invocations) — regression checks here compare under `FLEISCHWOLF_PDF_THREADS=1`, where output is byte-stable.

## Testing

- Full workspace test suite green (16 suites), fmt/pinned-clippy clean.
- Every commit A/B'd old-vs-new binary under `FLEISCHWOLF_PDF_THREADS=1` (byte-identical for structural changes; groundtruth-distance gate for SIMD resize).
- Installer exercised end-to-end in a clean container: rustup path, build, install, `env -i` conversion of a real PDF from a foreign CWD through the symlink (full ML output, zero env vars).

## After merge

Re-run `gh workflow run publish-models.yml` to add `decoder_kv.onnx` / `decoder_kv_int8.onnx` to the models release (existing assets unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fKFbatf55BK5j8vr3dZjj