### PR TITLE
feat(py): PyO3 bindings (fleischwolf-py) — docling-shaped drop-in, local-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ __pycache__/
 /.venv-gt
 /scratch-gt
 
+
+# fleischwolf-py is a standalone crate (own workspace) — its build dirs
+crates/fleischwolf-py/target/
+crates/fleischwolf-py/.venv/
+crates/fleischwolf-py/python/fleischwolf/*.so

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -265,9 +265,18 @@ Shipped:
 - **`fleischwolf-node`** — Node.js/Bun N-API bindings (npm package).
 - **MHTML backend** — no docling analogue.
 
+Experimental (in-repo, unpublished):
+
+- **PyO3 bindings** (`crates/fleischwolf-py`) — a strangler-fig drop-in for
+  docling's common path (`DocumentConverter().convert(p).document
+  .export_to_markdown()` / `export_to_dict()`), built locally with maturin;
+  models download in pure Python from the `models-v1` release into
+  `~/.cache/fleischwolf`, mirroring docling's artifact handling. The PyPI
+  name is tentative; see the crate README for local testing. Deliberately
+  outside the Cargo workspace and the crates.io publish flow.
+
 Planned:
 
-- **PyO3 bindings** (`fleischwolf-py`) for a strangler-fig drop-in.
 - **C++** bindings.
   
 ## 7. Testing

--- a/crates/fleischwolf-py/Cargo.toml
+++ b/crates/fleischwolf-py/Cargo.toml
@@ -1,0 +1,30 @@
+# Python bindings for fleischwolf (PyO3 + maturin) — a strangler-fig drop-in
+# for Python docling's common path:
+#
+#     from fleischwolf import DocumentConverter
+#     md = DocumentConverter().convert("doc.pdf").document.export_to_markdown()
+#
+# Deliberately a STANDALONE crate (the empty [workspace] below opts it out of
+# the repo workspace): it is built only by maturin, is NOT published to
+# crates.io by scripts/ci_publish.sh, and the PyPI name is still tentative.
+# Build/test locally per this crate's README.md.
+[package]
+name = "fleischwolf-py"
+version = "0.15.1"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/artiz/fleischwolf"
+publish = false
+
+[workspace]
+
+[lib]
+name = "fleischwolf_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+fleischwolf = { path = "../fleischwolf" }
+pyo3 = { version = "0.23", features = ["abi3-py39", "extension-module"] }
+
+[profile.release]
+lto = "thin"

--- a/crates/fleischwolf-py/README.md
+++ b/crates/fleischwolf-py/README.md
@@ -1,0 +1,73 @@
+# fleischwolf-py — Python bindings (PyO3)
+
+A **strangler-fig drop-in** for Python docling's common conversion path,
+backed by the Rust [fleischwolf](https://github.com/artiz/fleischwolf) engine:
+same call shape, no torch, ~4× faster PDF conversion at a fraction of the
+memory (see [`PDF_PERFORMANCE.md`](../../PDF_PERFORMANCE.md)).
+
+```python
+# was:  from docling.document_converter import DocumentConverter
+from fleischwolf import DocumentConverter
+
+result = DocumentConverter().convert("document.pdf")
+print(result.document.export_to_markdown())
+data = result.document.export_to_dict()     # docling-core JSON wire format (schema 1.10.0)
+```
+
+> **Status: experimental, not published.** The PyPI distribution name
+> (`fleischwolf`) is tentative and may change; nothing is uploaded anywhere.
+> Build and install locally as below. The crate is intentionally outside the
+> repo's Cargo workspace and its crates.io publish flow.
+
+## Try it locally
+
+Needs a Rust toolchain (1.82+) and Python ≥ 3.9.
+
+```bash
+cd crates/fleischwolf-py
+
+# 1. Build + install into the CURRENT virtualenv (create one first):
+python -m venv .venv && source .venv/bin/activate
+pip install maturin
+maturin develop --release          # compiles the Rust engine, installs `fleischwolf`
+
+# 2. One-time model download (~700 MB → ~/.cache/fleischwolf), pure Python —
+#    fetched from the repo's models-v1 GitHub release, like docling fetches
+#    its artifacts. Declarative formats (DOCX/HTML/XLSX/…) skip this entirely.
+python -c "import fleischwolf; fleischwolf.download_models()"
+
+# 3. Convert:
+python - <<'PY'
+from fleischwolf import DocumentConverter
+
+conv = DocumentConverter()
+result = conv.convert("../../tests/data/pdf/sources/2305.03393v1-pg9.pdf")
+print(result.status)                            # "success"
+print(result.document.export_to_markdown()[:400])
+PY
+```
+
+## API surface (docling-shaped)
+
+| fleischwolf | docling counterpart | notes |
+|---|---|---|
+| `DocumentConverter(strict=False, fetch_images=False, artifacts_path=None)` | `DocumentConverter(...)` | `strict` = fleischwolf-only cleaner Markdown; default output is docling-legacy byte parity. `artifacts_path` overrides the model cache dir. |
+| `.convert(path) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path`. Releases the GIL during conversion. |
+| `.convert_bytes(name, data)` | `DocumentStream` | extension of `name` drives format detection |
+| `result.status` / `result.document` | same | status: `"success" / "partial_success" / "failure"` |
+| `document.export_to_markdown()` | same | plus `export_to_markdown(strict=True/False)` per-call override |
+| `document.export_to_dict()` / `export_to_json()` | `export_to_dict()` | dict / JSON string of the docling wire format |
+| `document.save_as_markdown(p)` / `save_as_json(p)` | same | |
+| `fleischwolf.download_models()` | `docling-tools models download` | idempotent; `~/.cache/fleischwolf` or `$FLEISCHWOLF_CACHE_DIR`; INT8 models fetched when hosted and preferred automatically (`FLEISCHWOLF_FP32=1` opts out) |
+
+Model/env resolution order: explicit `DOCLING_*` env vars → the cache dir set
+by `ensure_env()` (called by the constructor) → the process CWD (`models/`,
+`.pdfium/`, matching the CLI). pdfium is Linux x64 from the release; on other
+platforms set `PDFIUM_DYNAMIC_LIB_PATH` to a local build.
+
+## Not covered (yet)
+
+Chunkers, VLM/enrichment pipelines, and docling's full options model
+(`PdfPipelineOptions`, per-format backends selection). The document object
+carries rendered text for inline formatting rather than structured
+`formatting` fields — see `MIGRATION.md` §4 for the documented divergences.

--- a/crates/fleischwolf-py/pyproject.toml
+++ b/crates/fleischwolf-py/pyproject.toml
@@ -1,0 +1,26 @@
+# NOT published to PyPI yet — the distribution name below is tentative and the
+# package is built/installed locally with maturin (see README.md).
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[project]
+name = "fleischwolf"
+version = "0.15.1"
+description = "Rust port of docling (fleischwolf): convert PDF/DOCX/HTML/... to Markdown or docling JSON. Python bindings."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Repository = "https://github.com/artiz/fleischwolf"
+
+[tool.maturin]
+module-name = "fleischwolf._native"
+python-source = "python"

--- a/crates/fleischwolf-py/python/fleischwolf/__init__.py
+++ b/crates/fleischwolf-py/python/fleischwolf/__init__.py
@@ -1,0 +1,56 @@
+"""fleischwolf — Rust docling port, Python bindings.
+
+A strangler-fig drop-in for Python docling's common path::
+
+    from fleischwolf import DocumentConverter          # was: from docling.document_converter import ...
+
+    result = DocumentConverter().convert("document.pdf")
+    print(result.document.export_to_markdown())
+    data = result.document.export_to_dict()            # docling JSON wire format
+
+One-time model setup (mirrors docling's artifact download; ~700 MB into
+``~/.cache/fleischwolf``)::
+
+    import fleischwolf; fleischwolf.download_models()
+
+Declarative formats (DOCX/HTML/XLSX/…) need no models at all.
+"""
+
+from . import models
+from .models import cache_dir, download_models, ensure_env
+from ._native import (
+    ConversionResult,
+    DoclingDocument,
+    __version__,
+)
+from ._native import DocumentConverter as _NativeDocumentConverter
+
+__all__ = [
+    "DocumentConverter",
+    "ConversionResult",
+    "DoclingDocument",
+    "download_models",
+    "ensure_env",
+    "cache_dir",
+    "models",
+    "__version__",
+]
+
+
+class DocumentConverter:
+    """docling-shaped converter. ``artifacts_path`` overrides the model cache
+    directory (docling's ``artifacts_path``); by default the pipeline is
+    pointed at ``~/.cache/fleischwolf`` (see :func:`download_models`)."""
+
+    def __init__(self, strict=False, fetch_images=False, artifacts_path=None):
+        ensure_env(artifacts_path)
+        self._inner = _NativeDocumentConverter(strict=strict, fetch_images=fetch_images)
+
+    def convert(self, source) -> ConversionResult:
+        """Convert a filesystem path (str / pathlib.Path)."""
+        return self._inner.convert(source)
+
+    def convert_bytes(self, name: str, data: bytes) -> ConversionResult:
+        """Convert in-memory bytes; ``name``'s extension drives format detection
+        (docling's ``DocumentStream`` counterpart)."""
+        return self._inner.convert_bytes(name, data)

--- a/crates/fleischwolf-py/python/fleischwolf/models.py
+++ b/crates/fleischwolf-py/python/fleischwolf/models.py
@@ -1,0 +1,130 @@
+"""Model/asset download for the fleischwolf Python bindings.
+
+Mirrors how Python docling manages its artifacts: models are fetched once
+into a per-user cache directory (default ``~/.cache/fleischwolf``, override
+with ``$FLEISCHWOLF_CACHE_DIR``) and the pipeline is pointed at them via the
+same ``DOCLING_*`` / ``PDFIUM_*`` environment variables the Rust CLI uses.
+Assets come from this repo's GitHub model release
+(https://github.com/artiz/fleischwolf/releases/tag/models-v1 — override the
+base URL with ``$FLEISCHWOLF_MODELS_URL``).
+
+Usage::
+
+    import fleischwolf
+    fleischwolf.download_models()          # once; idempotent, skips present files
+
+``DocumentConverter`` calls :func:`ensure_env` automatically, so after the
+one-time download no configuration is needed at all.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+BASE_URL = os.environ.get(
+    "FLEISCHWOLF_MODELS_URL",
+    "https://github.com/artiz/fleischwolf/releases/download/models-v1",
+)
+
+# release asset name -> path under the cache dir (the CLI's layout).
+_REQUIRED = {
+    "layout_heron.onnx": "models/layout_heron.onnx",
+    "ocr_rec.onnx": "models/ocr_rec.onnx",
+    "ppocr_keys_v1.txt": "models/ppocr_keys_v1.txt",
+    "encoder.onnx": "models/tableformer/encoder.onnx",
+    "decoder.onnx": "models/tableformer/decoder.onnx",
+    "bbox.onnx": "models/tableformer/bbox.onnx",
+}
+# Fetched when the release hosts them; a 404 is fine (older tag, optional
+# sidecars, INT8 variants — the pipeline falls back to fp32 gracefully).
+_OPTIONAL = {
+    "layout_heron_int8.onnx": "models/layout_heron_int8.onnx",
+    "decoder_int8.onnx": "models/tableformer/decoder_int8.onnx",
+    "encoder.onnx.data": "models/tableformer/encoder.onnx.data",
+    "decoder.onnx.data": "models/tableformer/decoder.onnx.data",
+    "bbox.onnx.data": "models/tableformer/bbox.onnx.data",
+}
+# pdfium rasterizer (Linux x64, matching what the release hosts).
+_PDFIUM = {"libpdfium.so": ".pdfium/lib/libpdfium.so"}
+
+
+def cache_dir() -> Path:
+    """The asset cache root (``$FLEISCHWOLF_CACHE_DIR`` or ``~/.cache/fleischwolf``)."""
+    if env := os.environ.get("FLEISCHWOLF_CACHE_DIR"):
+        return Path(env)
+    return Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "fleischwolf"
+
+
+def _fetch(url: str, dest: Path, optional: bool, progress: bool) -> bool:
+    if dest.exists():
+        return True
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".download")
+    try:
+        if progress:
+            print(f"  > {dest}", file=sys.stderr, flush=True)
+        with urllib.request.urlopen(url) as r, open(tmp, "wb") as f:
+            while chunk := r.read(1 << 20):
+                f.write(chunk)
+        tmp.rename(dest)
+        return True
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        if optional:
+            return False
+        raise
+
+
+def download_models(dest: "str | Path | None" = None, progress: bool = True) -> Path:
+    """Fetch the PDF/image pipeline's models + pdfium into the cache (idempotent).
+
+    Returns the cache root. Pass ``dest`` to use a custom directory (also set
+    it as ``$FLEISCHWOLF_CACHE_DIR`` at runtime, or pass the same value as
+    ``DocumentConverter(artifacts_path=...)``).
+    """
+    root = Path(dest) if dest else cache_dir()
+    if progress:
+        print(f"fleischwolf: fetching models to {root}", file=sys.stderr, flush=True)
+    for name, rel in {**_REQUIRED, **_PDFIUM}.items():
+        _fetch(f"{BASE_URL}/{name}", root / rel, optional=False, progress=progress)
+    for name, rel in _OPTIONAL.items():
+        _fetch(f"{BASE_URL}/{name}", root / rel, optional=True, progress=progress)
+    return root
+
+
+def _setdefault_if_exists(var: str, path: Path) -> None:
+    if var not in os.environ and path.exists():
+        os.environ[var] = str(path)
+
+
+def ensure_env(dest: "str | Path | None" = None) -> Path:
+    """Point the native pipeline at the cached assets via the ``DOCLING_*`` /
+    ``PDFIUM_*`` env vars (only filling ones that are not already set, so
+    explicit configuration always wins). Prefers the INT8 models when present,
+    matching the Rust pipeline's default; ``FLEISCHWOLF_FP32=1`` opts out.
+    Safe to call when nothing is downloaded yet — missing files simply leave
+    the env untouched (and the converter will fail with its usual clear
+    "model not found" message)."""
+    root = Path(dest) if dest else cache_dir()
+    fp32 = os.environ.get("FLEISCHWOLF_FP32", "0") not in ("", "0")
+    m = root / "models"
+
+    layout = m / "layout_heron_int8.onnx"
+    if fp32 or not layout.exists():
+        layout = m / "layout_heron.onnx"
+    _setdefault_if_exists("DOCLING_LAYOUT_ONNX", layout)
+
+    decoder = m / "tableformer/decoder_int8.onnx"
+    if fp32 or not decoder.exists():
+        decoder = m / "tableformer/decoder.onnx"
+    _setdefault_if_exists("DOCLING_TABLEFORMER_DECODER", decoder)
+
+    _setdefault_if_exists("DOCLING_OCR_REC_ONNX", m / "ocr_rec.onnx")
+    _setdefault_if_exists("DOCLING_OCR_DICT", m / "ppocr_keys_v1.txt")
+    _setdefault_if_exists("DOCLING_TABLEFORMER_ENCODER", m / "tableformer/encoder.onnx")
+    _setdefault_if_exists("DOCLING_TABLEFORMER_BBOX", m / "tableformer/bbox.onnx")
+    _setdefault_if_exists("PDFIUM_DYNAMIC_LIB_PATH", root / ".pdfium/lib")
+    return root

--- a/crates/fleischwolf-py/src/lib.rs
+++ b/crates/fleischwolf-py/src/lib.rs
@@ -1,0 +1,178 @@
+//! PyO3 bindings: a docling-shaped Python API over the fleischwolf converter.
+//!
+//! The Python-visible classes mirror docling's names and the common call
+//! shape (`DocumentConverter().convert(src).document.export_to_markdown()`),
+//! so swapping `from docling.document_converter import DocumentConverter` for
+//! `from fleischwolf import DocumentConverter` is the whole migration for the
+//! Markdown/JSON path. Model discovery/download lives on the Python side
+//! (`fleischwolf.models`), mirroring how docling fetches its artifacts.
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use fleischwolf::{ConversionStatus, SourceDocument};
+
+/// The converted document: docling-core's `DoclingDocument` counterpart.
+#[pyclass(name = "DoclingDocument")]
+struct PyDoclingDocument {
+    inner: fleischwolf::DoclingDocument,
+}
+
+#[pymethods]
+impl PyDoclingDocument {
+    /// Markdown export. `strict=None` keeps the converter's mode (docling-legacy
+    /// byte-parity by default); `strict=True/False` overrides per call.
+    #[pyo3(signature = (strict = None))]
+    fn export_to_markdown(&self, strict: Option<bool>) -> String {
+        match strict {
+            Some(s) => self.inner.export_to_markdown_with(s),
+            None => self.inner.export_to_markdown(),
+        }
+    }
+
+    /// docling-core's native `DoclingDocument` JSON wire format, as a string.
+    fn export_to_json(&self) -> String {
+        self.inner.export_to_json()
+    }
+
+    /// docling's `export_to_dict()`: the JSON wire format as a Python dict.
+    fn export_to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let json = self.inner.export_to_json();
+        let loads = py.import("json")?.getattr("loads")?;
+        loads.call1((json,))
+    }
+
+    /// docling's `save_as_json(path)`.
+    fn save_as_json(&self, path: std::path::PathBuf) -> PyResult<()> {
+        std::fs::write(&path, self.inner.export_to_json())
+            .map_err(|e| PyRuntimeError::new_err(format!("save_as_json {}: {e}", path.display())))
+    }
+
+    /// docling's `save_as_markdown(path)`.
+    #[pyo3(signature = (path, strict = None))]
+    fn save_as_markdown(&self, path: std::path::PathBuf, strict: Option<bool>) -> PyResult<()> {
+        let md = match strict {
+            Some(s) => self.inner.export_to_markdown_with(s),
+            None => self.inner.export_to_markdown(),
+        };
+        std::fs::write(&path, md).map_err(|e| {
+            PyRuntimeError::new_err(format!("save_as_markdown {}: {e}", path.display()))
+        })
+    }
+}
+
+/// docling's `ConversionResult`: `.document`, `.status`, `.input.file`-ish name.
+#[pyclass(name = "ConversionResult")]
+struct PyConversionResult {
+    #[pyo3(get)]
+    status: String,
+    #[pyo3(get)]
+    input_name: String,
+    document: Py<PyDoclingDocument>,
+}
+
+#[pymethods]
+impl PyConversionResult {
+    #[getter]
+    fn document(&self, py: Python<'_>) -> Py<PyDoclingDocument> {
+        self.document.clone_ref(py)
+    }
+}
+
+/// docling's `DocumentConverter`. Thread-safe for sequential reuse; the heavy
+/// ML models are process-wide state loaded on first PDF/image conversion.
+#[pyclass(name = "DocumentConverter")]
+struct PyDocumentConverter {
+    inner: fleischwolf::DocumentConverter,
+}
+
+#[pymethods]
+impl PyDocumentConverter {
+    /// `strict` — fleischwolf-only cleaner Markdown (docling has no analogue;
+    /// default False = docling-legacy byte parity). `fetch_images` — resolve
+    /// remote/local `<img src>` for HTML/EPUB (docling's `enable_*_fetch`).
+    #[new]
+    #[pyo3(signature = (strict = false, fetch_images = false))]
+    fn new(strict: bool, fetch_images: bool) -> Self {
+        Self {
+            inner: fleischwolf::DocumentConverter::new()
+                .strict(strict)
+                .fetch_images(fetch_images),
+        }
+    }
+
+    /// Convert a document from a filesystem path (str / os.PathLike).
+    /// Releases the GIL for the (potentially long) conversion.
+    fn convert(&self, py: Python<'_>, source: PathLike) -> PyResult<PyConversionResult> {
+        let path = source.0;
+        let result = py
+            .allow_threads(|| {
+                let src = SourceDocument::from_file(&path)?;
+                self.inner.convert(src)
+            })
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        wrap_result(py, result)
+    }
+
+    /// Convert in-memory bytes; `name` (with extension) drives format detection,
+    /// mirroring docling's `DocumentStream(name=..., stream=...)`.
+    fn convert_bytes(
+        &self,
+        py: Python<'_>,
+        name: String,
+        data: Bound<'_, PyBytes>,
+    ) -> PyResult<PyConversionResult> {
+        let bytes = data.as_bytes().to_vec();
+        let ext = std::path::Path::new(&name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        let format = fleischwolf::InputFormat::from_extension(ext).ok_or_else(|| {
+            PyRuntimeError::new_err(format!("cannot detect input format from name {name:?}"))
+        })?;
+        let result = py
+            .allow_threads(|| {
+                self.inner
+                    .convert(SourceDocument::from_bytes(&name, format, bytes))
+            })
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        wrap_result(py, result)
+    }
+}
+
+fn wrap_result(py: Python<'_>, r: fleischwolf::ConversionResult) -> PyResult<PyConversionResult> {
+    let status = match r.status {
+        ConversionStatus::Success => "success",
+        ConversionStatus::PartialSuccess => "partial_success",
+        ConversionStatus::Failure => "failure",
+    }
+    .to_string();
+    Ok(PyConversionResult {
+        status,
+        input_name: r.input_name,
+        document: Py::new(py, PyDoclingDocument { inner: r.document })?,
+    })
+}
+
+/// str / pathlib.Path / anything os.PathLike → PathBuf.
+struct PathLike(std::path::PathBuf);
+
+impl<'py> FromPyObject<'py> for PathLike {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(p) = ob.extract::<std::path::PathBuf>() {
+            return Ok(PathLike(p));
+        }
+        let fspath = ob.py().import("os")?.getattr("fspath")?;
+        Ok(PathLike(fspath.call1((ob,))?.extract()?))
+    }
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyDocumentConverter>()?;
+    m.add_class::<PyConversionResult>()?;
+    m.add_class::<PyDoclingDocument>()?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The strangler-fig PyO3 bindings from the roadmap — **experimental, not published anywhere** (the PyPI name is tentative), built locally with maturin:

```python
# was:  from docling.document_converter import DocumentConverter
from fleischwolf import DocumentConverter

result = DocumentConverter().convert("document.pdf")
print(result.document.export_to_markdown())
data = result.document.export_to_dict()          # docling JSON wire format, schema 1.10.0
```

- **API surface mirrors docling**: `DocumentConverter(strict, fetch_images, artifacts_path)`, `.convert(path)` (str/`os.PathLike`, GIL released for the conversion), `.convert_bytes(name, data)` (the `DocumentStream` counterpart), `ConversionResult.status/.document`, `DoclingDocument.export_to_markdown/export_to_dict/export_to_json/save_as_*`.
- **Models download in pure Python, docling-style**: `fleischwolf.download_models()` fetches the pipeline assets (incl. pdfium and the INT8 variants) from the `models-v1` GitHub release into `~/.cache/fleischwolf` (`$FLEISCHWOLF_CACHE_DIR` overrides) with stdlib `urllib`; `ensure_env()` — called by the constructor — points the native pipeline at the cache via the standard `DOCLING_*`/`PDFIUM_*` env vars, preferring INT8 like the Rust default and never overriding explicitly-set variables. Declarative formats need no models at all.
- **Deliberately isolated**: standalone crate (own empty `[workspace]`, `publish = false`) — outside the repo workspace, untouched by CI's `cargo test`/clippy and by `ci_publish.sh`. Renaming the distribution later costs nothing.
- Crate README documents the full local try-it flow (venv → `maturin develop --release` → `download_models()` → convert); MIGRATION §6 moves PyO3 from "planned" to "experimental in-repo".

## Testing (all in-container, per the README steps)

- `maturin develop --release` builds and installs into a fresh venv.
- `download_models()` pulled 623 MB from the release (required + optional INT8/`.data` assets, 404-tolerant optional path exercised earlier against a tag without int8).
- Declarative Markdown conversion, `export_to_dict()` (schema 1.10.0), bytes API and `pathlib.Path` inputs pass without any models configured.
- A PDF converted through the full ML pipeline **from a foreign CWD with a clean environment** is **byte-identical** to the CLI's output on the same file (INT8 stack auto-selected from the cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fKFbatf55BK5j8vr3dZjj

---
_Generated by [Claude Code](https://claude.ai/code/session_017fKFbatf55BK5j8vr3dZjj)_