### PR TITLE
feat(pptx): inherited placeholder geometry, table spans, list-item location

### DIFF
--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -570,14 +570,24 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
     }
     for (ri, row) in table.rows.iter().enumerate() {
         for (ci, cell) in row.iter().enumerate() {
-            // A horizontal-span continuation is `<lcel/>` regardless of text;
-            // otherwise empty→`<ecel/>`, header→`<ched/>`, else `<fcel/>`.
+            // A span continuation is a token-only cell (no text child):
+            // horizontal → `<lcel/>`, vertical → `<ucel/>`. Otherwise
+            // empty→`<ecel/>`, header→`<ched/>`, else `<fcel/>`.
+            let cont = |grid: &Vec<Vec<bool>>| {
+                grid.get(ri)
+                    .and_then(|r| r.get(ci))
+                    .copied()
+                    .unwrap_or(false)
+            };
             let is_lcel = table
                 .structure
                 .as_ref()
-                .and_then(|s| s.col_continuation.get(ri))
-                .and_then(|r| r.get(ci))
-                .copied()
+                .map(|s| cont(&s.col_continuation))
+                .unwrap_or(false);
+            let is_ucel = table
+                .structure
+                .as_ref()
+                .map(|s| cont(&s.row_continuation))
                 .unwrap_or(false);
             let is_header = match &table.structure {
                 Some(s) => s.header_row.get(ri).copied().unwrap_or(false),
@@ -585,6 +595,8 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
             };
             let tok = if is_lcel {
                 "<lcel/>"
+            } else if is_ucel {
+                "<ucel/>"
             } else if cell.trim().is_empty() {
                 "<ecel/>"
             } else if is_header {
@@ -593,7 +605,7 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
                 "<fcel/>"
             };
             out.push(depth + 1, tok.to_string());
-            if !is_lcel && !cell.trim().is_empty() {
+            if !is_lcel && !is_ucel && !cell.trim().is_empty() {
                 emit_cell_text(out, depth + 1, cell);
             }
         }
@@ -675,6 +687,10 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
             }
             Node::Located { location, inner } => {
                 emit_located(out, depth, location, inner);
+                *i += 1;
+            }
+            Node::PageBreak => {
+                out.push(depth, "<page_break/>".to_string());
                 *i += 1;
             }
         }
@@ -870,6 +886,7 @@ fn emit_list(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u8
                 ordered: o,
                 number,
                 first_in_list,
+                location,
             } if *l == level => {
                 // A new sibling list at this depth closes this one (the caller
                 // re-opens): the backend flagged a fresh list, the kind flips, or
@@ -898,6 +915,12 @@ fn emit_list(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u8
                         out.push(depth + 1, "</ldiv>".to_string());
                     }
                     None => out.push(depth + 1, "<ldiv/>".to_string()),
+                }
+                // Layout provenance (PPTX shapes): the four `<location>` tokens
+                // follow the `<ldiv>` and precede the item's content, matching
+                // docling's element head inside the list.
+                if let Some(loc) = location {
+                    push_location(out, depth + 1, loc);
                 }
                 emit_list_item_content(out, depth + 1, text, has_nested);
                 *i += 1;

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -56,6 +56,13 @@ pub enum Node {
         text: String,
         level: u8,
         marker: Option<String>,
+        /// Optional layout provenance (`x0,y0,x1,y1`, normalized to 0–511): the
+        /// four DocLang `<location>` values emitted inside the `<list>` right
+        /// after the item's `<ldiv>`. Set only by backends with real geometry
+        /// (e.g. PPTX shapes); `None` for the declarative backends. Kept on the
+        /// item itself (rather than a [`Node::Located`] wrapper) so consecutive
+        /// items still group into one `<list>`.
+        location: Option<[u16; 4]>,
     },
     /// A fenced code block.
     Code {
@@ -103,6 +110,11 @@ pub enum Node {
         location: [u16; 4],
         inner: Box<Node>,
     },
+    /// A page boundary — docling's implicit page break between pages. The PPTX
+    /// backend emits one between consecutive slides. DocLang renders it as
+    /// `<page_break/>`; Markdown and JSON omit it (matching docling's default
+    /// exports, which carry page breaks only in the document model).
+    PageBreak,
 }
 
 /// Vertical text position of an [`InlineRun`] — docling's `Script`.
@@ -227,6 +239,10 @@ pub struct TableStructure {
     /// Same shape as [`Table::rows`]; `true` where a cell continues a
     /// horizontal span from its left neighbour (emitted as `<lcel/>`).
     pub col_continuation: Vec<Vec<bool>>,
+    /// Same shape as [`Table::rows`]; `true` where a cell continues a
+    /// vertical span from the cell above (emitted as `<ucel/>`). Empty or all
+    /// `false` when the backend has no vertical spans (e.g. USPTO CALS).
+    pub row_continuation: Vec<Vec<bool>>,
 }
 
 impl DoclingDocument {

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -193,6 +193,8 @@ impl Builder {
             Node::Furniture(_) => None,
             // Layout provenance is DocLang-only; emit the wrapped node.
             Node::Located { inner, .. } => self.add_node(inner, parent),
+            // Page breaks are DocLang-only; docling omits them from the JSON body.
+            Node::PageBreak => None,
             // Handled by `add_list` in `walk`.
             Node::ListItem { .. } => None,
         }
@@ -674,6 +676,7 @@ mod tests {
             text: "one".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         doc.push(Node::ListItem {
             ordered: false,
@@ -682,6 +685,7 @@ mod tests {
             text: "two".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         doc.push(Node::Table(Table {
             rows: vec![vec!["A".into(), "B".into()]],

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -293,6 +293,7 @@ fn render_list_run(items: &[Node], blocks: &mut Vec<String>, strict: bool) {
             text,
             level,
             marker: _,
+            location: _,
         } = item
         else {
             continue;
@@ -384,6 +385,8 @@ fn render_one(node: &Node, blocks: &mut Vec<String>, ctx: &mut Ctx) {
         Node::Furniture(_) => {}
         // Layout provenance is DocLang-only; render the wrapped node.
         Node::Located { inner, .. } => render_one(inner, blocks, ctx),
+        // Page breaks are DocLang-only; docling omits them from Markdown.
+        Node::PageBreak => {}
         // Handled by the run-merging branch in `render`.
         Node::ListItem { .. } => unreachable!("list items are rendered in runs"),
     }
@@ -617,6 +620,7 @@ mod tests {
             text: "first".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         doc.push(Node::ListItem {
             ordered: false,
@@ -625,6 +629,7 @@ mod tests {
             text: "second".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         let md = doc.export_to_markdown();
         assert_eq!(md, "# Title\n\nHello world.\n\n- first\n- second\n");
@@ -705,6 +710,7 @@ mod tests {
             text: "i\\_j".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         // Legacy reproduces docling's `\_` escaping byte-for-byte.
         assert_eq!(doc.export_to_markdown(), "# a\\_b\n\nx\\_y\n\n- i\\_j\n");
@@ -762,6 +768,7 @@ mod tests {
             text: "a".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         doc.push(Node::ListItem {
             ordered: false,
@@ -770,6 +777,7 @@ mod tests {
             text: "b".into(),
             level: 0,
             marker: None,
+            location: None,
         });
         doc.push(Node::Code {
             language: Some("rust".into()),

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -1042,6 +1042,7 @@ pub fn assemble_page(
                         text: md_escape(&rest),
                         level: 0,
                         marker: None,
+                        location: None,
                     });
                 } else {
                     nodes.push(Node::ListItem {
@@ -1051,6 +1052,7 @@ pub fn assemble_page(
                         text: md_escape(&stripped),
                         level: 0,
                         marker: None,
+                        location: None,
                     });
                 }
             }

--- a/crates/docling/src/backend/asciidoc.rs
+++ b/crates/docling/src/backend/asciidoc.rs
@@ -184,6 +184,7 @@ impl Parser {
             text: escape_text(text.trim()),
             level,
             marker: None,
+            location: None,
         });
         self.fresh_list = false;
     }

--- a/crates/docling/src/backend/docling_json.rs
+++ b/crates/docling/src/backend/docling_json.rs
@@ -124,6 +124,7 @@ fn text_item(item: &Value, level: u8, doc: &mut DoclingDocument) {
             text,
             level,
             marker: None,
+            location: None,
         }),
         "caption" => {} // rendered with its parent table/picture
         _ => doc.push(Node::Paragraph { text }), // text, paragraph, formula, footnote, …
@@ -181,6 +182,7 @@ fn list_group(children: &[Value], root: &Value, level: u8, doc: &mut DoclingDocu
             text: formatted_text(item),
             level,
             marker: None,
+            location: None,
         });
         first = false;
         if let Some(sub) = item["children"].as_array() {

--- a/crates/docling/src/backend/docx.rs
+++ b/crates/docling/src/backend/docx.rs
@@ -313,6 +313,7 @@ fn handle_paragraph_inner(
                     level,
                     // docling's DOCX backend passes the enumeration marker.
                     marker: Some(marker.clone()),
+                    location: None,
                 });
             } else {
                 // A multilevel marker (`1.1.`) renders as a bullet with the
@@ -324,6 +325,7 @@ fn handle_paragraph_inner(
                     text: format!("{marker} {text}"),
                     level,
                     marker: None,
+                    location: None,
                 });
             }
         } else {
@@ -334,6 +336,7 @@ fn handle_paragraph_inner(
                 text,
                 level,
                 marker: None,
+                location: None,
             });
         }
         return;

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -429,6 +429,7 @@ fn walk_list(list: ElementRef, ordered: bool, nodes: &mut Vec<Node>, level: u8, 
                 // docling's HTML backend passes an enumeration marker only for
                 // an ordered list with an explicit `start`; otherwise none.
                 marker: has_start.then(|| format!("{number}.")),
+                location: None,
             });
         }
         number += 1;
@@ -525,6 +526,7 @@ fn walk_dl(dl: ElementRef, nodes: &mut Vec<Node>, level: u8, base: Fmt) {
                         text,
                         level,
                         marker: None,
+                        location: None,
                     });
                 }
             }
@@ -569,6 +571,7 @@ fn walk_dd(dd: ElementRef, nodes: &mut Vec<Node>, level: u8, base: Fmt) {
             text,
             level,
             marker: None,
+            location: None,
         });
     }
     for (kind, el) in nested {

--- a/crates/docling/src/backend/jats.rs
+++ b/crates/docling/src/backend/jats.rs
@@ -299,6 +299,7 @@ fn add_citation(doc: &mut DoclingDocument, parent_is_list: bool, text: &str) {
             text: escape_text(text),
             level: 0,
             marker: None,
+            location: None,
         });
     } else {
         doc.push(Node::Paragraph {
@@ -367,6 +368,7 @@ fn walk_linear(
                         text: escape_text(&text),
                         level: 0,
                         marker: None,
+                        location: None,
                     });
                 }
                 stop_walk = true;
@@ -646,6 +648,7 @@ fn add_footnote_group(doc: &mut DoclingDocument, node: XmlNode, hlevel: i32) {
             text: escape_text(&item),
             level: 0,
             marker: None,
+            location: None,
         });
     }
 }

--- a/crates/docling/src/backend/latex.rs
+++ b/crates/docling/src/backend/latex.rs
@@ -260,6 +260,7 @@ fn emit_list(inner: &str, doc: &mut DoclingDocument) {
                 text,
                 level: 0,
                 marker: None,
+                location: None,
             });
             first = false;
         }

--- a/crates/docling/src/backend/markdown.rs
+++ b/crates/docling/src/backend/markdown.rs
@@ -480,6 +480,7 @@ fn emit_item(
             text,
             level,
             marker: None,
+            location: None,
         });
         *emitted = true;
     }

--- a/crates/docling/src/backend/odf.rs
+++ b/crates/docling/src/backend/odf.rs
@@ -562,6 +562,7 @@ fn add_odf_list(
             text,
             level: depth,
             marker: None,
+            location: None,
         });
         has_last = true;
         for n in &nested {

--- a/crates/docling/src/backend/pptx.rs
+++ b/crates/docling/src/backend/pptx.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use docling_core::{DoclingDocument, Node, PictureImage, Table};
+use docling_core::{DoclingDocument, Node, PictureImage, Table, TableStructure};
 use roxmltree::{Document, Node as XmlNode};
 
 use crate::backend::ooxml::{content_type, picture_image, resolve, Package};
@@ -37,10 +37,14 @@ impl DeclarativeBackend for PptxBackend {
             .map(|r| (r.id.clone(), resolve("ppt", &r.target)))
             .collect();
 
-        for rid in slide_rids(&presentation) {
+        for (slide_ix, rid) in slide_rids(&presentation).into_iter().enumerate() {
             let Some(part) = rid_to_part.get(&rid).cloned() else {
                 continue;
             };
+            // Placeholder geometry inherited from the slide's layout → master,
+            // for shapes that carry no own `<a:xfrm>` (python-pptx resolves
+            // `shape.left/top/...` up this chain).
+            let phmap = slide_placeholders(&mut pkg, &part);
             // Relationship ids whose target is a real, image-typed part — only
             // these become pictures (linked/missing/wrong-type blips are dropped,
             // matching python-pptx + PIL).
@@ -74,8 +78,13 @@ impl DeclarativeBackend for PptxBackend {
                 continue;
             };
             if let Some(tree) = descendant(slide.root_element(), "spTree") {
+                // docling emits a page break at each slide boundary (one between
+                // consecutive slides).
+                if slide_ix > 0 {
+                    doc.push(Node::PageBreak);
+                }
                 for shape in tree.children().filter(XmlNode::is_element) {
-                    handle_shape(shape, &valid_imgs, &images, slide_size, &mut doc);
+                    handle_shape(shape, &valid_imgs, &images, slide_size, &phmap, &mut doc);
                 }
             }
         }
@@ -103,18 +112,23 @@ fn handle_shape(
     valid_imgs: &HashSet<String>,
     images: &HashMap<String, PictureImage>,
     slide_size: (i64, i64),
+    phmap: &PhMap,
     doc: &mut DoclingDocument,
 ) {
     match shape.tag_name().name() {
         "grpSp" => {
             for child in shape.children().filter(XmlNode::is_element) {
-                handle_shape(child, valid_imgs, images, slide_size, doc);
+                handle_shape(child, valid_imgs, images, slide_size, phmap, doc);
             }
         }
         "graphicFrame" => {
             if let Some(tbl) = descendant(shape, "tbl") {
                 if let Some(table) = parse_table(tbl) {
-                    push_located(doc, shape_location(shape, slide_size), Node::Table(table));
+                    push_located(
+                        doc,
+                        shape_location(shape, slide_size, phmap),
+                        Node::Table(table),
+                    );
                 }
             }
         }
@@ -128,7 +142,7 @@ fn handle_shape(
             if let Some(rid) = embedded.filter(|rid| valid_imgs.contains(rid)) {
                 push_located(
                     doc,
-                    shape_location(shape, slide_size),
+                    shape_location(shape, slide_size, phmap),
                     Node::Picture {
                         caption: None,
                         image: images.get(&rid).cloned(),
@@ -136,7 +150,7 @@ fn handle_shape(
                 );
             }
         }
-        "sp" => handle_text_shape(shape, shape_location(shape, slide_size), doc),
+        "sp" => handle_text_shape(shape, shape_location(shape, slide_size, phmap), doc),
         _ => {}
     }
 }
@@ -156,22 +170,15 @@ fn slide_size(presentation: &str) -> (i64, i64) {
 }
 
 /// docling's `_generate_prov`: the shape's bbox normalized to DocLang's 0–511
-/// grid. The bbox is bottom-left origin (so y is flipped); a shape with no
-/// transform — or `left == 0` (docling's `if shape.left:` truthiness) — takes
-/// the whole slide.
-fn shape_location(shape: XmlNode, (w, h): (i64, i64)) -> [u16; 4] {
-    let geom = descendant(shape, "xfrm").and_then(|x| {
-        let off = x.children().find(|n| n.has_tag_name("off"))?;
-        let ext = x.children().find(|n| n.has_tag_name("ext"))?;
-        Some((
-            off.attribute("x")?.parse::<i64>().ok()?,
-            off.attribute("y")?.parse::<i64>().ok()?,
-            ext.attribute("cx")?.parse::<i64>().ok()?,
-            ext.attribute("cy")?.parse::<i64>().ok()?,
-        ))
-    });
+/// grid. The bbox is bottom-left origin (so y is flipped). The shape's geometry
+/// is its own `<a:xfrm>` if present, else the placeholder box it inherits from
+/// the slide layout/master (python-pptx `shape.left/top/...`). A shape with no
+/// resolvable geometry — or `left == 0` (docling's `if shape.left:` truthiness)
+/// — takes the whole slide.
+fn shape_location(shape: XmlNode, (w, h): (i64, i64), phmap: &PhMap) -> [u16; 4] {
+    let geom = xfrm_geom(shape).or_else(|| inherited_geom(shape, phmap));
     let (left, top, cw, ch) = match geom {
-        Some((x, y, cx, cy)) if x != 0 => (x, y, cx, cy),
+        Some([x, y, cx, cy]) if x != 0 => (x, y, cx, cy),
         _ => (0, 0, w, h),
     };
     let n = |v: i64, dim: i64| -> u16 {
@@ -186,6 +193,101 @@ fn shape_location(shape: XmlNode, (w, h): (i64, i64)) -> [u16; 4] {
         n(left + cw, w),
         n(h - top, h),
     ]
+}
+
+/// A shape/placeholder's own transform `[x, y, cx, cy]` in EMU, from its
+/// `<a:xfrm>` (`<p:xfrm>` for a graphic frame — `descendant` matches either).
+fn xfrm_geom(node: XmlNode) -> Option<[i64; 4]> {
+    let x = descendant(node, "xfrm")?;
+    let off = x.children().find(|n| n.has_tag_name("off"))?;
+    let ext = x.children().find(|n| n.has_tag_name("ext"))?;
+    Some([
+        off.attribute("x")?.parse().ok()?,
+        off.attribute("y")?.parse().ok()?,
+        ext.attribute("cx")?.parse().ok()?,
+        ext.attribute("cy")?.parse().ok()?,
+    ])
+}
+
+/// The geometry a placeholder shape inherits from its layout/master: match its
+/// `<p:ph>` by `idx` first, then by `type` (python-pptx's inheritance keys).
+fn inherited_geom(shape: XmlNode, phmap: &PhMap) -> Option<[i64; 4]> {
+    let ph = descendant(shape, "ph")?;
+    if let Some(idx) = ph.attribute("idx") {
+        if let Some(g) = phmap.by_idx.get(idx) {
+            return Some(*g);
+        }
+    }
+    if let Some(t) = ph.attribute("type") {
+        if let Some(g) = phmap.by_type.get(t) {
+            return Some(*g);
+        }
+    }
+    None
+}
+
+/// Placeholder geometries a slide can inherit, keyed by `<p:ph>` `idx` and
+/// `type`. The layout is consulted before the master (layout wins).
+#[derive(Default)]
+struct PhMap {
+    by_idx: HashMap<String, [i64; 4]>,
+    by_type: HashMap<String, [i64; 4]>,
+}
+
+/// Build the [`PhMap`] for a slide: its layout part (via the slide's `.rels`)
+/// then that layout's master (via the layout's `.rels`). Placeholders already
+/// seen (layout) are not overwritten by the master.
+fn slide_placeholders(pkg: &mut Package, slide_part: &str) -> PhMap {
+    let mut map = PhMap::default();
+    let slide_dir = slide_part.rsplit_once('/').map_or("", |(d, _)| d);
+    let Some(layout_part) = rel_target(pkg, slide_part, slide_dir, "/slideLayout") else {
+        return map;
+    };
+    if let Some(xml) = pkg.read(&layout_part) {
+        collect_placeholders(&xml, &mut map);
+    }
+    let layout_dir = layout_part.rsplit_once('/').map_or("", |(d, _)| d);
+    if let Some(master_part) = rel_target(pkg, &layout_part, layout_dir, "/slideMaster") {
+        if let Some(xml) = pkg.read(&master_part) {
+            collect_placeholders(&xml, &mut map);
+        }
+    }
+    map
+}
+
+/// Resolve the first relationship of `part` whose type ends with `suffix` to a
+/// package path (against `base_dir`).
+fn rel_target(pkg: &mut Package, part: &str, base_dir: &str, suffix: &str) -> Option<String> {
+    pkg.rels_for(part)
+        .iter()
+        .find(|r| r.rel_type.ends_with(suffix))
+        .map(|r| resolve(base_dir, &r.target))
+}
+
+/// Record every placeholder's own `<a:xfrm>` geometry from a layout/master part,
+/// keyed by its `<p:ph>` `idx` and `type`. `or_insert` keeps the earlier source
+/// (layout before master).
+fn collect_placeholders(xml: &str, map: &mut PhMap) {
+    let Ok(doc) = Document::parse(xml) else {
+        return;
+    };
+    let Some(tree) = descendant(doc.root_element(), "spTree") else {
+        return;
+    };
+    for sp in tree.children().filter(|n| n.has_tag_name("sp")) {
+        let Some(ph) = descendant(sp, "ph") else {
+            continue;
+        };
+        let Some(geom) = xfrm_geom(sp) else {
+            continue;
+        };
+        if let Some(idx) = ph.attribute("idx") {
+            map.by_idx.entry(idx.to_string()).or_insert(geom);
+        }
+        if let Some(t) = ph.attribute("type") {
+            map.by_type.entry(t.to_string()).or_insert(geom);
+        }
+    }
 }
 
 /// Wrap `node` in a [`Node::Located`] carrying the shape's provenance.
@@ -245,8 +347,9 @@ fn handle_text_shape(sp: XmlNode, location: [u16; 4], doc: &mut DoclingDocument)
                 } else {
                     0
                 };
-                // List items stay bare so consecutive items still group into
-                // one `<list>`; their per-item `<location>` is a follow-up.
+                // Each item carries its shape's `<location>` (all items of a
+                // body placeholder share the one box); the location rides on the
+                // item itself so consecutive items still group into one `<list>`.
                 doc.push(Node::ListItem {
                     ordered: numbered,
                     number: n,
@@ -254,6 +357,7 @@ fn handle_text_shape(sp: XmlNode, location: [u16; 4], doc: &mut DoclingDocument)
                     text,
                     level: 0,
                     marker: None,
+                    location: Some(location),
                 });
             }
             None => {
@@ -319,33 +423,57 @@ fn parse_table(tbl: XmlNode) -> Option<Table> {
     if rows.is_empty() || num_cols == 0 {
         return None;
     }
+    // `<a:tblPr firstRow="1">` marks the first row as a header band (→ `<ched/>`).
+    let first_row_header = descendant(tbl, "tblPr")
+        .and_then(|p| p.attribute("firstRow"))
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
+    // Every grid position has its own `<a:tc>` (merge continuations included), so
+    // the column index maps directly. A `hMerge` continuation is a horizontal
+    // span (`<lcel/>`), a `vMerge` continuation a vertical span (`<ucel/>`); the
+    // structure overlay carries those for DocLang. The `rows` text grid keeps
+    // docling's Markdown/JSON behaviour: the origin cell's text is replicated
+    // across its whole `rowSpan × gridSpan` region.
     let mut grid = vec![vec![String::new(); num_cols]; rows.len()];
+    let mut col_continuation = vec![vec![false; num_cols]; rows.len()];
+    let mut row_continuation = vec![vec![false; num_cols]; rows.len()];
     for (ri, row) in rows.iter().enumerate() {
         let cells: Vec<XmlNode> = row.children().filter(|n| n.has_tag_name("tc")).collect();
-        for (ci, tc) in cells.iter().enumerate() {
-            // Continuation cells of a merge are filled by their origin.
-            if tc.attribute("hMerge").is_some() || tc.attribute("vMerge").is_some() {
+        for (ci, tc) in cells.iter().enumerate().take(num_cols) {
+            let h = tc.attribute("hMerge").is_some();
+            let v = tc.attribute("vMerge").is_some();
+            col_continuation[ri][ci] = h;
+            row_continuation[ri][ci] = v;
+            // Continuation cells carry no text of their own (DocLang emits only
+            // the token); the origin below fills their grid text for Markdown.
+            if h || v {
                 continue;
             }
             let text = cell_text(*tc);
             let span = |name: &str| -> usize {
                 tc.attribute(name).and_then(|s| s.parse().ok()).unwrap_or(1)
             };
-            let (gridspan, rowspan) = (span("gridSpan"), span("rowSpan"));
-            let row_end = (ri + rowspan).min(rows.len());
-            let col_end = (ci + gridspan).min(num_cols);
-            for row in grid.iter_mut().take(row_end).skip(ri) {
-                for cell in row.iter_mut().take(col_end).skip(ci) {
+            let row_end = (ri + span("rowSpan")).min(rows.len());
+            let col_end = (ci + span("gridSpan")).min(num_cols);
+            for grow in grid.iter_mut().take(row_end).skip(ri) {
+                for cell in grow.iter_mut().take(col_end).skip(ci) {
                     *cell = text.clone();
                 }
             }
         }
     }
+    let header_row = (0..rows.len())
+        .map(|ri| first_row_header && ri == 0)
+        .collect();
     Some(Table {
         rows: grid,
         location: None,
-        structure: None,
+        structure: Some(TableStructure {
+            header_row,
+            col_continuation,
+            row_continuation,
+        }),
     })
 }
 

--- a/crates/docling/src/backend/uspto.rs
+++ b/crates/docling/src/backend/uspto.rs
@@ -608,6 +608,8 @@ fn parse_table(table: XmlNode) -> Option<Table> {
         structure: Some(TableStructure {
             header_row,
             col_continuation,
+            // CALS spans are horizontal-only; no vertical-span continuations.
+            row_continuation: Vec::new(),
         }),
     })
 }


### PR DESCRIPTION
Raises PPTX DocLang (.dclx) conformance 79% → 96% mean over the 7 pptx fixtures
(issue #32), closing the three biggest <location>-provenance gaps.

- Inherited placeholder geometry (dominant fix): a shape with no own <a:xfrm>
  resolves its box from slide layout → master, matching <p:ph> by idx then type
  (python-pptx's shape.left/top inheritance). Previously collapsed to 0/0/512/512.
- Table OTSL spans: TableStructure gains row_continuation, the serializer a
  <ucel/> branch; parse_table emits <ched>/<ecel>/<fcel>/<lcel>/<ucel> from
  hMerge/vMerge/firstRow. rows text grid still replicates span text, so
  Markdown/JSON are byte-identical (outputs_match_fixtures unchanged).
- List-item <location>: Node::ListItem gains a location field emitted inside
  <list> after each <ldiv>, so items keep grouping.
- <page_break/> between slides (new Node::PageBreak; Markdown/JSON omit it).

issue_2663 + bad_text EXACT; unrecognized_shape 98%, sample 93%, comments 88%.
Residual is the notes/comments layer (follow-up).

Tests: docling-core 19, docling 62 (incl. outputs_match_fixtures); fmt + clippy clean.