### PR TITLE
docs(migration): measured conformance numbers for the wordy format rows

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -87,16 +87,16 @@ PyPI; run via `scripts/conformance/conformance.sh <fmt>`), not the committed gro
 | DeepSeek-OCR Markdown | `deepseek.rs` | **3/3 exact** (auto-detected VLM-token variant) |
 | XLSX | `xlsx.rs` (calamine) | **9/9 exact** |
 | PPTX | `pptx.rs` (roxmltree) | **7/7 exact** |
-| DOCX | `docx.rs` (roxmltree) | core (most fixtures); residual in §5 |
+| DOCX | `docx.rs` (roxmltree) | **24/26 exact** (residual: `drawingml` grouped shapes, `textbox` floating-frame layout — §5) |
 | WebVTT | `webvtt.rs` | **4/4 exact** |
 | Email (.eml) | `email.rs` (mail-parser) | **2/2 exact** |
-| EPUB | `epub.rs` → HTML backend | core exact (shares HTML residual) |
-| ODF (odt/ods/odp) | `odf.rs` | core + list continuation + rich table cells + ODS table regions; residual in §5 |
-| JATS | `jats.rs` (roxmltree) | metadata + full `<body>`/`<back>` (tables, figures, references, lists, footnotes, formulas) |
-| USPTO | `uspto.rs` | modern `us-patent-*-v4x` **+ legacy `pap-v15` applications + `PATDOC`/ST.32 grants**, incl. CALS tables; APS-text residual in §5 |
-| XBRL | `xbrl.rs` | arelle-free core (dei facts → title, `*TextBlock` → HTML) |
+| EPUB | `epub.rs` → HTML backend | **0/1** — the single fixture is 39 diff lines (heading-italic nesting + colophon inline-link layout, the HTML inline residual) |
+| ODF (odt/ods/odp) | `odf.rs` | **2/6 exact** on the native files (`.ods` table + `text_document_01`; `text_document_03` within 2 lines); presentations/frames — §5 |
+| JATS | `jats.rs` (roxmltree) | **3/4 exact**; the eLife plain-text route diverges (252 diff lines) |
+| USPTO | `uspto.rs` | **1/5 exact (2/5 whitespace-normalized)** on the sources live docling converts — it errors on the other 5 (those are validated byte-exact via `.dclx`), and its APS-text *Markdown* export is empty where ours emits the text dump (the `.dclx` matches exactly — §5) |
+| XBRL | `xbrl.rs` | arelle-free core (dei facts → title, `*TextBlock` → HTML); *vs committed groundtruth* 0/2 (30 / 346 diff lines) — live docling needs arelle, which the conformance venv doesn't ship |
 | JSON-docling | `docling_json.rs` (serde_json) | reads docling's native JSON; ~51/145 round-trip exact |
-| LaTeX | `latex.rs` (scanner) | simple `.tex` ≈ live; multi-file arxiv out of scope |
+| LaTeX | `latex.rs` (scanner) | simple `.tex` ≈ live (0/2 exact, but within 2 / 9 diff lines); multi-file arxiv out of scope |
 | MHTML (.mhtml/.mht) | `mhtml.rs` (mail-parser) → HTML backend | **docling.rs extension — no docling backend to compare against**; embedded images resolved by `Content-Location`/`cid:` |
 
 Shared OOXML infrastructure (`ooxml.rs`): a `zip` reader, `.rels` parsing, part
@@ -297,7 +297,8 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   done: mixed-style list continuation, empty-list-item level collapse, ODS
   sheet→table region detection with numeric alignment, and rich table cells.
 - **DOCX grouped/anchored drawings** — position-sorted layout of grouped shapes
-  and `<mc:AlternateContent>` image de-duplication (`drawingml` fixture).
+  and `<mc:AlternateContent>` image de-duplication (`drawingml` fixture, 8 diff
+  lines), and floating text-frame ordering (`textbox` fixture, 40 diff lines).
   Multilevel shared list/heading numbering and advanced OMML/inline-equation
   spacing are done (byte-for-byte against pylatexenc).
 - **`wiki_duck` offline rendering.** The HTML subsystem itself is complete

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -132,14 +132,17 @@ line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈91% mean ov
 | JATS | 95% | HTML | 84% |
 | | | WebVTT | 81% |
 
-The remaining format gaps are tracked under
-[issue #32](https://github.com/docling-project/docling.rs/issues/32); its children
-(#38–#41, #44) landed the ODF, USPTO legacy-entity, elife XML, wiki_duck and
-APS-plain-text work — `pftaps` is now byte-exact (§5). The PDF path now emits
-full layout `<location>` provenance (text, headings, tables, pictures, list
-items, code, and page-header/footer furniture), scored against a 16-fixture
-DocLang groundtruth with a ±2-grid-unit geometry tolerance — **63% mean** (§3,
-`PDF_CONFORMANCE.md`).
+This effort was tracked as
+[issue #32](https://github.com/docling-project/docling.rs/issues/32) — **closed,
+both targets met** (non-PDF ≥90%: 91%; PDF ≥50%: 63% at ±2). Its children
+(#38–#41, #44, all closed) landed the ODF, USPTO legacy-entity, elife XML,
+wiki_duck and APS-plain-text work — `pftaps` is byte-exact (§5). The PDF path
+emits full layout `<location>` provenance (text, headings, tables, pictures,
+list items, code, and page-header/footer furniture), scored against a
+16-fixture DocLang groundtruth with a ±2-grid-unit geometry tolerance —
+**63% mean** (§3, `PDF_CONFORMANCE.md`); the residual is model-level
+(TableFormer OTSL structure, layout classification — the closed-as-model-level
+blockers of `PDF_CONFORMANCE.md`), not serialization.
 
 ---
 
@@ -161,14 +164,15 @@ DocLang groundtruth with a ±2-grid-unit geometry tolerance — **63% mean** (§
   archives (`scripts/conformance/dclx_conformance.sh`): **≈91% mean similarity over
   the 134-fixture non-PDF corpus** (issue #32's ≥90% target) — csv/asciidoc/email
   exact, uspto/docx/pptx/jats in the mid-to-high 90s, md/odf/latex low 90s,
-  xlsx/html/webvtt in the 80s (full table in §2). The format-by-format gaps are
+  xlsx/html/webvtt in the 80s (full table in §2). The format-by-format work was
   tracked as [issue #32](https://github.com/docling-project/docling.rs/issues/32) and its
-  children (#38–#41, #44). This is an **output** format; a DocLang *input* backend is
-  still out of scope (§5). For **PDF**, where the reference `<location>` geometry
-  comes from docling's own layout run, the metric is scored with a ±2-grid-unit
-  geometry tolerance (text/structure still byte-exact): **52% exact · 63% at ±2**
-  (issue #32 target ≥50%); the remaining gap is model-level (TableFormer/layout/
-  reading order), not serialization — see [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md).
+  children (#38–#41, #44) — all closed, targets met. This is an **output** format;
+  a DocLang *input* backend is still out of scope (§5). For **PDF**, where the
+  reference `<location>` geometry comes from docling's own layout run, the metric
+  is scored with a ±2-grid-unit geometry tolerance (text/structure still
+  byte-exact): **52% exact · 63% at ±2** (against the ≥50% target); the remaining
+  gap is model-level (TableFormer/layout/reading order), not serialization — see
+  [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md).
 
 - **JSON** rebuilds docling's full `body`-tree-of-`$ref`s model from the `Node`
   tree (texts/groups/tables/pictures, labels, list grouping, table grids,
@@ -230,9 +234,10 @@ These are deliberate or unavoidable divergences, not bugs.
      docling-parse's line sanitizer (`dp_lines.rs`): 3-pass corner-distance
      contraction with gap-proportional space insertion, `enforce_same_font`,
      ligature recomposition, loose-box geometry. Plus docling's markdown escaping,
-     typographic-punctuation normalization, wrap dehyphenation,
-     paragraph-continuation merging, band-aware two-column reading order, and
-     false-picture / page-number layout fixes. The parser is now the **sole** text
+     docling-parse's typographic-punctuation table (every curly quote → `'`),
+     wrap dehyphenation, paragraph-continuation merging, docling's rule-based
+     reading-order predictor with cluster cells joined in docling-parse index
+     order, and false-picture / page-number layout fixes. The parser is now the **sole** text
      source — pdfium does only page rasterisation + link annotations. Its per-word
      cells reproduce docling-parse's `word_cells` byte-for-byte (377/377 on
      `2305-pg9`), which is what TableFormer matches against; a char-frequency

--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -185,7 +185,9 @@ suppression** (empty low-confidence margin boxes on text pages), and
 ## Remaining blockers (model-level)
 
 These yield smaller or uncertain gains than the text-layer work already shipped.
-Each is tracked as its own issue:
+The issues that tracked them (#60–#63) are **closed**: everything
+heuristic-level in them landed, and what remains below is the documented
+model-level (or by-design) residual each issue closed with:
 
 1. **TableFormer structure on complex tables**
    ([#60](https://github.com/docling-project/docling.rs/issues/60)). The

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -41,6 +41,11 @@ ensure_docling() {
   uv pip install --quiet --python "$PYBIN" "$DOCLING_PKG" >&2
   # The msword backend imports these unconditionally (image rendering + OMML→LaTeX).
   uv pip install --quiet --python "$PYBIN" pypdfium2 pylatexenc >&2
+  # The OpenDocument backend needs odfdo; the `docling` meta package does not
+  # forward docling-slim's `format-opendocument` extra, so install it directly —
+  # without it the ODF conversions raise ImportError and conformance.sh silently
+  # falls back to the committed groundtruth instead of measuring live docling.
+  uv pip install --quiet --python "$PYBIN" "docling-slim[format-opendocument]" >&2
   if ! "$PYBIN" -c "import docling.backend.html_backend" >/dev/null 2>&1; then
     echo "error: docling still not importable after install" >&2
     return 1

--- a/scripts/conformance/docling_convert.py
+++ b/scripts/conformance/docling_convert.py
@@ -18,9 +18,17 @@ Usage:
 If no output path is given, Markdown is written to stdout.
 """
 
+import mimetypes
 import re
 import sys
 from pathlib import Path
+
+# Minimal containers ship no /etc/mime.types, so Python's mimetypes registry
+# doesn't know epub and docling's InputDocument rejects the file with a
+# validation error — which conformance.sh then silently masks by falling back
+# to the committed groundtruth. Register it explicitly so the live-docling
+# reference is always the one measured.
+mimetypes.add_type("application/epub+zip", ".epub")
 
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument


### PR DESCRIPTION
Replace the qualitative statuses with numbers from scripts/conformance/conformance.sh against live published docling 2.112: DOCX 24/26 exact (drawingml 8, textbox 40 diff lines), EPUB 0/1 (39 diff lines, the HTML inline residual), native ODF 2/6 exact, JATS 3/4 exact (eLife plain-text route 252), USPTO 1/5 exact / 2/5 ws-normalized on the sources live docling converts (its APS-text Markdown export is empty where ours emits the text dump; the .dclx matches byte-exactly), LaTeX 0/2 but within 2/9 diff lines. XBRL is marked as measured against the committed groundtruth: live docling needs arelle.

Two silent-fallback fixes in the harness so these numbers stay honest: register application/epub+zip in Python's mimetypes registry (minimal containers ship no /etc/mime.types, so docling rejected .epub and the script fell back to groundtruth), and install
docling-slim[format-opendocument] into the compare venv (the docling meta package does not forward the extra; without odfdo every ODF conversion fell back the same way).


Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT