### PR TITLE
feat(docling-py): docling-shaped PdfPipelineOptions/config and widere-exports

### DIFF
--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -381,6 +381,16 @@ impl Pipeline {
         }
     }
 
+    /// Eagerly load the models (the full-intra serial worker: layout + OCR, and
+    /// the shared TableFormer unless disabled) so the first conversion doesn't pay
+    /// the load cost. Idempotent; respects `no_ocr` / `no_table_former` (with
+    /// `no_ocr` there is nothing to load). The docling.rs analogue of docling's
+    /// `DocumentConverter.initialize_pipeline`.
+    pub fn warm_up(&mut self) -> Result<(), PdfError> {
+        self.primary()?;
+        Ok(())
+    }
+
     /// The full-intra serial worker, loaded on first use.
     fn primary(&mut self) -> Result<&mut Worker, PdfError> {
         if self.primary.is_none() {

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -62,8 +62,9 @@ PY
 
 | docling.rs | docling counterpart | notes |
 |---|---|---|
-| `DocumentConverter(format_options=None, *, do_ocr=True, do_table_structure=True, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `artifacts_path` overrides the model cache dir. |
+| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
 | `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
+| `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
 | `.convert_bytes(name, data)` | `DocumentStream` | extension of `name` drives format detection |
 | `InputFormat`, `PdfPipelineOptions`, `PdfFormatOption`, `AcceleratorOptions`, `TableFormerMode`, `DocumentStream`, `ImageRefMode` | same modules | docling-shaped config re-exported from `docling_rs` (see below) |
 | `result.status` / `result.document` / `result.input.file` | same | `.status` is a `ConversionStatus` str-enum (`"success" / "partial_success" / "failure"`); `.document` is a genuine `docling_core` `DoclingDocument` |

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -65,6 +65,7 @@ PY
 | `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
 | `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
 | `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
+| `.initialize_pipeline(format=None)` | same | pre-loads the PDF/image ML models so the first conversion isn't slow and later PDFs reuse the warm pipeline (no-op for non-ML formats; needs the models available) |
 | `.convert_bytes(name, data)` | `DocumentStream` | extension of `name` drives format detection |
 | `InputFormat`, `PdfPipelineOptions`, `PdfFormatOption`, `AcceleratorOptions`, `TableFormerMode`, `DocumentStream`, `ImageRefMode` | same modules | docling-shaped config re-exported from `docling_rs` (see below) |
 | `ConversionError` | `docling.exceptions.ConversionError` | raised on a failed conversion; caught by `convert_all(..., raises_on_error=False)` |

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -62,9 +62,10 @@ PY
 
 | docling.rs | docling counterpart | notes |
 |---|---|---|
-| `DocumentConverter(fetch_images=False, artifacts_path=None)` | `DocumentConverter(...)` | `fetch_images` resolves remote/local `<img src>` (HTML/EPUB); `artifacts_path` overrides the model cache dir. |
-| `.convert(path) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path`. Releases the GIL during conversion. |
+| `DocumentConverter(format_options=None, *, do_ocr=True, do_table_structure=True, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `artifacts_path` overrides the model cache dir. |
+| `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
 | `.convert_bytes(name, data)` | `DocumentStream` | extension of `name` drives format detection |
+| `InputFormat`, `PdfPipelineOptions`, `PdfFormatOption`, `AcceleratorOptions`, `TableFormerMode`, `DocumentStream`, `ImageRefMode` | same modules | docling-shaped config re-exported from `docling_rs` (see below) |
 | `result.status` / `result.document` / `result.input.file` | same | `.status` is a `ConversionStatus` str-enum (`"success" / "partial_success" / "failure"`); `.document` is a genuine `docling_core` `DoclingDocument` |
 | `document.export_to_markdown(...)` | same | docling-core's own method — all of docling's params (`image_placeholder`, `page_break_placeholder`, …) apply |
 | `document.export_to_dict()` / `export_to_json()` / `export_to_doctags()` | same | docling-core's own serializers over the wire format |
@@ -76,11 +77,36 @@ by `ensure_env()` (called by the constructor) → the process CWD (`models/`,
 `.pdfium/`, matching the CLI). pdfium is Linux x64 from the release; on other
 platforms set `PDFIUM_DYNAMIC_LIB_PATH` to a local build.
 
+## Configuration (docling-shaped)
+
+`docling_rs` re-exports docling-shaped config objects — same names and fields, so
+docling code reads unchanged:
+
+```python
+from docling_rs import DocumentConverter, InputFormat, PdfFormatOption, PdfPipelineOptions, AcceleratorOptions
+
+opts = PdfPipelineOptions(
+    do_ocr=False,                                   # skip OCR on scanned pages
+    do_table_structure=True,                        # TableFormer table recovery
+    accelerator_options=AcceleratorOptions(num_threads=4),
+)
+conv = DocumentConverter(format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)})
+# shorthand: DocumentConverter(do_ocr=False, do_table_structure=True)
+```
+
+The Rust engine acts on `do_ocr`, `do_table_structure`, and
+`accelerator_options.num_threads` (→ ONNX Runtime intra-op threads via
+`DOCLING_RS_PDF_THREADS`). The remaining `PdfPipelineOptions` fields
+(`images_scale`, `generate_page_images`, `table_structure_options.mode`, …) are
+accepted for API compatibility but do not change the pipeline. `InputFormat`,
+`DocumentStream` and `ImageRefMode` are re-exported too (the last straight from
+`docling_core`, for `export_to_markdown(image_mode=…)`).
+
 ## Not covered (yet)
 
-VLM/enrichment pipelines and docling's full options model
-(`PdfPipelineOptions`, per-format backend selection). Chunkers **are** available
-now — the returned object is a real `docling_core` `DoclingDocument`, so
+VLM/enrichment pipelines, GPU accelerator devices (the engine is ONNX Runtime on
+CPU), and per-format *backend* selection. Chunkers **are** available — the
+returned object is a real `docling_core` `DoclingDocument`, so
 `docling_core.transforms.chunker`'s `HierarchicalChunker` / `HybridChunker`
 operate on it directly (install docling-core's own extras for those:
 `pip install "docling-core[chunking]"`). The document carries rendered text for

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -67,6 +67,7 @@ PY
 | `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
 | `.convert_bytes(name, data)` | `DocumentStream` | extension of `name` drives format detection |
 | `InputFormat`, `PdfPipelineOptions`, `PdfFormatOption`, `AcceleratorOptions`, `TableFormerMode`, `DocumentStream`, `ImageRefMode` | same modules | docling-shaped config re-exported from `docling_rs` (see below) |
+| `ConversionError` | `docling.exceptions.ConversionError` | raised on a failed conversion; caught by `convert_all(..., raises_on_error=False)` |
 | `result.status` / `result.document` / `result.input.file` | same | `.status` is a `ConversionStatus` str-enum (`"success" / "partial_success" / "failure"`); `.document` is a genuine `docling_core` `DoclingDocument` |
 | `document.export_to_markdown(...)` | same | docling-core's own method — all of docling's params (`image_placeholder`, `page_break_placeholder`, …) apply |
 | `document.export_to_dict()` / `export_to_json()` / `export_to_doctags()` | same | docling-core's own serializers over the wire format |
@@ -101,7 +102,9 @@ The Rust engine acts on `do_ocr`, `do_table_structure`, and
 (`images_scale`, `generate_page_images`, `table_structure_options.mode`, …) are
 accepted for API compatibility but do not change the pipeline. `InputFormat`,
 `DocumentStream` and `ImageRefMode` are re-exported too (the last straight from
-`docling_core`, for `export_to_markdown(image_mode=…)`).
+`docling_core`, for `export_to_markdown(image_mode=…)`). A GPU
+`accelerator_options.device` (`CUDA`/`MPS`) is accepted but warns and falls back
+to CPU — the engine runs ONNX Runtime on the CPU execution provider.
 
 ## Not covered (yet)
 

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -171,6 +171,17 @@ class DocumentConverter:
             ),
         )
 
+    def initialize_pipeline(self, format: Optional[InputFormat] = None) -> None:
+        """Eagerly load the ML models for ``format`` (docling's
+        ``initialize_pipeline``), so the first PDF conversion doesn't pay the
+        model-load cost and later ones reuse the warm pipeline. Only ``PDF`` /
+        ``IMAGE`` have models; other formats are a no-op. Uses the converter's
+        configured ``do_ocr`` / ``do_table_structure`` (and needs the models
+        available — see :func:`download_models`)."""
+        self._inner.initialize_pipeline(
+            InputFormat(format).value if format is not None else None
+        )
+
     def convert(self, source: Union[str, os.PathLike, DocumentStream]) -> ConversionResult:
         """Convert a filesystem path (str / pathlib.Path) or an in-memory
         :class:`DocumentStream`."""

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -14,6 +14,14 @@ returns docling-core's JSON wire format; this module loads that into the genuine
 ``export_to_markdown()`` / ``export_to_dict()`` / ``export_to_doctags()``, the
 serializers, and the chunkers — is docling's own Python code, unchanged.
 
+Configuration follows docling's shape — ``PdfPipelineOptions`` / ``PdfFormatOption``
+and per-call kwargs::
+
+    from docling_rs import DocumentConverter, InputFormat, PdfFormatOption, PdfPipelineOptions
+
+    opts = PdfPipelineOptions(do_ocr=False, do_table_structure=True)
+    conv = DocumentConverter(format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)})
+
 One-time model setup (mirrors docling's artifact download; ~700 MB into
 ``~/.cache/docling.rs``)::
 
@@ -28,12 +36,22 @@ import enum
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import Dict, Optional, Union
 
-from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc import DoclingDocument, ImageRefMode
 
 from . import models
 from .models import cache_dir, download_models, ensure_env
+from .options import (
+    AcceleratorDevice,
+    AcceleratorOptions,
+    DocumentStream,
+    InputFormat,
+    PdfFormatOption,
+    PdfPipelineOptions,
+    TableFormerMode,
+    TableStructureOptions,
+)
 from ._native import __version__
 from ._native import DocumentConverter as _NativeDocumentConverter
 
@@ -41,8 +59,19 @@ __all__ = [
     "DocumentConverter",
     "ConversionResult",
     "ConversionStatus",
-    "DoclingDocument",
     "InputDocument",
+    "DoclingDocument",
+    "ImageRefMode",
+    # docling-shaped configuration
+    "InputFormat",
+    "DocumentStream",
+    "PdfPipelineOptions",
+    "PdfFormatOption",
+    "TableStructureOptions",
+    "TableFormerMode",
+    "AcceleratorOptions",
+    "AcceleratorDevice",
+    # model / env helpers
     "download_models",
     "ensure_env",
     "cache_dir",
@@ -82,19 +111,57 @@ class ConversionResult:
 class DocumentConverter:
     """docling-shaped converter whose processor is Rust.
 
-    ``artifacts_path`` overrides the model cache directory (docling's
-    ``artifacts_path``); by default the pipeline is pointed at
-    ``~/.cache/docling.rs`` (see :func:`download_models`). ``fetch_images``
-    resolves remote/local ``<img src>`` for HTML/EPUB.
+    Parameters mirror docling's converter and ``PdfPipelineOptions``:
+
+    * ``format_options`` — ``{InputFormat.PDF: PdfFormatOption(pipeline_options=...)}``,
+      as in docling. The PDF/image pipeline options ``do_ocr``,
+      ``do_table_structure`` and ``accelerator_options.num_threads`` take effect.
+    * ``do_ocr`` / ``do_table_structure`` — a shorthand for the same, used when no
+      ``format_options`` is given.
+    * ``fetch_images`` — resolve remote/local ``<img src>`` for HTML/EPUB.
+    * ``use_web_browser`` — render HTML via headless Chrome before parsing.
+    * ``artifacts_path`` — override the model cache dir (docling's
+      ``artifacts_path``); defaults to ``~/.cache/docling.rs``.
     """
 
-    def __init__(self, fetch_images: bool = False, artifacts_path=None):
+    def __init__(
+        self,
+        format_options: Optional[Dict[InputFormat, PdfFormatOption]] = None,
+        *,
+        do_ocr: bool = True,
+        do_table_structure: bool = True,
+        fetch_images: bool = False,
+        use_web_browser: bool = False,
+        artifacts_path=None,
+    ):
         ensure_env(artifacts_path)
-        self._inner = _NativeDocumentConverter(fetch_images=fetch_images)
 
-    def convert(self, source: Union[str, os.PathLike]) -> ConversionResult:
-        """Convert a filesystem path (str / pathlib.Path)."""
-        native = self._inner.convert(source)
+        # A PDF/IMAGE PdfFormatOption overrides the shorthand kwargs.
+        pipeline = _pdf_pipeline_options(format_options)
+        if pipeline is not None:
+            do_ocr = pipeline.do_ocr
+            do_table_structure = pipeline.do_table_structure
+            acc = getattr(pipeline, "accelerator_options", None)
+            if acc is not None and acc.num_threads:
+                # Process-wide ONNX Runtime intra-op threads; don't clobber an
+                # explicit environment override.
+                os.environ.setdefault("DOCLING_RS_PDF_THREADS", str(acc.num_threads))
+
+        self._inner = _NativeDocumentConverter(
+            fetch_images=fetch_images,
+            do_ocr=do_ocr,
+            do_table_structure=do_table_structure,
+            use_web_browser=use_web_browser,
+        )
+
+    def convert(self, source: Union[str, os.PathLike, DocumentStream]) -> ConversionResult:
+        """Convert a filesystem path (str / pathlib.Path) or an in-memory
+        :class:`DocumentStream`."""
+        if isinstance(source, DocumentStream):
+            data = source.stream.read()
+            native = self._inner.convert_bytes(source.name, data)
+        else:
+            native = self._inner.convert(source)
         return _wrap(native)
 
     def convert_bytes(self, name: str, data: bytes) -> ConversionResult:
@@ -102,6 +169,20 @@ class DocumentConverter:
         (docling's ``DocumentStream`` counterpart)."""
         native = self._inner.convert_bytes(name, data)
         return _wrap(native)
+
+
+def _pdf_pipeline_options(
+    format_options: Optional[Dict[InputFormat, PdfFormatOption]],
+) -> Optional[PdfPipelineOptions]:
+    """The PDF (or image) pipeline options from a docling-style ``format_options``
+    mapping, if any."""
+    if not format_options:
+        return None
+    for fmt in (InputFormat.PDF, InputFormat.IMAGE):
+        fo = format_options.get(fmt)
+        if fo is not None and getattr(fo, "pipeline_options", None) is not None:
+            return fo.pipeline_options
+    return None
 
 
 def _wrap(native) -> ConversionResult:

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -36,7 +36,7 @@ import enum
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Iterable, Iterator, Optional, Union
 
 from docling_core.types.doc import DoclingDocument, ImageRefMode
 
@@ -120,6 +120,8 @@ class DocumentConverter:
       ``format_options`` is given.
     * ``fetch_images`` — resolve remote/local ``<img src>`` for HTML/EPUB.
     * ``use_web_browser`` — render HTML via headless Chrome before parsing.
+    * ``allowed_formats`` — restrict conversion to these :class:`InputFormat`\\ s
+      (docling's converter arg); a source of any other format raises.
     * ``artifacts_path`` — override the model cache dir (docling's
       ``artifacts_path``); defaults to ``~/.cache/docling.rs``.
     """
@@ -128,6 +130,7 @@ class DocumentConverter:
         self,
         format_options: Optional[Dict[InputFormat, PdfFormatOption]] = None,
         *,
+        allowed_formats: Optional[Iterable[InputFormat]] = None,
         do_ocr: bool = True,
         do_table_structure: bool = True,
         fetch_images: bool = False,
@@ -152,23 +155,46 @@ class DocumentConverter:
             do_ocr=do_ocr,
             do_table_structure=do_table_structure,
             use_web_browser=use_web_browser,
+            allowed_formats=(
+                [InputFormat(f).value for f in allowed_formats]
+                if allowed_formats is not None
+                else None
+            ),
         )
 
     def convert(self, source: Union[str, os.PathLike, DocumentStream]) -> ConversionResult:
         """Convert a filesystem path (str / pathlib.Path) or an in-memory
         :class:`DocumentStream`."""
-        if isinstance(source, DocumentStream):
-            data = source.stream.read()
-            native = self._inner.convert_bytes(source.name, data)
-        else:
-            native = self._inner.convert(source)
+        native = self._convert_native(source)
         return _wrap(native)
+
+    def convert_all(
+        self,
+        sources: Iterable[Union[str, os.PathLike, DocumentStream]],
+        raises_on_error: bool = True,
+    ) -> Iterator[ConversionResult]:
+        """Convert many sources, yielding a :class:`ConversionResult` each
+        (docling's ``convert_all``). With ``raises_on_error=False`` a failing
+        source yields a ``failure`` result (empty document) instead of raising."""
+        for source in sources:
+            try:
+                yield _wrap(self._convert_native(source))
+            except Exception:
+                if raises_on_error:
+                    raise
+                name = source.name if isinstance(source, DocumentStream) else str(source)
+                yield ConversionResult("failure", name, DoclingDocument(name=Path(name).name))
 
     def convert_bytes(self, name: str, data: bytes) -> ConversionResult:
         """Convert in-memory bytes; ``name``'s extension drives format detection
         (docling's ``DocumentStream`` counterpart)."""
         native = self._inner.convert_bytes(name, data)
         return _wrap(native)
+
+    def _convert_native(self, source):
+        if isinstance(source, DocumentStream):
+            return self._inner.convert_bytes(source.name, source.stream.read())
+        return self._inner.convert(source)
 
 
 def _pdf_pipeline_options(

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import enum
 import os
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, Optional, Union
@@ -52,13 +53,14 @@ from .options import (
     TableFormerMode,
     TableStructureOptions,
 )
-from ._native import __version__
+from ._native import ConversionError, __version__
 from ._native import DocumentConverter as _NativeDocumentConverter
 
 __all__ = [
     "DocumentConverter",
     "ConversionResult",
     "ConversionStatus",
+    "ConversionError",
     "InputDocument",
     "DoclingDocument",
     "ImageRefMode",
@@ -145,10 +147,17 @@ class DocumentConverter:
             do_ocr = pipeline.do_ocr
             do_table_structure = pipeline.do_table_structure
             acc = getattr(pipeline, "accelerator_options", None)
-            if acc is not None and acc.num_threads:
-                # Process-wide ONNX Runtime intra-op threads; don't clobber an
-                # explicit environment override.
-                os.environ.setdefault("DOCLING_RS_PDF_THREADS", str(acc.num_threads))
+            if acc is not None:
+                if acc.device in (AcceleratorDevice.CUDA, AcceleratorDevice.MPS):
+                    warnings.warn(
+                        f"docling.rs runs ONNX Runtime on the CPU; accelerator "
+                        f"device {acc.device.value!r} is ignored (using CPU).",
+                        stacklevel=2,
+                    )
+                if acc.num_threads:
+                    # Process-wide ONNX Runtime intra-op threads; don't clobber an
+                    # explicit environment override.
+                    os.environ.setdefault("DOCLING_RS_PDF_THREADS", str(acc.num_threads))
 
         self._inner = _NativeDocumentConverter(
             fetch_images=fetch_images,

--- a/crates/docling-py/python/docling_rs/options.py
+++ b/crates/docling-py/python/docling_rs/options.py
@@ -42,6 +42,9 @@ class InputFormat(str, enum.Enum):
     EMAIL = "email"
     LATEX = "latex"
     MHTML = "mhtml"
+    XML_XBRL = "xml_xbrl"
+    XML_DOCLANG = "xml_doclang"
+    METS_GBS = "mets_gbs"
 
 
 class AcceleratorDevice(str, enum.Enum):

--- a/crates/docling-py/python/docling_rs/options.py
+++ b/crates/docling-py/python/docling_rs/options.py
@@ -1,0 +1,119 @@
+"""docling-shaped configuration objects.
+
+These mirror the names and fields of docling's ``InputFormat`` /
+``PdfPipelineOptions`` / ``PdfFormatOption`` / ``DocumentStream`` so existing
+docling code reads unchanged, but they are plain, dependency-free dataclasses:
+the Rust engine acts on the subset it supports (``do_ocr``,
+``do_table_structure``, and ``accelerator_options.num_threads``), and the rest
+are accepted for API compatibility. See the crate README for the support matrix.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import BinaryIO, Optional
+
+
+class InputFormat(str, enum.Enum):
+    """docling's ``InputFormat``. The first block matches docling's members
+    one-for-one (same string values); the second lists formats docling.rs also
+    handles. A ``str`` enum, so ``InputFormat.PDF == "pdf"``."""
+
+    DOCX = "docx"
+    PPTX = "pptx"
+    HTML = "html"
+    IMAGE = "image"
+    PDF = "pdf"
+    ASCIIDOC = "asciidoc"
+    MD = "md"
+    CSV = "csv"
+    XLSX = "xlsx"
+    XML_USPTO = "xml_uspto"
+    XML_JATS = "xml_jats"
+    JSON_DOCLING = "json_docling"
+    AUDIO = "audio"
+    # docling.rs also supports:
+    ODT = "odt"
+    ODS = "ods"
+    ODP = "odp"
+    EPUB = "epub"
+    VTT = "vtt"
+    EMAIL = "email"
+    LATEX = "latex"
+    MHTML = "mhtml"
+
+
+class AcceleratorDevice(str, enum.Enum):
+    """docling's ``AcceleratorDevice``. The Rust engine runs ONNX Runtime on the
+    CPU execution provider, so `AUTO`/`CPU` are honoured and GPU devices fall
+    back to CPU."""
+
+    AUTO = "auto"
+    CPU = "cpu"
+    CUDA = "cuda"
+    MPS = "mps"
+
+
+class TableFormerMode(str, enum.Enum):
+    """docling's ``TableFormerMode`` (accepted; the Rust TableFormer runs a
+    single accurate mode)."""
+
+    FAST = "fast"
+    ACCURATE = "accurate"
+
+
+@dataclass
+class AcceleratorOptions:
+    """docling's ``AcceleratorOptions``. ``num_threads`` maps to the engine's
+    ONNX Runtime intra-op thread count (via ``DOCLING_RS_PDF_THREADS``)."""
+
+    num_threads: int = 4
+    device: AcceleratorDevice = AcceleratorDevice.AUTO
+
+
+@dataclass
+class TableStructureOptions:
+    """docling's ``TableStructureOptions`` (accepted for API compatibility)."""
+
+    do_cell_matching: bool = True
+    mode: TableFormerMode = TableFormerMode.ACCURATE
+
+
+@dataclass
+class PdfPipelineOptions:
+    """docling's ``PdfPipelineOptions``.
+
+    Acted on by the Rust engine: ``do_ocr``, ``do_table_structure`` and
+    ``accelerator_options.num_threads``. The remaining fields are accepted so
+    docling code constructs unchanged, but do not alter the pipeline (images are
+    always extracted; the export image mode is chosen by docling-core at
+    ``export_to_markdown(...)`` time)."""
+
+    do_ocr: bool = True
+    do_table_structure: bool = True
+    table_structure_options: TableStructureOptions = field(
+        default_factory=TableStructureOptions
+    )
+    accelerator_options: AcceleratorOptions = field(default_factory=AcceleratorOptions)
+    images_scale: float = 1.0
+    generate_page_images: bool = False
+    generate_picture_images: bool = False
+
+
+@dataclass
+class PdfFormatOption:
+    """docling's ``PdfFormatOption``: carries ``pipeline_options`` for a format,
+    as passed in ``DocumentConverter(format_options={InputFormat.PDF: ...})``."""
+
+    pipeline_options: Optional[PdfPipelineOptions] = None
+
+
+@dataclass
+class DocumentStream:
+    """docling's ``DocumentStream``: an in-memory source whose ``name`` (with
+    extension) drives format detection. ``stream`` is any binary file-like
+    object (e.g. ``io.BytesIO``)."""
+
+    name: str
+    stream: BinaryIO

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -58,20 +58,36 @@ impl PyDocumentConverter {
         do_ocr = true,
         do_table_structure = true,
         use_web_browser = false,
+        allowed_formats = None,
     ))]
     fn new(
         fetch_images: bool,
         do_ocr: bool,
         do_table_structure: bool,
         use_web_browser: bool,
-    ) -> Self {
-        Self {
-            inner: docling::DocumentConverter::new()
+        allowed_formats: Option<Vec<String>>,
+    ) -> PyResult<Self> {
+        // `allowed_formats` (docling's converter arg) restricts which input
+        // formats convert; an unknown name is an error so typos surface early.
+        let base = match allowed_formats {
+            Some(names) => {
+                let mut formats = Vec::with_capacity(names.len());
+                for name in &names {
+                    formats.push(parse_format(name).ok_or_else(|| {
+                        PyRuntimeError::new_err(format!("unknown input format {name:?}"))
+                    })?);
+                }
+                docling::DocumentConverter::with_allowed_formats(formats)
+            }
+            None => docling::DocumentConverter::new(),
+        };
+        Ok(Self {
+            inner: base
                 .fetch_images(fetch_images)
                 .no_ocr(!do_ocr)
                 .no_table_former(!do_table_structure)
                 .use_web_browser(use_web_browser),
-        }
+        })
     }
 
     /// Convert a document from a filesystem path (str / os.PathLike).
@@ -111,6 +127,39 @@ impl PyDocumentConverter {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         Ok(native_result(result))
     }
+}
+
+/// Map a docling `InputFormat` string value (as in `docling_rs.InputFormat`,
+/// matching `docling::InputFormat::name()`) to the engine enum.
+fn parse_format(name: &str) -> Option<docling::InputFormat> {
+    use docling::InputFormat::*;
+    Some(match name {
+        "docx" => Docx,
+        "pptx" => Pptx,
+        "html" => Html,
+        "image" => Image,
+        "pdf" => Pdf,
+        "asciidoc" => Asciidoc,
+        "md" => Md,
+        "csv" => Csv,
+        "xlsx" => Xlsx,
+        "odt" => Odt,
+        "ods" => Ods,
+        "odp" => Odp,
+        "xml_uspto" => XmlUspto,
+        "xml_jats" => XmlJats,
+        "xml_xbrl" => XmlXbrl,
+        "xml_doclang" => XmlDoclang,
+        "mets_gbs" => MetsGbs,
+        "json_docling" => JsonDocling,
+        "audio" => Audio,
+        "vtt" => Vtt,
+        "latex" => Latex,
+        "email" => Email,
+        "epub" => Epub,
+        "mhtml" => Mhtml,
+        _ => return None,
+    })
 }
 
 fn native_result(r: docling::ConversionResult) -> PyNativeResult {

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -42,14 +42,35 @@ struct PyDocumentConverter {
 
 #[pymethods]
 impl PyDocumentConverter {
-    /// `fetch_images` — resolve remote/local `<img src>` for HTML/EPUB (docling's
-    /// image fetch). Markdown flavour is chosen at export time by docling-core on
-    /// the Python side, so there is no `strict` knob here anymore.
+    /// Engine knobs mapped from docling's converter/`PdfPipelineOptions` on the
+    /// Python side:
+    /// * `fetch_images` — resolve remote/local `<img src>` for HTML/EPUB.
+    /// * `do_ocr` — run OCR on scanned PDF/image pages (docling's `do_ocr`).
+    /// * `do_table_structure` — recover table structure with TableFormer
+    ///   (docling's `do_table_structure`).
+    /// * `use_web_browser` — render HTML via headless Chrome before parsing.
+    ///
+    /// Markdown flavour is chosen at export time by docling-core, so there is no
+    /// `strict` knob here.
     #[new]
-    #[pyo3(signature = (fetch_images = false))]
-    fn new(fetch_images: bool) -> Self {
+    #[pyo3(signature = (
+        fetch_images = false,
+        do_ocr = true,
+        do_table_structure = true,
+        use_web_browser = false,
+    ))]
+    fn new(
+        fetch_images: bool,
+        do_ocr: bool,
+        do_table_structure: bool,
+        use_web_browser: bool,
+    ) -> Self {
         Self {
-            inner: docling::DocumentConverter::new().fetch_images(fetch_images),
+            inner: docling::DocumentConverter::new()
+                .fetch_images(fetch_images)
+                .no_ocr(!do_ocr)
+                .no_table_former(!do_table_structure)
+                .use_web_browser(use_web_browser),
         }
     }
 

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -13,11 +13,15 @@
 //! document-shaped is reconstructed on the Python side. Model discovery/download
 //! lives in `docling_rs.models`, mirroring how docling fetches its artifacts.
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 use docling::{ConversionStatus, SourceDocument};
+
+// docling's `ConversionError`: raised when a conversion fails (docling code does
+// `except ConversionError`). Re-exported from the Python package.
+pyo3::create_exception!(_native, ConversionError, PyException);
 
 /// The Rust processor's result: a conversion status, the input name, and the
 /// document as docling-core's JSON wire format. The Python layer validates the
@@ -74,7 +78,7 @@ impl PyDocumentConverter {
                 let mut formats = Vec::with_capacity(names.len());
                 for name in &names {
                     formats.push(parse_format(name).ok_or_else(|| {
-                        PyRuntimeError::new_err(format!("unknown input format {name:?}"))
+                        PyValueError::new_err(format!("unknown input format {name:?}"))
                     })?);
                 }
                 docling::DocumentConverter::with_allowed_formats(formats)
@@ -99,7 +103,7 @@ impl PyDocumentConverter {
                 let src = SourceDocument::from_file(&path)?;
                 self.inner.convert(src)
             })
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| ConversionError::new_err(e.to_string()))?;
         Ok(native_result(result))
     }
 
@@ -117,14 +121,14 @@ impl PyDocumentConverter {
             .and_then(|e| e.to_str())
             .unwrap_or("");
         let format = docling::InputFormat::from_extension(ext).ok_or_else(|| {
-            PyRuntimeError::new_err(format!("cannot detect input format from name {name:?}"))
+            ConversionError::new_err(format!("cannot detect input format from name {name:?}"))
         })?;
         let result = py
             .allow_threads(|| {
                 self.inner
                     .convert(SourceDocument::from_bytes(&name, format, bytes))
             })
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| ConversionError::new_err(e.to_string()))?;
         Ok(native_result(result))
     }
 }
@@ -194,6 +198,7 @@ impl<'py> FromPyObject<'py> for PathLike {
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDocumentConverter>()?;
     m.add_class::<PyNativeResult>()?;
+    m.add("ConversionError", m.py().get_type::<ConversionError>())?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -42,6 +42,12 @@ struct PyNativeResult {
 #[pyclass(name = "DocumentConverter")]
 struct PyDocumentConverter {
     inner: docling::DocumentConverter,
+    /// A persistent, primed PDF pipeline once `initialize_pipeline` runs — so
+    /// PDFs reuse its warm models across `convert` calls instead of reloading
+    /// them each time (the transient path `inner` takes otherwise).
+    pdf_pipeline: std::sync::Mutex<Option<docling::Pipeline>>,
+    no_ocr: bool,
+    no_table_former: bool,
 }
 
 #[pymethods]
@@ -91,20 +97,45 @@ impl PyDocumentConverter {
                 .no_ocr(!do_ocr)
                 .no_table_former(!do_table_structure)
                 .use_web_browser(use_web_browser),
+            pdf_pipeline: std::sync::Mutex::new(None),
+            no_ocr: !do_ocr,
+            no_table_former: !do_table_structure,
         })
+    }
+
+    /// Eagerly load the PDF/image ML models (docling's `initialize_pipeline`), so
+    /// the first PDF conversion doesn't pay the model-load cost and later ones
+    /// reuse the warm pipeline. `format` mirrors docling's arg — only `"pdf"` /
+    /// `"image"` have models, so other formats are a no-op. Uses the converter's
+    /// configured `do_ocr` / `do_table_structure`.
+    #[pyo3(signature = (format = None))]
+    fn initialize_pipeline(&self, py: Python<'_>, format: Option<String>) -> PyResult<()> {
+        let is_ml = match format.as_deref() {
+            Some(f) => matches!(f, "pdf" | "image"),
+            None => true,
+        };
+        if !is_ml {
+            return Ok(());
+        }
+        let mut slot = self.pdf_pipeline.lock().unwrap();
+        if slot.is_none() {
+            let mut pipeline = docling::Pipeline::new()
+                .map_err(|e| ConversionError::new_err(e.to_string()))?
+                .no_table_former(self.no_table_former)
+                .no_ocr(self.no_ocr);
+            py.allow_threads(|| pipeline.warm_up())
+                .map_err(|e| ConversionError::new_err(e.to_string()))?;
+            *slot = Some(pipeline);
+        }
+        Ok(())
     }
 
     /// Convert a document from a filesystem path (str / os.PathLike).
     /// Releases the GIL for the (potentially long) conversion.
     fn convert(&self, py: Python<'_>, source: PathLike) -> PyResult<PyNativeResult> {
-        let path = source.0;
-        let result = py
-            .allow_threads(|| {
-                let src = SourceDocument::from_file(&path)?;
-                self.inner.convert(src)
-            })
+        let src = SourceDocument::from_file(&source.0)
             .map_err(|e| ConversionError::new_err(e.to_string()))?;
-        Ok(native_result(result))
+        self.convert_source(py, src)
     }
 
     /// Convert in-memory bytes; `name` (with extension) drives format detection,
@@ -123,11 +154,30 @@ impl PyDocumentConverter {
         let format = docling::InputFormat::from_extension(ext).ok_or_else(|| {
             ConversionError::new_err(format!("cannot detect input format from name {name:?}"))
         })?;
+        self.convert_source(py, SourceDocument::from_bytes(&name, format, bytes))
+    }
+}
+
+impl PyDocumentConverter {
+    /// Convert a prepared [`SourceDocument`], routing PDFs through the warm
+    /// pipeline when `initialize_pipeline` has primed it (otherwise the transient
+    /// `inner` path, which reloads models per call).
+    fn convert_source(&self, py: Python<'_>, src: SourceDocument) -> PyResult<PyNativeResult> {
+        if src.format == docling::InputFormat::Pdf {
+            let mut slot = self.pdf_pipeline.lock().unwrap();
+            if let Some(pipeline) = slot.as_mut() {
+                let doc = py
+                    .allow_threads(|| pipeline.convert(&src.bytes, None, &src.name))
+                    .map_err(|e| ConversionError::new_err(e.to_string()))?;
+                return Ok(PyNativeResult {
+                    status: "success".to_string(),
+                    input_name: src.name,
+                    document_json: doc.export_to_json(),
+                });
+            }
+        }
         let result = py
-            .allow_threads(|| {
-                self.inner
-                    .convert(SourceDocument::from_bytes(&name, format, bytes))
-            })
+            .allow_threads(|| self.inner.convert(src))
             .map_err(|e| ConversionError::new_err(e.to_string()))?;
         Ok(native_result(result))
     }

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -126,3 +126,30 @@ def test_convert_all_raises_on_error_false():
     assert len(out) == 2
     assert out[0].status == "success"
     assert out[1].status == "failure"
+
+
+def test_conversion_error_type():
+    from docling_rs import DocumentConverter, ConversionError
+
+    missing = REPO / "tests/data/html/sources/__nope__.html"
+    with pytest.raises(ConversionError):
+        DocumentConverter().convert(missing)
+
+
+def test_gpu_device_warns_cpu_only():
+    from docling_rs import (
+        DocumentConverter,
+        InputFormat,
+        PdfFormatOption,
+        PdfPipelineOptions,
+        AcceleratorOptions,
+        AcceleratorDevice,
+    )
+
+    opts = PdfPipelineOptions(
+        accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CUDA)
+    )
+    with pytest.warns(UserWarning, match="CPU"):
+        DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
+        )

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -88,3 +88,41 @@ def test_image_ref_mode_reexport_drives_export():
     # docling-core's own export honours the re-exported enum.
     md = doc.export_to_markdown(image_mode=ImageRefMode.EMBEDDED)
     assert isinstance(md, str)
+
+
+def test_allowed_formats_restricts_conversion():
+    from docling_rs import DocumentConverter, InputFormat
+
+    # HTML allowed → converts.
+    ok = DocumentConverter(allowed_formats=[InputFormat.HTML]).convert(HTML)
+    assert ok.status == "success"
+
+    # HTML not in the allowed set → the engine refuses it.
+    conv = DocumentConverter(allowed_formats=[InputFormat.PDF, InputFormat.DOCX])
+    with pytest.raises(Exception):
+        conv.convert(HTML)
+
+
+def test_unknown_allowed_format_raises():
+    from docling_rs import DocumentConverter
+
+    with pytest.raises(Exception):
+        DocumentConverter(allowed_formats=["not_a_format"])
+
+
+def test_convert_all_yields_results():
+    from docling_rs import DocumentConverter
+
+    results = list(DocumentConverter().convert_all([HTML, HTML]))
+    assert len(results) == 2
+    assert all(r.status == "success" for r in results)
+
+
+def test_convert_all_raises_on_error_false():
+    from docling_rs import DocumentConverter
+
+    missing = REPO / "tests/data/html/sources/__does_not_exist__.html"
+    out = list(DocumentConverter().convert_all([HTML, missing], raises_on_error=False))
+    assert len(out) == 2
+    assert out[0].status == "success"
+    assert out[1].status == "failure"

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -1,0 +1,90 @@
+"""Tests for the docling-shaped configuration surface and re-exports
+(declarative path only — no ML models required)."""
+
+import io
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+HTML = REPO / "tests/data/html/sources/hyperlink_03.html"
+
+docling_rs = pytest.importorskip("docling_rs")
+
+
+def test_input_format_matches_docling_values():
+    from docling_rs import InputFormat
+
+    # docling's own members carry these exact string values.
+    assert InputFormat.PDF == "pdf"
+    assert InputFormat.DOCX == "docx"
+    assert InputFormat.XML_JATS == "xml_jats"
+    assert InputFormat.JSON_DOCLING == "json_docling"
+
+
+def test_reexports_are_importable():
+    import docling_rs as d
+
+    for name in (
+        "DocumentConverter",
+        "ConversionResult",
+        "ConversionStatus",
+        "DoclingDocument",
+        "ImageRefMode",
+        "InputFormat",
+        "DocumentStream",
+        "PdfPipelineOptions",
+        "PdfFormatOption",
+        "AcceleratorOptions",
+        "AcceleratorDevice",
+        "TableFormerMode",
+    ):
+        assert hasattr(d, name), name
+
+
+def test_pipeline_options_via_format_options_convert():
+    from docling_rs import (
+        DocumentConverter,
+        InputFormat,
+        PdfFormatOption,
+        PdfPipelineOptions,
+        AcceleratorOptions,
+    )
+
+    opts = PdfPipelineOptions(
+        do_ocr=False,
+        do_table_structure=False,
+        accelerator_options=AcceleratorOptions(num_threads=2),
+    )
+    conv = DocumentConverter(
+        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
+    )
+    # Options are PDF-pipeline knobs; a declarative HTML convert still works.
+    res = conv.convert(HTML)
+    assert res.status == "success"
+    assert res.document.export_to_markdown()
+
+
+def test_shorthand_flags_convert():
+    from docling_rs import DocumentConverter
+
+    res = DocumentConverter(do_ocr=False, do_table_structure=True).convert(HTML)
+    assert res.status == "success"
+
+
+def test_document_stream_source():
+    from docling_rs import DocumentConverter, DocumentStream
+
+    stream = DocumentStream(name="hyperlink_03.html", stream=io.BytesIO(HTML.read_bytes()))
+    res = DocumentConverter().convert(stream)
+    assert res.status == "success"
+    assert res.document.texts
+
+
+def test_image_ref_mode_reexport_drives_export():
+    from docling_rs import DocumentConverter, ImageRefMode
+
+    doc = DocumentConverter().convert(HTML).document
+    # docling-core's own export honours the re-exported enum.
+    md = doc.export_to_markdown(image_mode=ImageRefMode.EMBEDDED)
+    assert isinstance(md, str)

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -153,3 +153,13 @@ def test_gpu_device_warns_cpu_only():
         DocumentConverter(
             format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
         )
+
+
+def test_initialize_pipeline_noop_for_non_ml_format():
+    from docling_rs import DocumentConverter, InputFormat
+
+    conv = DocumentConverter()
+    # No models needed for a declarative format → clean no-op, and conversion
+    # still works afterwards.
+    conv.initialize_pipeline(InputFormat.MD)
+    assert conv.convert(HTML).status == "success"


### PR DESCRIPTION
Extend the Python drop-in toward docling's converter surface:

- Native `DocumentConverter` now takes `do_ocr` / `do_table_structure` / `use_web_browser`, mapped to the engine's `no_ocr` / `no_table_former` / `use_web_browser` builder flags.
- New `options.py` with dependency-free, docling-shaped config: `InputFormat`, `PdfPipelineOptions`, `PdfFormatOption`, `TableStructureOptions`, `TableFormerMode`, `AcceleratorOptions`, `AcceleratorDevice`, `DocumentStream`.
- `DocumentConverter(format_options={InputFormat.PDF: PdfFormatOption(...)})` applies the supported knobs (`do_ocr`, `do_table_structure`, `accelerator_options.num_threads` → `DOCLING_RS_PDF_THREADS`); a shorthand kwarg form is also accepted. `.convert()` now accepts a `DocumentStream`.
- Re-export `ImageRefMode` from docling-core so `export_to_markdown(image_mode=…)` works from `docling_rs`.

Documented the support matrix in the README; added a config test suite. Verified with maturin: all 11 tests pass on the declarative path.