### PR TITLE
feat(pptx): DocLang shape &lt;location&gt; provenance (issue #39)

### DIFF
--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -338,7 +338,25 @@ fn attr_escape(v: &str) -> String {
 /// the reference's block form: plain fragments as bare indented lines,
 /// formatted fragments as their own inline elements — matching minidom's
 /// output for a `<text>` with element children.
-fn emit_text_element(out: &mut Out, depth: i32, tag_open: &str, tag: &str, text: &str) {
+fn emit_text_element(
+    out: &mut Out,
+    depth: i32,
+    tag_open: &str,
+    tag: &str,
+    text: &str,
+    location: Option<&[u16; 4]>,
+) {
+    // With layout provenance the element renders in block form: the `<location>`
+    // tokens are element children, then the text runs.
+    if let Some(loc) = location {
+        out.push(depth, format!("<{tag_open}>"));
+        push_location(out, depth + 1, loc);
+        if !text.is_empty() {
+            emit_runs(out, depth + 1, inline_runs(text));
+        }
+        out.push(depth, format!("</{tag}>"));
+        return;
+    }
     // An empty text item renders as an empty element on one line (docling emits
     // one per blank body paragraph).
     if text.is_empty() {
@@ -535,14 +553,20 @@ fn emit_code(out: &mut Out, depth: i32, language: Option<&str>, text: &str) {
     }
 }
 
+/// Emit the four `<location>` provenance tokens (`x0,y0,x1,y1`) as element
+/// children — docling's element head for backends with real geometry.
+fn push_location(out: &mut Out, depth: i32, loc: &[u16; 4]) {
+    for v in loc {
+        out.push(depth, format!("<location value=\"{v}\"/>"));
+    }
+}
+
 fn emit_table(out: &mut Out, depth: i32, table: &Table) {
     out.push(depth, "<table>".to_string());
-    // Layout provenance (spreadsheet backends): four `<location>` tokens
+    // Layout provenance (spreadsheet/slide backends): four `<location>` tokens
     // (x0,y0,x1,y1) precede the cells, matching docling's element head.
-    if let Some(loc) = table.location {
-        for v in loc {
-            out.push(depth + 1, format!("<location value=\"{v}\"/>"));
-        }
+    if let Some(loc) = &table.location {
+        push_location(out, depth + 1, loc);
     }
     for (ri, row) in table.rows.iter().enumerate() {
         for (ci, cell) in row.iter().enumerate() {
@@ -605,11 +629,11 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
                 } else {
                     format!("heading level=\"{level}\"")
                 };
-                emit_text_element(out, depth, &open, "heading", text);
+                emit_text_element(out, depth, &open, "heading", text, None);
                 *i += 1;
             }
             Node::Paragraph { text } => {
-                emit_text_element(out, depth, "text", "text", text);
+                emit_text_element(out, depth, "text", "text", text, None);
                 *i += 1;
             }
             Node::Code { language, text } => {
@@ -621,13 +645,7 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
                 *i += 1;
             }
             Node::Picture { caption, image: _ } => {
-                if let Some(c) = caption.as_ref().filter(|c| !c.trim().is_empty()) {
-                    out.push(depth, "<picture>".to_string());
-                    out.push(depth + 1, format!("<caption>{}</caption>", escape_text(c)));
-                    out.push(depth, "</picture>".to_string());
-                } else {
-                    out.push(depth, "<picture></picture>".to_string());
-                }
+                emit_picture(out, depth, caption.as_deref(), None);
                 *i += 1;
             }
             Node::ListItem { level: l, .. } => {
@@ -653,6 +671,10 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
             }
             Node::Furniture(inner) => {
                 emit_furniture(out, depth, inner);
+                *i += 1;
+            }
+            Node::Located { location, inner } => {
+                emit_located(out, depth, location, inner);
                 *i += 1;
             }
         }
@@ -779,6 +801,56 @@ fn emit_furniture(out: &mut Out, depth: i32, inner: &Node) {
     }
 }
 
+/// Render a `<picture>` — with optional layout provenance and caption. Empty
+/// (no location, no caption) collapses to `<picture></picture>`.
+fn emit_picture(out: &mut Out, depth: i32, caption: Option<&str>, location: Option<&[u16; 4]>) {
+    let caption = caption.filter(|c| !c.trim().is_empty());
+    if location.is_none() && caption.is_none() {
+        out.push(depth, "<picture></picture>".to_string());
+        return;
+    }
+    out.push(depth, "<picture>".to_string());
+    if let Some(loc) = location {
+        push_location(out, depth + 1, loc);
+    }
+    if let Some(c) = caption {
+        out.push(depth + 1, format!("<caption>{}</caption>", escape_text(c)));
+    }
+    out.push(depth, "</picture>".to_string());
+}
+
+/// Render a [`Node::Located`] wrapper: the inner element with its `<location>`
+/// tokens as the first children.
+fn emit_located(out: &mut Out, depth: i32, location: &[u16; 4], inner: &Node) {
+    match inner {
+        Node::Heading { level, text } => {
+            let open = if *level <= 1 {
+                "heading".to_string()
+            } else {
+                format!("heading level=\"{level}\"")
+            };
+            emit_text_element(out, depth, &open, "heading", text, Some(location));
+        }
+        Node::Paragraph { text } => {
+            emit_text_element(out, depth, "text", "text", text, Some(location));
+        }
+        Node::Picture { caption, .. } => {
+            emit_picture(out, depth, caption.as_deref(), Some(location));
+        }
+        Node::Table(t) => {
+            // The wrapper's location takes precedence over any on the table.
+            let mut t = t.clone();
+            t.location = Some(*location);
+            emit_table(out, depth, &t);
+        }
+        // Other node kinds carry no location today — render them as-is.
+        other => {
+            let mut i = 0usize;
+            emit_nodes(out, depth, std::slice::from_ref(other), &mut i, 0);
+        }
+    }
+}
+
 fn emit_list(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u8) {
     let ordered = matches!(nodes[*i], Node::ListItem { ordered: true, .. });
     let open = if ordered {
@@ -865,7 +937,7 @@ fn emit_list_item_content(out: &mut Out, depth: i32, text: &str, has_nested: boo
     let runs = inline_runs_from_markdown(text);
     let single_plain = runs.len() <= 1 && runs.first().map_or(true, |r| r.is_plain());
     if single_plain {
-        emit_text_element(out, depth, "text", "text", text);
+        emit_text_element(out, depth, "text", "text", text, None);
     } else {
         emit_inline_group(out, depth, false, &runs);
     }
@@ -892,6 +964,24 @@ fn emit_field_region(out: &mut Out, depth: i32, items: &[FieldItem]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn located_heading_emits_location_tokens_in_block_form() {
+        let doclang = export_to_doclang(&[Node::Located {
+            location: [44, 170, 340, 386],
+            inner: Box::new(Node::Heading {
+                level: 1,
+                text: "X-Library".into(),
+            }),
+        }]);
+        assert!(
+            doclang.contains(
+                "<heading>\n    <location value=\"44\"/>\n    <location value=\"170\"/>\n    \
+                 <location value=\"340\"/>\n    <location value=\"386\"/>\n    X-Library\n  </heading>"
+            ),
+            "got:\n{doclang}"
+        );
+    }
 
     fn code(language: Option<&str>, text: &str) -> String {
         export_to_doclang(&[Node::Code {

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -94,6 +94,15 @@ pub enum Node {
     /// HTML `<title>`, …). Markdown and JSON omit furniture by default; DocLang
     /// renders the wrapped node with a `<layer value="furniture"/>` head.
     Furniture(Box<Node>),
+    /// A node carrying layout provenance — the four DocLang `<location>` values
+    /// (`x0,y0,x1,y1`, normalized to 0–511) docling attaches to elements from
+    /// backends with real geometry (e.g. the slide shapes in PPTX). Markdown and
+    /// JSON render the wrapped node unchanged; DocLang emits the `<location>`
+    /// tokens as the element's first children.
+    Located {
+        location: [u16; 4],
+        inner: Box<Node>,
+    },
 }
 
 /// Vertical text position of an [`InlineRun`] — docling's `Script`.

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -191,6 +191,8 @@ impl Builder {
             }
             // Furniture is not emitted into the body/JSON (DocLang-only layer).
             Node::Furniture(_) => None,
+            // Layout provenance is DocLang-only; emit the wrapped node.
+            Node::Located { inner, .. } => self.add_node(inner, parent),
             // Handled by `add_list` in `walk`.
             Node::ListItem { .. } => None,
         }

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -382,6 +382,8 @@ fn render_one(node: &Node, blocks: &mut Vec<String>, ctx: &mut Ctx) {
         // Furniture (page headers/footers, HTML `<title>`) is excluded from
         // Markdown by default, mirroring docling.
         Node::Furniture(_) => {}
+        // Layout provenance is DocLang-only; render the wrapped node.
+        Node::Located { inner, .. } => render_one(inner, blocks, ctx),
         // Handled by the run-merging branch in `render`.
         Node::ListItem { .. } => unreachable!("list items are rendered in runs"),
     }

--- a/crates/docling/src/backend/pptx.rs
+++ b/crates/docling/src/backend/pptx.rs
@@ -29,6 +29,7 @@ impl DeclarativeBackend for PptxBackend {
         let presentation = pkg
             .read("ppt/presentation.xml")
             .ok_or_else(|| ConversionError::Parse("pptx: no presentation.xml".into()))?;
+        let slide_size = slide_size(&presentation);
         let content_types = pkg.read("[Content_Types].xml").unwrap_or_default();
         let rid_to_part: HashMap<String, String> = pkg
             .rels_for("ppt/presentation.xml")
@@ -74,7 +75,7 @@ impl DeclarativeBackend for PptxBackend {
             };
             if let Some(tree) = descendant(slide.root_element(), "spTree") {
                 for shape in tree.children().filter(XmlNode::is_element) {
-                    handle_shape(shape, &valid_imgs, &images, &mut doc);
+                    handle_shape(shape, &valid_imgs, &images, slide_size, &mut doc);
                 }
             }
         }
@@ -101,18 +102,19 @@ fn handle_shape(
     shape: XmlNode,
     valid_imgs: &HashSet<String>,
     images: &HashMap<String, PictureImage>,
+    slide_size: (i64, i64),
     doc: &mut DoclingDocument,
 ) {
     match shape.tag_name().name() {
         "grpSp" => {
             for child in shape.children().filter(XmlNode::is_element) {
-                handle_shape(child, valid_imgs, images, doc);
+                handle_shape(child, valid_imgs, images, slide_size, doc);
             }
         }
         "graphicFrame" => {
             if let Some(tbl) = descendant(shape, "tbl") {
                 if let Some(table) = parse_table(tbl) {
-                    doc.push(Node::Table(table));
+                    push_located(doc, shape_location(shape, slide_size), Node::Table(table));
                 }
             }
         }
@@ -124,15 +126,74 @@ fn handle_shape(
                     .map(|a| a.value().to_string())
             });
             if let Some(rid) = embedded.filter(|rid| valid_imgs.contains(rid)) {
-                doc.push(Node::Picture {
-                    caption: None,
-                    image: images.get(&rid).cloned(),
-                });
+                push_located(
+                    doc,
+                    shape_location(shape, slide_size),
+                    Node::Picture {
+                        caption: None,
+                        image: images.get(&rid).cloned(),
+                    },
+                );
             }
         }
-        "sp" => handle_text_shape(shape, doc),
+        "sp" => handle_text_shape(shape, shape_location(shape, slide_size), doc),
         _ => {}
     }
+}
+
+/// Slide size (EMU) from `<p:sldSz cx cy>`, defaulting to the 4:3 standard.
+fn slide_size(presentation: &str) -> (i64, i64) {
+    Document::parse(presentation)
+        .ok()
+        .and_then(|d| {
+            let sz = d.descendants().find(|n| n.has_tag_name("sldSz"))?;
+            Some((
+                sz.attribute("cx")?.parse().ok()?,
+                sz.attribute("cy")?.parse().ok()?,
+            ))
+        })
+        .unwrap_or((9144000, 6858000))
+}
+
+/// docling's `_generate_prov`: the shape's bbox normalized to DocLang's 0–511
+/// grid. The bbox is bottom-left origin (so y is flipped); a shape with no
+/// transform — or `left == 0` (docling's `if shape.left:` truthiness) — takes
+/// the whole slide.
+fn shape_location(shape: XmlNode, (w, h): (i64, i64)) -> [u16; 4] {
+    let geom = descendant(shape, "xfrm").and_then(|x| {
+        let off = x.children().find(|n| n.has_tag_name("off"))?;
+        let ext = x.children().find(|n| n.has_tag_name("ext"))?;
+        Some((
+            off.attribute("x")?.parse::<i64>().ok()?,
+            off.attribute("y")?.parse::<i64>().ok()?,
+            ext.attribute("cx")?.parse::<i64>().ok()?,
+            ext.attribute("cy")?.parse::<i64>().ok()?,
+        ))
+    });
+    let (left, top, cw, ch) = match geom {
+        Some((x, y, cx, cy)) if x != 0 => (x, y, cx, cy),
+        _ => (0, 0, w, h),
+    };
+    let n = |v: i64, dim: i64| -> u16 {
+        if dim == 0 {
+            return 0;
+        }
+        ((512.0 * v as f64 / dim as f64).round() as i64).clamp(0, 511) as u16
+    };
+    [
+        n(left, w),
+        n(h - (top + ch), h),
+        n(left + cw, w),
+        n(h - top, h),
+    ]
+}
+
+/// Wrap `node` in a [`Node::Located`] carrying the shape's provenance.
+fn push_located(doc: &mut DoclingDocument, location: [u16; 4], node: Node) {
+    doc.push(Node::Located {
+        location,
+        inner: Box::new(node),
+    });
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -154,7 +215,7 @@ fn placeholder_kind(sp: XmlNode) -> Placeholder {
     }
 }
 
-fn handle_text_shape(sp: XmlNode, doc: &mut DoclingDocument) {
+fn handle_text_shape(sp: XmlNode, location: [u16; 4], doc: &mut DoclingDocument) {
     let Some(tx_body) = descendant(sp, "txBody") else {
         return;
     };
@@ -184,6 +245,8 @@ fn handle_text_shape(sp: XmlNode, doc: &mut DoclingDocument) {
                 } else {
                     0
                 };
+                // List items stay bare so consecutive items still group into
+                // one `<list>`; their per-item `<location>` is a follow-up.
                 doc.push(Node::ListItem {
                     ordered: numbered,
                     number: n,
@@ -196,10 +259,12 @@ fn handle_text_shape(sp: XmlNode, doc: &mut DoclingDocument) {
             None => {
                 in_list = false;
                 match kind {
-                    Placeholder::Title => doc.push(Node::Heading { level: 1, text }),
+                    Placeholder::Title => {
+                        push_located(doc, location, Node::Heading { level: 1, text })
+                    }
                     // docling intends SECTION_HEADER for subtitles but a bug
                     // leaves the label as PARAGRAPH, so subtitles render as text.
-                    _ => doc.push(Node::Paragraph { text }),
+                    _ => push_located(doc, location, Node::Paragraph { text }),
                 }
             }
         }


### PR DESCRIPTION
Part of #39 — raise PPTX DocLang conformance.

## Summary

PPTX slide shapes carry geometry (offset/extent in EMU) that docling normalizes to DocLang's 0–511 grid and attaches as `<location>` provenance on **every** heading/text/table/picture. We only emitted it for tables; this adds it for all shape-derived elements — the single biggest gap in the PPTX `.dclx` output.

- **`Node::Located { location, inner }`** wrapper (mirroring `Furniture`): Markdown/JSON render the inner node transparently, DocLang emits the four `<location>` tokens as the element's first children (via a refactored `emit_text_element`/`emit_picture` + `push_location`).
- **PPTX geometry** — ported from docling's `_generate_prov`: bbox `[left, H-(top+height), left+width, H-top]` (bottom-left origin → y flipped), normalized `clamp(round(512·v/dim), 0, 511)`, with a shape lacking a transform / at `left==0` taking the whole slide (docling's `if shape.left:` truthiness).

## Conformance

| Fixture | before | after |
|---|--------|-------|
| powerpoint_bad_text | 55% | **EXACT** |
| powerpoint_with_image | 46% | **98%** |
| powerpoint_malformed_pictures | 48% | **96%** |
| powerpoint_sample | 68% | 76% |
| **pptx mean** | **55%** | **79%** |

No Markdown/JSON change (the wrapper is DocLang-only; `outputs_match_fixtures` unchanged). New unit test for the `Located` serialization.

## Remaining gap (follow-ups toward ≥90%)

- **List items** still emit a bare `<ldiv/>` without their shape's `<location>` — wrapping them broke `<list>` grouping, so they're left bare for now; giving list items provenance needs the list-grouping paths to see through `Located`.
- **Inherited placeholder geometry** — placeholder shapes whose position comes from the slide layout/master (not the shape's own `xfrm`) fall back to the full-slide bbox; resolving them needs layout/master placeholder matching.
- Table row/col spans (`<ucel>`/`<lcel>`) and furniture-layer shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fKFbatf55BK5j8vr3dZjj)_