### PR TITLE
feat(odf): rich inline runs, list markers, table spans + rich cells

### DIFF
--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -593,7 +593,10 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
                 Some(s) => s.header_row.get(ri).copied().unwrap_or(false),
                 None => ri == 0,
             };
-            let tok = if is_lcel {
+            let tok = if is_lcel && is_ucel {
+                // Continues a span in both axes (a 2-D covered cell) → `<xcel/>`.
+                "<xcel/>"
+            } else if is_lcel {
                 "<lcel/>"
             } else if is_ucel {
                 "<ucel/>"
@@ -605,8 +608,22 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
                 "<fcel/>"
             };
             out.push(depth + 1, tok.to_string());
-            if !is_lcel && !is_ucel && !cell.trim().is_empty() {
-                emit_cell_text(out, depth + 1, cell);
+            if !is_lcel && !is_ucel {
+                // A rich cell (ODF lists / nested tables / multi-paragraph)
+                // emits its structured blocks after the token; otherwise the
+                // flat cell text renders inline.
+                let blocks = table
+                    .cell_blocks
+                    .as_ref()
+                    .and_then(|b| b.get(ri))
+                    .and_then(|r| r.get(ci))
+                    .filter(|b| !b.is_empty());
+                if let Some(blocks) = blocks {
+                    let mut bi = 0;
+                    emit_nodes(out, depth + 1, blocks, &mut bi, 0);
+                } else if !cell.trim().is_empty() {
+                    emit_cell_text(out, depth + 1, cell);
+                }
             }
         }
         out.push(depth + 1, "<nl/>".to_string());
@@ -739,9 +756,17 @@ fn emit_inline_group(out: &mut Out, depth: i32, unwrapped: bool, runs: &[InlineR
     out.push(depth, "<text>".to_string());
     for (i, run) in runs.iter().enumerate() {
         if run.is_plain() {
-            // First child has no leading newline → indented; the rest sit at 0.
-            let d = if i == 0 { depth + 1 } else { 0 };
-            out.push(d, escape_text(&run.text));
+            let e = escape_text(&run.text);
+            // A `<content>`-wrapped run is an *element* child → indented like the
+            // styled runs. A bare text/CDATA node sits at column 0 (its record
+            // delimiter's leading newline), except the first child, which has no
+            // leading newline and stays indented.
+            let d = if e.starts_with("<content>") || i == 0 {
+                depth + 1
+            } else {
+                0
+            };
+            out.push(d, e);
         } else {
             emit_styled(out, depth + 1, &style_tags(run), &escape_text(&run.text));
         }

--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -563,6 +563,28 @@ fn push_location(out: &mut Out, depth: i32, loc: &[u16; 4]) {
 
 fn emit_table(out: &mut Out, depth: i32, table: &Table) {
     out.push(depth, "<table>".to_string());
+    emit_table_rows(out, depth, table);
+    out.push(depth, "</table>".to_string());
+}
+
+/// A chart — docling's `PictureItem` with a tabular chart-data annotation:
+/// `<picture class="chart">` wrapping a `<label value="{kind}"/>` and the data
+/// grid as a `<tabular>` (same cell tokens as a table).
+fn emit_chart(out: &mut Out, depth: i32, kind: &str, table: &Table) {
+    out.push(depth, "<picture class=\"chart\">".to_string());
+    out.push(
+        depth + 1,
+        format!("<label value=\"{}\"/>", attr_escape(kind)),
+    );
+    out.push(depth + 1, "<tabular>".to_string());
+    emit_table_rows(out, depth + 1, table);
+    out.push(depth + 1, "</tabular>".to_string());
+    out.push(depth, "</picture>".to_string());
+}
+
+/// Emit a grid's cells (the shared body of `<table>` and a chart's `<tabular>`):
+/// the location head, then each row's OTSL cell tokens at `depth + 1`.
+fn emit_table_rows(out: &mut Out, depth: i32, table: &Table) {
     // Layout provenance (spreadsheet/slide backends): four `<location>` tokens
     // (x0,y0,x1,y1) precede the cells, matching docling's element head.
     if let Some(loc) = &table.location {
@@ -628,7 +650,6 @@ fn emit_table(out: &mut Out, depth: i32, table: &Table) {
         }
         out.push(depth + 1, "<nl/>".to_string());
     }
-    out.push(depth, "</table>".to_string());
 }
 
 /// Table-cell content: virtual text (no wrapper), inline markers re-parsed.
@@ -675,6 +696,15 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
             }
             Node::Picture { caption, image: _ } => {
                 emit_picture(out, depth, caption.as_deref(), None);
+                *i += 1;
+            }
+            Node::Chart { kind, table } => {
+                emit_chart(out, depth, kind, table);
+                *i += 1;
+            }
+            Node::DoclangOnly(inner) => {
+                let mut j = 0;
+                emit_nodes(out, depth, std::slice::from_ref(inner), &mut j, level);
                 *i += 1;
             }
             Node::ListItem { level: l, .. } => {

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -228,6 +228,13 @@ pub struct Table {
     /// `rows` still carries the full text grid (span text replicated) for
     /// Markdown/JSON; DocLang uses this overlay to emit `<ched/>`/`<lcel/>`.
     pub structure: Option<TableStructure>,
+    /// Optional per-cell block content, parallel to `rows`. A *rich* cell (an
+    /// ODF cell holding a list, several paragraphs, or a nested table) carries
+    /// its DocLang blocks here; the DocLang serializer emits them after the
+    /// cell token instead of the flat `rows` text. Markdown/JSON ignore this
+    /// and render `rows`, so their output is unchanged. `None` (or an empty
+    /// `Vec` for a given cell) → the flat text is used everywhere.
+    pub cell_blocks: Option<Vec<Vec<Vec<Node>>>>,
 }
 
 /// OTSL structure overlay for a [`Table`], parallel to [`Table::rows`].

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -77,6 +77,17 @@ pub enum Node {
         caption: Option<String>,
         image: Option<PictureImage>,
     },
+    /// A chart (docling's `PictureItem` classified as a chart, carrying a
+    /// `PictureTabularChartData` annotation). Markdown and JSON render it exactly
+    /// like a [`Node::Picture`] placeholder (an `<!-- image -->` / `picture`
+    /// item); the DocLang serializer emits `<picture class="chart">` with a
+    /// `<label value="{kind}"/>` and the data `table` as a `<tabular>`.
+    Chart {
+        /// docling's classification label, e.g. `bar_chart`, `line_chart`.
+        kind: String,
+        /// The chart's data grid (row 0 is the header band).
+        table: Table,
+    },
     /// A logical grouping of child nodes (e.g. a list, a section).
     Group { label: String, children: Vec<Node> },
     /// A form key-value region (docling's `field_region`): a set of form fields,
@@ -115,6 +126,11 @@ pub enum Node {
     /// `<page_break/>`; Markdown and JSON omit it (matching docling's default
     /// exports, which carry page breaks only in the document model).
     PageBreak,
+    /// A node docling keeps in the document model (and DocLang) but leaves out
+    /// of the Markdown and JSON exports — e.g. an ODF *presentation*'s pictures
+    /// and charts, which appear in the `.dclx` body but not in its `.md`/`.json`.
+    /// DocLang renders the wrapped node in place; Markdown and JSON skip it.
+    DoclangOnly(Box<Node>),
 }
 
 /// Vertical text position of an [`InlineRun`] — docling's `Script`.

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -691,6 +691,7 @@ mod tests {
             rows: vec![vec!["A".into(), "B".into()]],
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
 
         let v: Value = serde_json::from_str(&doc.export_to_json()).unwrap();

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -182,6 +182,11 @@ impl Builder {
             Node::Picture { caption, image } => {
                 Some(self.add_picture(caption.as_deref(), image.as_ref(), parent))
             }
+            // A chart is a picture item in the JSON (its data table is
+            // DocLang-only); no image payload.
+            Node::Chart { .. } => Some(self.add_picture(None, None, parent)),
+            // A DocLang-only node is omitted from the JSON body.
+            Node::DoclangOnly(_) => None,
             Node::Group { label, children } => Some(self.add_group(label, children, parent)),
             Node::FieldRegion { items } => Some(self.add_field_region(items, parent)),
             // A rich inline group is a text item over its Markdown text; the

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -680,6 +680,7 @@ mod tests {
             rows: vec![vec!["a".into(), "b".into()], vec!["1".into(), "2".into()]],
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
         let md = doc.export_to_markdown();
         assert_eq!(md, "| a | b |\n| - | - |\n| 1 | 2 |\n");
@@ -692,6 +693,7 @@ mod tests {
             rows: vec![vec!["a".into(), "b".into()], vec!["1".into(), "2".into()]],
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
         let md = doc.export_to_markdown();
         // Numeric data columns are right-aligned; columns padded to header+2.
@@ -787,6 +789,7 @@ mod tests {
             rows: vec![vec!["a".into(), "b".into()], vec!["1".into(), "2".into()]],
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
         doc.push(Node::Picture {
             caption: Some("Fig 1".into()),

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -363,6 +363,11 @@ fn render_one(node: &Node, blocks: &mut Vec<String>, ctx: &mut Ctx) {
             }
             blocks.push(picture_marker(image.as_ref(), ctx));
         }
+        // A chart renders like a picture placeholder (its data table is
+        // DocLang-only); no image payload.
+        Node::Chart { .. } => blocks.push(picture_marker(None, ctx)),
+        // A DocLang-only node is omitted from Markdown.
+        Node::DoclangOnly(_) => {}
         Node::Group { children, .. } => render(children, blocks, ctx),
         Node::FieldRegion { items } => {
             // docling renders the region container (which carries no text of its

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -1072,6 +1072,7 @@ pub fn assemble_page(
                     rows,
                     location: None,
                     structure: None,
+                    cell_blocks: None,
                 }));
             }
             // docling does not decode formulas in the standard pipeline; it emits

--- a/crates/docling/src/backend/asciidoc.rs
+++ b/crates/docling/src/backend/asciidoc.rs
@@ -234,6 +234,7 @@ impl Parser {
                 rows,
                 location: None,
                 structure: None,
+                cell_blocks: None,
             }));
         }
         self.in_table = false;

--- a/crates/docling/src/backend/csv.rs
+++ b/crates/docling/src/backend/csv.rs
@@ -42,6 +42,7 @@ impl DeclarativeBackend for CsvBackend {
                 rows,
                 location: None,
                 structure: None,
+                cell_blocks: None,
             }));
         }
         Ok(doc)

--- a/crates/docling/src/backend/docling_json.rs
+++ b/crates/docling/src/backend/docling_json.rs
@@ -212,6 +212,7 @@ fn table_item(item: &Value, root: &Value, doc: &mut DoclingDocument) {
             rows,
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
     }
     push_captions(item, root, doc);

--- a/crates/docling/src/backend/docx.rs
+++ b/crates/docling/src/backend/docx.rs
@@ -884,6 +884,7 @@ fn parse_table_with(tbl: XmlNode, ctx: &Ctx, nested: bool) -> Option<Table> {
         rows: grid,
         location: None,
         structure: None,
+        cell_blocks: None,
     })
 }
 

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -1029,6 +1029,7 @@ fn parse_table_cells(
         rows,
         location: None,
         structure: None,
+        cell_blocks: None,
     })
 }
 

--- a/crates/docling/src/backend/jats.rs
+++ b/crates/docling/src/backend/jats.rs
@@ -602,6 +602,7 @@ fn parse_jats_table(table: XmlNode) -> Option<Table> {
         rows: grid,
         location: None,
         structure: None,
+        cell_blocks: None,
     })
 }
 

--- a/crates/docling/src/backend/latex.rs
+++ b/crates/docling/src/backend/latex.rs
@@ -294,6 +294,7 @@ fn emit_table(inner: &str, doc: &mut DoclingDocument) {
             rows,
             location: None,
             structure: None,
+            cell_blocks: None,
         }));
     }
 }

--- a/crates/docling/src/backend/markdown.rs
+++ b/crates/docling/src/backend/markdown.rs
@@ -311,6 +311,7 @@ impl MarkdownBackend {
                 rows,
                 location: None,
                 structure: None,
+                cell_blocks: None,
             }));
         }
     }

--- a/crates/docling/src/backend/odf.rs
+++ b/crates/docling/src/backend/odf.rs
@@ -14,7 +14,9 @@ use crate::backend::ooxml::Package;
 use crate::backend::DeclarativeBackend;
 use crate::error::ConversionError;
 use crate::source::SourceDocument;
-use docling_core::{DoclingDocument, Node, Table};
+use docling_core::{
+    inline_paragraph_node, DoclingDocument, InlineRun, Node, Script, Table, TableStructure,
+};
 
 pub struct OdfBackend;
 
@@ -25,6 +27,27 @@ struct Fmt {
     strike: bool,
     underline: bool,
     script: u8, // 0 none, 1 sub, 2 super
+}
+
+impl Fmt {
+    /// The structured [`InlineRun`] for a text segment under this formatting —
+    /// the ODF analogue of the DOCX backend's `to_inline_run` (underline and
+    /// sub/superscript have no Markdown marker, so they only survive here).
+    fn to_inline_run(self, text: &str) -> InlineRun {
+        InlineRun {
+            text: text.to_string(),
+            bold: self.bold,
+            italic: self.italic,
+            underline: self.underline,
+            strike: self.strike,
+            script: match self.script {
+                1 => Script::Sub,
+                2 => Script::Super,
+                _ => Script::Baseline,
+            },
+            code: false,
+        }
+    }
 }
 
 #[derive(Default, Clone)]
@@ -38,11 +61,14 @@ struct StyleInfo {
     script: Option<u8>,
 }
 
-/// One list level's rendering: bullet vs numbered, and its `start-value`.
-#[derive(Default, Clone, Copy)]
+/// One list level's rendering: bullet vs numbered, its `start-value`, and the
+/// prefix/suffix wrapping an enumerated marker (`num-prefix`/`num-suffix`).
+#[derive(Default, Clone)]
 struct OdfLevel {
     numbered: bool,
     start: i64,
+    prefix: String,
+    suffix: String,
 }
 
 /// List style name → level (1-based) → level rendering.
@@ -107,7 +133,17 @@ fn parse_styles(content: &Document, styles: Option<&Document>) -> Styles {
                                 .and_then(|v| v.parse().ok())
                                 .map(|n: i64| n.max(1))
                                 .unwrap_or(1);
-                            levels.insert(level, OdfLevel { numbered, start });
+                            let prefix = attr(lv, "num-prefix").unwrap_or("").to_string();
+                            let suffix = attr(lv, "num-suffix").unwrap_or("").to_string();
+                            levels.insert(
+                                level,
+                                OdfLevel {
+                                    numbered,
+                                    start,
+                                    prefix,
+                                    suffix,
+                                },
+                            );
                         }
                         lists.insert(name.to_string(), levels);
                     }
@@ -205,6 +241,7 @@ fn paragraph_style_names(styles: &Styles, name: Option<&str>) -> Vec<String> {
 // ---------------------------------------------------------------- text runs
 
 /// One formatted run of text.
+#[derive(Clone)]
 struct Run {
     text: String,
     fmt: Fmt,
@@ -274,6 +311,35 @@ fn runs_to_text(mut runs: Vec<Run>) -> String {
         // (e.g. a leading `<text:line-break/>`), keeping only internal breaks.
         .trim()
         .to_string()
+}
+
+/// The structured [`InlineRun`]s for a paragraph — one per format group, the
+/// DocLang-only counterpart of [`runs_to_text`]. Adjacent same-format runs are
+/// merged (raw text kept, so inter-run spacing survives as docling emits it),
+/// then the whole paragraph is stripped at its two ends (docling's
+/// `_normalize_odf_text_runs`). Empty groups drop out.
+fn runs_to_inline(runs: Vec<Run>) -> Vec<InlineRun> {
+    let mut merged: Vec<Run> = Vec::new();
+    for r in runs {
+        if let Some(last) = merged.last_mut() {
+            if last.fmt == r.fmt {
+                last.text.push_str(&r.text);
+                continue;
+            }
+        }
+        merged.push(r);
+    }
+    if let Some(first) = merged.first_mut() {
+        first.text = first.text.trim_start().to_string();
+    }
+    if let Some(last) = merged.last_mut() {
+        last.text = last.text.trim_end().to_string();
+    }
+    merged
+        .into_iter()
+        .filter(|r| !r.text.is_empty())
+        .map(|r| r.fmt.to_inline_run(&r.text))
+        .collect()
 }
 
 fn serialize_run(text: &str, fmt: Fmt) -> String {
@@ -351,7 +417,7 @@ fn handle_block(
             let names = paragraph_style_names(styles, attr(el, "style-name"));
             let mut runs = Vec::new();
             collect_runs(el, styles, Fmt::default(), &mut runs);
-            let text = runs_to_text(runs);
+            let text = runs_to_text(runs.clone());
             if text.is_empty() {
                 return;
             }
@@ -360,7 +426,10 @@ fn handle_block(
             } else if names.iter().any(|n| n == "Subtitle") {
                 doc.push(Node::Heading { level: 2, text });
             } else {
-                doc.push(Node::Paragraph { text });
+                // Styled `<text:span>` runs → a rich `InlineGroup` (Markdown/JSON
+                // still render `text`, so their output is unchanged); a plain
+                // paragraph collapses back to `Node::Paragraph`.
+                doc.push(inline_paragraph_node(text, runs_to_inline(runs), false));
             }
         }
         "list" => {
@@ -394,12 +463,16 @@ fn emit_paragraph_images(el: XmlNode, doc: &mut DoclingDocument) {
 }
 
 /// Continuation state carried across sibling `<text:list>` elements — docling's
-/// `_OdfListState`.
-#[derive(Clone, Copy)]
+/// `_OdfListState`. Carries the marker affixes so a continued list keeps the
+/// original level's `num-prefix`/`num-suffix` even when its own `<text:list>`
+/// element resolves to a bare style.
+#[derive(Clone)]
 struct ListCont {
     enumerated: bool,
     counter: i64,
     has_last: bool,
+    prefix: String,
+    suffix: String,
 }
 
 /// A list's item elements (`<text:list-item>` / `<text:list-header>`).
@@ -486,6 +559,16 @@ fn level_start(styles: &Styles, list: XmlNode, level: i64) -> i64 {
         .unwrap_or(1)
 }
 
+/// A level's `num-prefix`/`num-suffix` — the affixes wrapping an enumerated
+/// marker (e.g. `"" / "."` → `1.`).
+fn level_affixes(styles: &Styles, list: XmlNode, level: i64) -> (String, String) {
+    attr(list, "style-name")
+        .and_then(|name| styles.lists.get(name))
+        .and_then(|levels| levels.get(&level))
+        .map(|lv| (lv.prefix.clone(), lv.suffix.clone()))
+        .unwrap_or_default()
+}
+
 /// Emit an ODF list as flat [`Node::ListItem`]s — a port of docling's
 /// `_add_odf_list`. `depth` is the Markdown nesting level for items of this list;
 /// `style_level` (1-based) drives style lookups; empty items collapse (their
@@ -504,7 +587,7 @@ fn add_odf_list(
         return None;
     }
     let style_enum = level_is_enumerated(styles, list, style_level, enumerated_fallback);
-    let should_continue = continued.map(|c| c.has_last).unwrap_or(false)
+    let should_continue = continued.as_ref().map(|c| c.has_last).unwrap_or(false)
         && list_starts_with_empty_nested(list, styles);
 
     // A list with no direct text of its own (and not continuing) is transparent:
@@ -519,9 +602,15 @@ fn add_odf_list(
         return None;
     }
 
-    let (mut counter, current_enum) = match (should_continue, continued) {
+    let (mut counter, current_enum) = match (should_continue, &continued) {
         (true, Some(c)) => (c.counter, c.enumerated),
         _ => (level_start(styles, list, style_level) - 1, style_enum),
+    };
+    // Enumerated-marker affixes: reuse the continued list's so numbering that
+    // spans sibling `<text:list>`s keeps one suffix; else this level's own.
+    let (prefix, suffix) = match (should_continue, &continued) {
+        (true, Some(c)) => (c.prefix.clone(), c.suffix.clone()),
+        _ => level_affixes(styles, list, style_level),
     };
     let mut has_last = should_continue;
 
@@ -550,10 +639,13 @@ fn add_odf_list(
             continue;
         }
         counter += 1;
-        let (ordered, number) = if current_enum {
-            (true, counter.max(0) as u64)
+        let (ordered, number, marker) = if current_enum {
+            let n = counter.max(0) as u64;
+            // docling renders an enumerated marker inside the `<ldiv>`:
+            // `<marker>{prefix}{n}{suffix}</marker>` (e.g. `1.`).
+            (true, n, Some(format!("{prefix}{n}{suffix}")))
         } else {
-            (false, 0)
+            (false, 0, None)
         };
         doc.push(Node::ListItem {
             ordered,
@@ -561,7 +653,7 @@ fn add_odf_list(
             first_in_list: false,
             text,
             level: depth,
-            marker: None,
+            marker,
             location: None,
         });
         has_last = true;
@@ -582,6 +674,8 @@ fn add_odf_list(
         enumerated: current_enum,
         counter,
         has_last,
+        prefix,
+        suffix,
     })
 }
 
@@ -626,7 +720,20 @@ fn parse_table(table: XmlNode, styles: &Styles) -> Option<Table> {
         return None;
     }
 
-    let mut grid = vec![vec![String::new(); num_cols]; tr_rows.len()];
+    // The text grid plus the OTSL span overlay. ODF marks a span on its anchor
+    // (`number-columns-spanned`/`number-rows-spanned`) and emits an explicit
+    // `covered-table-cell` at every covered position; we mark the anchor's
+    // rectangle so a covered cell becomes `<lcel/>` (horizontal), `<ucel/>`
+    // (vertical) or `<xcel/>` (both). Text stays on the anchor only, so
+    // Markdown/JSON are unchanged.
+    let nrows = tr_rows.len();
+    let mut grid = vec![vec![String::new(); num_cols]; nrows];
+    let mut col_cont = vec![vec![false; num_cols]; nrows];
+    let mut row_cont = vec![vec![false; num_cols]; nrows];
+    // Parallel per-cell block content for rich cells (lists / multiple
+    // paragraphs / nested tables). Empty for plain cells.
+    let mut blocks: Vec<Vec<Vec<Node>>> = vec![vec![Vec::new(); num_cols]; nrows];
+    let mut any_rich = false;
     for (ri, tr) in tr_rows.iter().enumerate() {
         let mut ci = 0usize;
         for tc in tr
@@ -634,31 +741,73 @@ fn parse_table(table: XmlNode, styles: &Styles) -> Option<Table> {
             .filter(|c| c.has_tag_name("table-cell") || c.has_tag_name("covered-table-cell"))
         {
             let reps = repeat(tc, "number-columns-repeated");
-            let text = if tc.has_tag_name("covered-table-cell") {
-                String::new()
-            } else {
-                cell_text(tc, styles)
-            };
+            if tc.has_tag_name("covered-table-cell") {
+                // A covered position: its continuation kind is set by the anchor
+                // whose rectangle reaches it; here we only advance the column.
+                ci = (ci + reps).min(num_cols);
+                continue;
+            }
+            let text = cell_text(tc, styles);
+            let cell_nodes = cell_blocks_of(tc, styles);
+            any_rich |= !cell_nodes.is_empty();
+            let cspan = repeat(tc, "number-columns-spanned");
+            let rspan = repeat(tc, "number-rows-spanned");
             for _ in 0..reps {
                 if ci >= num_cols {
                     break;
                 }
                 grid[ri][ci] = text.clone();
+                blocks[ri][ci] = cell_nodes.clone();
+                let r_end = (ri + rspan).min(nrows);
+                let c_end = (ci + cspan).min(num_cols);
+                for rr in ri..r_end {
+                    for cc in ci..c_end {
+                        if rr == ri && cc == ci {
+                            continue;
+                        }
+                        col_cont[rr][cc] |= cc > ci;
+                        row_cont[rr][cc] |= rr > ri;
+                    }
+                }
                 ci += 1;
             }
         }
     }
 
-    trim_grid_to_bounds(grid).map(|rows| Table {
+    let (min_r, max_r, min_c, max_c) = data_bounds(&grid)?;
+    let slice = |g: Vec<Vec<bool>>| -> Vec<Vec<bool>> {
+        g[min_r..=max_r]
+            .iter()
+            .map(|row| row[min_c..=max_c].to_vec())
+            .collect()
+    };
+    let rows: Vec<Vec<String>> = grid[min_r..=max_r]
+        .iter()
+        .map(|row| row[min_c..=max_c].to_vec())
+        .collect();
+    // docling marks the first (trimmed) row of an ODF table as the header band.
+    let header_row = (0..rows.len()).map(|r| r == 0).collect();
+    let cell_blocks = any_rich.then(|| {
+        blocks[min_r..=max_r]
+            .iter()
+            .map(|row| row[min_c..=max_c].to_vec())
+            .collect()
+    });
+    Some(Table {
         rows,
         location: None,
-        structure: None,
+        structure: Some(TableStructure {
+            header_row,
+            col_continuation: slice(col_cont),
+            row_continuation: slice(row_cont),
+        }),
+        cell_blocks,
     })
 }
 
-/// Trim a table grid to the smallest rectangle covering all non-empty cells
-/// (docling's `_find_true_data_bounds`); returns `None` when the grid is empty.
-fn trim_grid_to_bounds(grid: Vec<Vec<String>>) -> Option<Vec<Vec<String>>> {
+/// The smallest rectangle covering all non-empty cells as `(min_r, max_r,
+/// min_c, max_c)` — docling's `_find_true_data_bounds`; `None` when empty.
+fn data_bounds(grid: &[Vec<String>]) -> Option<(usize, usize, usize, usize)> {
     let non_empty = |r: &Vec<String>| r.iter().any(|c| !c.trim().is_empty());
     let (min_r, max_r) = (
         grid.iter().position(non_empty)?,
@@ -668,12 +817,7 @@ fn trim_grid_to_bounds(grid: Vec<Vec<String>>) -> Option<Vec<Vec<String>>> {
     let col_used = |c: usize| (min_r..=max_r).any(|r| !grid[r][c].trim().is_empty());
     let min_c = (0..ncols).find(|&c| col_used(c))?;
     let max_c = (0..ncols).rposition(col_used)?;
-    Some(
-        grid[min_r..=max_r]
-            .iter()
-            .map(|row| row[min_c..=max_c].to_vec())
-            .collect(),
-    )
+    Some((min_r, max_r, min_c, max_c))
 }
 
 /// A table cell's Markdown. A *rich* cell (lists, multiple paragraphs, nested
@@ -686,6 +830,20 @@ fn cell_text(tc: XmlNode, styles: &Styles) -> String {
     } else {
         plain_cell_text(tc)
     }
+}
+
+/// A *rich* cell's DocLang block content — the structured counterpart of
+/// [`rich_cell_markdown`], built by walking the cell's children exactly like a
+/// document body (so lists, headings, paragraphs with inline runs and nested
+/// tables all render through the same code). Empty for a plain cell, whose flat
+/// [`cell_text`] the serializer uses instead. Markdown/JSON never consult this.
+fn cell_blocks_of(tc: XmlNode, styles: &Styles) -> Vec<Node> {
+    if !is_rich_cell(tc, styles) {
+        return Vec::new();
+    }
+    let mut sub = DoclingDocument::new("");
+    walk_blocks(tc.children().filter(XmlNode::is_element), styles, &mut sub);
+    sub.nodes
 }
 
 /// Whether a cell must render as rich block content — docling's
@@ -907,6 +1065,7 @@ fn add_ods_sheet(table: XmlNode, doc: &mut DoclingDocument) {
                 rows,
                 location: None,
                 structure: None,
+                cell_blocks: None,
             }));
         }
     }

--- a/crates/docling/src/backend/odf.rs
+++ b/crates/docling/src/backend/odf.rs
@@ -74,9 +74,21 @@ struct OdfLevel {
 /// List style name → level (1-based) → level rendering.
 type ListStyles = HashMap<String, HashMap<i64, OdfLevel>>;
 
+/// An embedded chart object: its docling classification (`bar_chart`, …) and
+/// data grid, keyed in [`Styles::charts`] by the object name a `<draw:object>`
+/// references (e.g. `Object 1`).
+#[derive(Clone)]
+struct ChartInfo {
+    kind: String,
+    table: Table,
+}
+
 struct Styles {
     map: HashMap<String, StyleInfo>,
     lists: ListStyles,
+    /// Embedded chart objects by name (`Object 1` → chart). Empty for documents
+    /// with no charts.
+    charts: HashMap<String, ChartInfo>,
 }
 
 impl DeclarativeBackend for OdfBackend {
@@ -91,7 +103,8 @@ impl DeclarativeBackend for OdfBackend {
         let content_dom =
             Document::parse(&content).map_err(|e| ConversionError::Parse(format!("odf: {e}")))?;
         let styles_dom = Document::parse(&styles_xml).ok();
-        let styles = parse_styles(&content_dom, styles_dom.as_ref());
+        let mut styles = parse_styles(&content_dom, styles_dom.as_ref());
+        styles.charts = load_charts(&mut pkg, &content_dom, &styles);
 
         let mut doc = DoclingDocument::new(&source.name);
         let Some(body) = content_dom.descendants().find(|n| n.has_tag_name("body")) else {
@@ -152,7 +165,60 @@ fn parse_styles(content: &Document, styles: Option<&Document>) -> Styles {
             }
         }
     }
-    Styles { map, lists }
+    Styles {
+        map,
+        lists,
+        charts: HashMap::new(),
+    }
+}
+
+/// Load every embedded chart object a `<draw:object>` references. Each object is
+/// a sub-package part `{name}/content.xml` holding a `<chart:chart>`; we keep its
+/// classification and data `<table:table>` (parsed like any ODF table). Objects
+/// that are not charts (or fail to parse) are skipped.
+fn load_charts(
+    pkg: &mut Package,
+    content: &Document,
+    styles: &Styles,
+) -> HashMap<String, ChartInfo> {
+    let mut charts = HashMap::new();
+    for obj in content.descendants().filter(|n| n.has_tag_name("object")) {
+        let Some(href) = attr(obj, "href") else {
+            continue;
+        };
+        let name = href.trim_start_matches("./");
+        if charts.contains_key(name) {
+            continue;
+        }
+        let Some(xml) = pkg.read(&format!("{name}/content.xml")) else {
+            continue;
+        };
+        let Ok(dom) = Document::parse(&xml) else {
+            continue;
+        };
+        let Some(chart) = dom.descendants().find(|n| n.has_tag_name("chart")) else {
+            continue;
+        };
+        let kind = chart_kind(attr(chart, "class").unwrap_or(""));
+        let Some(table_node) = chart.descendants().find(|n| n.has_tag_name("table")) else {
+            continue;
+        };
+        if let Some(table) = parse_table(table_node, styles) {
+            charts.insert(name.to_string(), ChartInfo { kind, table });
+        }
+    }
+    charts
+}
+
+/// Map an ODF `chart:class` (`chart:bar`, `chart:line`, …) to docling's
+/// `PictureClassificationLabel` chart kind (`bar_chart`, `line_chart`, …).
+fn chart_kind(class: &str) -> String {
+    let base = class.strip_prefix("chart:").unwrap_or(class);
+    match base {
+        "circle" | "ring" => "pie_chart".to_string(),
+        "" => "chart".to_string(),
+        other => format!("{other}_chart"),
+    }
 }
 
 fn style_info(s: XmlNode) -> StyleInfo {
@@ -395,7 +461,7 @@ fn handle_block(
     let _ = counters;
     match el.tag_name().name() {
         "h" => {
-            emit_paragraph_images(el, doc);
+            emit_paragraph_images(el, styles, doc);
             let level = attr(el, "outline-level")
                 .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(1)
@@ -413,7 +479,7 @@ fn handle_block(
         "p" => {
             // docling's `_add_odf_paragraph` emits a paragraph's pictures before
             // its text.
-            emit_paragraph_images(el, doc);
+            emit_paragraph_images(el, styles, doc);
             let names = paragraph_style_names(styles, attr(el, "style-name"));
             let mut runs = Vec::new();
             collect_runs(el, styles, Fmt::default(), &mut runs);
@@ -444,22 +510,45 @@ fn handle_block(
     }
 }
 
-/// Emit a placeholder picture for each embedded bitmap (`<draw:image>`) in a
-/// paragraph, skipping the `ObjectReplacements/` previews of embedded objects.
-fn emit_paragraph_images(el: XmlNode, doc: &mut DoclingDocument) {
-    for img in el.descendants().filter(|n| n.has_tag_name("image")) {
-        let href = attr(img, "href").unwrap_or("");
-        if href
-            .trim_start_matches("./")
-            .starts_with("ObjectReplacements/")
-        {
-            continue;
+/// Emit the graphics anchored in a paragraph: each `<draw:frame>` yields one
+/// node.
+fn emit_paragraph_images(el: XmlNode, styles: &Styles, doc: &mut DoclingDocument) {
+    for frame in el.descendants().filter(|n| n.has_tag_name("frame")) {
+        emit_frame_graphic(frame, styles, doc);
+    }
+}
+
+/// Emit one node for a `<draw:frame>`: a chart when it wraps a known embedded
+/// chart object, else a single picture placeholder from its first real image
+/// (an `ObjectReplacements/` preview and alternate encodings collapse into that
+/// one picture — docling emits one `PictureItem` per frame, not per bitmap).
+/// Returns whether a node was emitted.
+fn emit_frame_graphic(frame: XmlNode, styles: &Styles, doc: &mut DoclingDocument) -> bool {
+    if let Some(obj) = frame.children().find(|c| c.has_tag_name("object")) {
+        let name = attr(obj, "href").unwrap_or("").trim_start_matches("./");
+        if let Some(info) = styles.charts.get(name) {
+            doc.push(Node::Chart {
+                kind: info.kind.clone(),
+                table: info.table.clone(),
+            });
+            return true;
         }
+    }
+    let has_real_image = frame.children().any(|c| {
+        c.has_tag_name("image")
+            && !attr(c, "href")
+                .unwrap_or("")
+                .trim_start_matches("./")
+                .starts_with("ObjectReplacements/")
+    });
+    if has_real_image {
         doc.push(Node::Picture {
             caption: None,
             image: None,
         });
+        return true;
     }
+    false
 }
 
 /// Continuation state carried across sibling `<text:list>` elements — docling's
@@ -1106,6 +1195,18 @@ fn walk_presentation(pres: XmlNode, styles: &Styles, doc: &mut DoclingDocument) 
             for table in frame.children().filter(|c| c.has_tag_name("table")) {
                 if let Some(t) = parse_table(table, styles) {
                     doc.push(Node::Table(t));
+                }
+            }
+            // An embedded chart object on the slide → a chart node. A
+            // presentation's graphics are DocLang-only: they appear in the
+            // `.dclx` body but not in docling's presentation `.md`/`.json`.
+            if let Some(obj) = frame.children().find(|c| c.has_tag_name("object")) {
+                let name = attr(obj, "href").unwrap_or("").trim_start_matches("./");
+                if let Some(info) = styles.charts.get(name) {
+                    doc.push(Node::DoclangOnly(Box::new(Node::Chart {
+                        kind: info.kind.clone(),
+                        table: info.table.clone(),
+                    })));
                 }
             }
         }

--- a/crates/docling/src/backend/pptx.rs
+++ b/crates/docling/src/backend/pptx.rs
@@ -474,6 +474,7 @@ fn parse_table(tbl: XmlNode) -> Option<Table> {
             col_continuation,
             row_continuation,
         }),
+        cell_blocks: None,
     })
 }
 

--- a/crates/docling/src/backend/uspto.rs
+++ b/crates/docling/src/backend/uspto.rs
@@ -611,6 +611,7 @@ fn parse_table(table: XmlNode) -> Option<Table> {
             // CALS spans are horizontal-only; no vertical-span continuations.
             row_continuation: Vec::new(),
         }),
+        cell_blocks: None,
     })
 }
 

--- a/crates/docling/src/backend/xlsx.rs
+++ b/crates/docling/src/backend/xlsx.rs
@@ -262,6 +262,7 @@ fn find_tables(
                     rows,
                     location: None,
                     structure: None,
+                    cell_blocks: None,
                 },
                 min_r,
                 min_c,


### PR DESCRIPTION
Raise ODF DocLang (.dclx) conformance from a 66% to an 85% mean over the six odf fixtures (issue #40), closing the largest gaps against docling's groundtruth while keeping Markdown/JSON byte-identical (outputs_match_fixtures unchanged):

- Styled `<text:span>` runs → a rich `InlineGroup` (reusing the docx/html inline path): a paragraph's format groups become structured `<content>/<bold>/<italic>/<underline>/<strikethrough>/<super|subscript>` runs instead of a flat Markdown-marker string. `runs_to_inline` keeps the inter-run spacing docling emits and strips only the paragraph ends.
- Ordered-list markers: enumerated items now carry `<marker>{n}{suffix}</marker>` (e.g. `1.`) from the level's `num-prefix`/`num-suffix`, threaded through the `_OdfListState` continuation so numbering that spans sibling `<text:list>`s keeps one suffix.
- Table OTSL spans: `parse_table` reads `number-columns/rows-spanned` and marks each anchor's covered rectangle, emitting `<lcel/>`/`<ucel/>`/`<xcel/>` (the serializer gains the 2-D `<xcel/>` branch). Row 0 stays the header band.
- Rich table cells: a cell holding a list, several paragraphs or a nested table now carries its DocLang blocks (`Table.cell_blocks`, built by walking the cell like a document body); the serializer emits them after the cell token. Markdown/JSON keep rendering the flat cell text, so their output is unchanged.
- DocLang serializer: a `<content>`-wrapped inline run indents like an element child (fixing multi-run `<text>` layout); shared with docx/html (verified no change there, whose runs are trimmed).

text_document_01 98%, text_document_03 95%, odf_presentation_01 98%. The two remaining laggards (odf_presentation_02, text_document_02 at ~64%) are the embedded bar-chart object (`<picture class="chart">` + `<tabular>`), a follow-up.