### PR TITLE
feat(node): async + streaming Markdown on the warm Pipeline (#66)

### DIFF
--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -159,12 +159,22 @@ import { Pipeline } from 'docling.rs'
 
 const pipeline = new Pipeline({ strict: true })
 for (const path of pdfPaths) {
-  const { content } = pipeline.convertFile(path, { to: 'markdown' }) // warm models
+  const { content } = await pipeline.convertFileAsync(path, { to: 'json' }) // warm models, off the event loop
+}
+
+// Or stream a PDF's Markdown as pages finish converting:
+for await (const chunk of pipeline.streamFileMarkdown('paper.pdf')) {
+  process.stdout.write(chunk)
 }
 ```
 
-`Pipeline` handles `pdf` and `image` inputs (the ML pipeline) and is synchronous
-— reuse one instance behind a job queue.
+`Pipeline` handles `pdf` and `image` inputs (the ML pipeline). The sync
+`convertFile` / `convert` block the event loop; the `*Async` variants run on the
+libuv thread pool, and `streamFileMarkdown` yields Markdown chunks in document
+order as pages finish. Conversions on one instance run one at a time (the
+models are mutable sessions) — overlapping `*Async` calls queue in submission
+order, so batch throughput comes from keeping the models warm, not from
+parallel calls.
 
 ### Images
 
@@ -199,7 +209,8 @@ JSON output always embeds extracted images as data URIs.
 | `checkDependencies(options?)` | `DependencyStatus` | Report which PDF/image deps are present. |
 
 `Pipeline` is the reusable warm PDF/image converter: `new Pipeline(converterOptions)`
-then `convertFile` / `convert`.
+then `convertFile` / `convert` / `convertFileAsync` / `convertAsync` /
+`convertFileStreaming` / `streamFileMarkdown`.
 
 `DocumentConverter` is the reusable form: `new DocumentConverter(converterOptions)`
 then `convert` / `convertFile` / `convertFileAsync` / `convertAsync` /

--- a/crates/docling-node/examples/pdf-pipeline.mjs
+++ b/crates/docling-node/examples/pdf-pipeline.mjs
@@ -19,10 +19,17 @@ console.log('deps:', checkDependencies())
 const res = await convertFileAsync(file, { to: 'markdown' })
 console.log(res.content.slice(0, 500))
 
-// For MANY PDFs, reuse a warm Pipeline so the models load once instead of per call:
+// For MANY PDFs, reuse a warm Pipeline so the models load once instead of per
+// call. The *Async variants run off the event loop (calls on one instance
+// queue — the models are mutable sessions):
 const pipeline = new Pipeline({ strict: true })
 for (const path of process.argv.slice(2)) {
-  const r = pipeline.convertFile(path, { to: 'json' })
+  const r = await pipeline.convertFileAsync(path, { to: 'json' })
   const doc = JSON.parse(r.content)
   console.log(`${path}: ${doc.texts.length} text nodes, ${doc.tables.length} tables`)
+}
+
+// Stream a PDF's Markdown through the warm pipeline as pages finish converting:
+for await (const chunk of pipeline.streamFileMarkdown(file)) {
+  process.stdout.write(chunk)
 }

--- a/crates/docling-node/index.d.ts
+++ b/crates/docling-node/index.d.ts
@@ -37,15 +37,40 @@ export declare class DocumentConverter {
   convertFileStreaming(path: string, callback: StreamCallback, options?: OutputOptions | null): void
 }
 
+/** Output options for {@link Pipeline.streamFileMarkdown} (streamable modes only). */
+export interface PipelineStreamOptions {
+  imageMode?: 'placeholder' | 'embedded'
+  artifactsDir?: string
+}
+
 /**
  * A reusable PDF/image pipeline that keeps the ONNX models loaded across calls.
  * Use instead of the per-call functions when converting many PDFs/images — the
  * one-shot path reloads every model each call. Handles `pdf` and `image` inputs.
+ *
+ * The `*Async` variants run the conversion off the event loop; overlapping
+ * calls on one instance queue (the models are mutable sessions), so batch
+ * throughput comes from keeping the models warm, not from parallel calls.
  */
 export declare class Pipeline {
   constructor(options?: ConverterOptions | null)
   convertFile(path: string, options?: OutputOptions | null): ConvertResult
   convert(input: ConvertInput, options?: OutputOptions | null): ConvertResult
+  /** Async (Promise) file conversion on the warm pipeline, off the event loop. */
+  convertFileAsync(path: string, options?: OutputOptions | null): Promise<ConvertResult>
+  /** Async (Promise) bytes conversion on the warm pipeline, off the event loop. */
+  convertAsync(input: ConvertInput, options?: OutputOptions | null): Promise<ConvertResult>
+  /** Callback-form streaming (prefer {@link Pipeline.streamFileMarkdown}). */
+  convertFileStreaming(path: string, callback: StreamCallback, options?: OutputOptions | null): void
+  /**
+   * Stream a PDF's Markdown in chunks through the warm pipeline, in document
+   * order, as pages finish converting (an image arrives as a single chunk).
+   * Concatenating the chunks reproduces the buffered Markdown byte-for-byte.
+   */
+  streamFileMarkdown(
+    filePath: string,
+    options?: PipelineStreamOptions,
+  ): AsyncGenerator<string, void, unknown>
 }
 
 // --- dependency provisioning (PDF/image ML pipeline) -----------------------

--- a/crates/docling-node/index.js
+++ b/crates/docling-node/index.js
@@ -5,7 +5,8 @@
 //   1. dependency guards — converting a PDF/image/METS input throws a clear
 //      error unless the ML models + pdfium are on disk (see
 //      scripts/download_dependencies.sh);
-//   2. a `streamFileMarkdown` async generator over Markdown chunks.
+//   2. `streamFileMarkdown` async generators over Markdown chunks (module-level
+//      and on the warm `Pipeline`).
 //
 // Works in Node.js and Bun (Bun implements N-API).
 
@@ -21,6 +22,48 @@ function mlFormatOf(name, format) {
     return native.formatFromName(`x.${String(format).replace(/^\./, '')}`) || String(format)
   }
   return native.formatFromName(name || '') || ''
+}
+
+// Bridge a native (err, chunk) streaming callback into an async generator.
+// `start` receives the callback and kicks off the native conversion. Chunks
+// are delivered on the event loop (via a threadsafe function); a null chunk
+// ends the stream, a non-null err ends it with a throw.
+async function* chunkStream(start) {
+  const queue = []
+  let done = false
+  let failure = null
+  let notify = null
+  const wake = () => {
+    if (notify) {
+      const n = notify
+      notify = null
+      n()
+    }
+  }
+
+  start((err, chunk) => {
+    if (err) {
+      failure = err
+      done = true
+    } else if (chunk === null || chunk === undefined) {
+      done = true
+    } else {
+      queue.push(chunk)
+    }
+    wake()
+  })
+
+  while (true) {
+    if (queue.length > 0) {
+      yield queue.shift()
+      continue
+    }
+    if (failure) throw failure
+    if (done) return
+    await new Promise((resolve) => {
+      notify = resolve
+    })
+  }
 }
 
 // --- guarded one-shot functions --------------------------------------------
@@ -94,6 +137,41 @@ class Pipeline {
     assertMlReady(mlFormatOf(input && input.name, input && input.format))
     return this._inner.convert(input, options)
   }
+
+  // async so a guard failure surfaces as a rejected promise, not a sync throw.
+  async convertFileAsync(path, options) {
+    assertMlReady(mlFormatOf(path))
+    return this._inner.convertFileAsync(path, options)
+  }
+
+  async convertAsync(input, options) {
+    assertMlReady(mlFormatOf(input && input.name, input && input.format))
+    return this._inner.convertAsync(input, options)
+  }
+
+  convertFileStreaming(path, callback, options) {
+    assertMlReady(mlFormatOf(path))
+    return this._inner.convertFileStreaming(path, callback, options)
+  }
+
+  /**
+   * Stream a PDF's Markdown in chunks through the warm pipeline, in document
+   * order, as pages finish converting (an image arrives as a single chunk).
+   * Same contract as the module-level `streamFileMarkdown`, but reusing this
+   * instance's loaded models — no per-call model reload.
+   *
+   * @param {string} filePath
+   * @param {object} [options] output options (`imageMode`: `placeholder` or
+   *   `embedded`; `referenced` is rejected)
+   * @returns {AsyncGenerator<string, void, unknown>}
+   */
+  async *streamFileMarkdown(filePath, options = {}) {
+    assertMlReady(mlFormatOf(filePath))
+    const { imageMode, artifactsDir } = options
+    yield* chunkStream((callback) =>
+      this._inner.convertFileStreaming(filePath, callback, { imageMode, artifactsDir }),
+    )
+  }
 }
 
 // --- streaming --------------------------------------------------------------
@@ -113,49 +191,9 @@ async function* streamFileMarkdown(filePath, options = {}) {
   assertMlReady(mlFormatOf(filePath))
   const { strict, fetchImages, allowedFormats, imageMode, artifactsDir } = options
   const converter = new native.DocumentConverter({ strict, fetchImages, allowedFormats })
-
-  // Bridge the native (err, chunk) callback into an async generator. Chunks are
-  // delivered on the event loop (via a threadsafe function); a null chunk ends
-  // the stream, a non-null err ends it with a throw.
-  const queue = []
-  let done = false
-  let failure = null
-  let notify = null
-  const wake = () => {
-    if (notify) {
-      const n = notify
-      notify = null
-      n()
-    }
-  }
-
-  converter.convertFileStreaming(
-    filePath,
-    (err, chunk) => {
-      if (err) {
-        failure = err
-        done = true
-      } else if (chunk === null || chunk === undefined) {
-        done = true
-      } else {
-        queue.push(chunk)
-      }
-      wake()
-    },
-    { imageMode, artifactsDir },
+  yield* chunkStream((callback) =>
+    converter.convertFileStreaming(filePath, callback, { imageMode, artifactsDir }),
   )
-
-  while (true) {
-    if (queue.length > 0) {
-      yield queue.shift()
-      continue
-    }
-    if (failure) throw failure
-    if (done) return
-    await new Promise((resolve) => {
-      notify = resolve
-    })
-  }
 }
 
 // --- exports (explicit, so ESM named imports work in Node and Bun) ----------

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -12,7 +12,7 @@
 //! - the [`DocumentConverter`] class, which holds converter config so it can be
 //!   reused across many documents.
 
-use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -20,7 +20,7 @@ use napi_derive::napi;
 
 use docling::{
     ConversionStatus, DoclingDocument, DocumentConverter as RsConverter, ImageMode, InputFormat,
-    Pipeline as RsPipeline, SourceDocument,
+    MarkdownStreamer, Pipeline as RsPipeline, SourceDocument,
 };
 
 // ---------------------------------------------------------------------------
@@ -542,10 +542,11 @@ impl DocumentConverter {
 /// for a sequence of documents (e.g. behind a job queue).
 #[napi]
 pub struct Pipeline {
-    // RefCell: the Rust pipeline needs `&mut` to convert (models are mutable
-    // sessions), but napi hands us `&self`. A Pipeline is bound to the JS thread,
-    // so single-threaded interior mutability is sound here.
-    inner: RefCell<RsPipeline>,
+    // Arc<Mutex>: the Rust pipeline needs `&mut` to convert (models are mutable
+    // sessions), and the async / streaming paths run it off the JS thread. The
+    // mutex serializes conversions on one instance — concurrent `*Async` calls
+    // queue rather than reload models.
+    inner: Arc<Mutex<RsPipeline>>,
     strict: bool,
 }
 
@@ -557,7 +558,7 @@ impl Pipeline {
     pub fn new(options: Option<ConverterOptions>) -> Result<Self> {
         let strict = options.and_then(|o| o.strict).unwrap_or(false);
         Ok(Self {
-            inner: RefCell::new(RsPipeline::new().map_err(convert_err)?),
+            inner: Arc::new(Mutex::new(RsPipeline::new().map_err(convert_err)?)),
             strict,
         })
     }
@@ -569,8 +570,9 @@ impl Pipeline {
         path: String,
         options: Option<OutputOptions>,
     ) -> Result<ConvertResult> {
+        let cfg = output_config(options, self.strict)?;
         let source = SourceDocument::from_file(&path).map_err(convert_err)?;
-        self.run(source, options)
+        Ok(run_pipeline(&self.inner, source, &cfg, self.strict)?.into_js())
     }
 
     /// Convert PDF or image bytes, reusing the warm models.
@@ -580,42 +582,240 @@ impl Pipeline {
         input: ConvertInput,
         options: Option<OutputOptions>,
     ) -> Result<ConvertResult> {
+        let cfg = self.output_cfg(options)?;
         let source = source_from_input(input)?;
-        self.run(source, options)
+        Ok(run_pipeline(&self.inner, source, &cfg, self.strict)?.into_js())
+    }
+
+    /// Async (Promise-returning) file conversion on the warm pipeline. The
+    /// CPU-bound work runs on the libuv thread pool, keeping the event loop
+    /// free; calls on the same instance run one at a time (the models are
+    /// mutable sessions), so overlapping Promises queue in submission order.
+    #[napi(ts_return_type = "Promise<ConvertResult>")]
+    pub fn convert_file_async(
+        &self,
+        path: String,
+        options: Option<OutputOptions>,
+    ) -> Result<AsyncTask<PipelineFileTask>> {
+        let cfg = self.output_cfg(options)?;
+        Ok(AsyncTask::new(PipelineFileTask {
+            pipe: Arc::clone(&self.inner),
+            strict: self.strict,
+            path,
+            cfg,
+        }))
+    }
+
+    /// Async (Promise-returning) bytes conversion on the warm pipeline.
+    #[napi(ts_return_type = "Promise<ConvertResult>")]
+    pub fn convert_async(
+        &self,
+        input: ConvertInput,
+        options: Option<OutputOptions>,
+    ) -> Result<AsyncTask<PipelineBytesTask>> {
+        let cfg = self.output_cfg(options)?;
+        let source = source_from_input(input)?;
+        Ok(AsyncTask::new(PipelineBytesTask {
+            pipe: Arc::clone(&self.inner),
+            strict: self.strict,
+            source: Some(source),
+            cfg,
+        }))
+    }
+
+    /// Stream a PDF's Markdown in chunks through the warm pipeline, in document
+    /// order, as pages finish converting (an image converts in one step and
+    /// arrives as a single chunk).
+    ///
+    /// `callback` is invoked as `(err, chunk)`: once per Markdown chunk with
+    /// `chunk` a string, once with `chunk === null` at the end, or once with a
+    /// non-null `err` on failure. Only `placeholder` / `embedded` image modes
+    /// stream; `referenced` is rejected. Prefer the `streamFileMarkdown`
+    /// async-generator wrapper in JS over calling this directly.
+    #[napi]
+    pub fn convert_file_streaming(
+        &self,
+        path: String,
+        callback: ThreadsafeFunction<Option<String>, ErrorStrategy::CalleeHandled>,
+        options: Option<OutputOptions>,
+    ) -> Result<()> {
+        let cfg = self.output_cfg(options)?;
+        if cfg.image_mode == ImageMode::Referenced {
+            return Err(Error::new(
+                Status::InvalidArg,
+                "streaming supports the 'placeholder' and 'embedded' image modes; \
+                 'referenced' needs the buffered convertFile / convertFileAsync",
+            ));
+        }
+        let pipe = Arc::clone(&self.inner);
+        let strict = self.strict;
+        // The background thread owns the conversion and pushes each chunk
+        // through the threadsafe function (which marshals back to the JS loop).
+        std::thread::spawn(move || {
+            stream_pipeline(&pipe, &path, &cfg, strict, &callback);
+        });
+        Ok(())
     }
 }
 
 impl Pipeline {
-    fn run(&self, source: SourceDocument, options: Option<OutputOptions>) -> Result<ConvertResult> {
-        let cfg = output_config(options, self.strict)?;
-        let mut pipe = self.inner.borrow_mut();
-        let mut doc = match source.format {
-            InputFormat::Pdf => pipe
-                .convert(&source.bytes, None, &source.name)
-                .map_err(convert_err)?,
-            InputFormat::Image => pipe
-                .convert_image(&source.bytes, &source.name)
-                .map_err(convert_err)?,
-            other => {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    format!(
-                        "Pipeline handles pdf and image inputs (the ML pipeline); got '{}'. \
-                         Use convertFile / convert for other formats.",
-                        other.as_str()
-                    ),
-                ))
-            }
-        };
-        doc.strict_markdown = self.strict;
-        Ok(render_doc(
-            doc,
-            &cfg,
-            source.name,
-            source.format.as_str().to_string(),
-            "success".to_string(),
+    fn output_cfg(&self, options: Option<OutputOptions>) -> Result<ConvertConfig> {
+        output_config(options, self.strict)
+    }
+}
+
+/// Lock the pipeline and run one buffered conversion. Free of napi/JS handle
+/// types, so the async tasks call it from the libuv pool.
+fn run_pipeline(
+    pipe: &Mutex<RsPipeline>,
+    source: SourceDocument,
+    cfg: &ConvertConfig,
+    strict: bool,
+) -> Result<RawResult> {
+    let mut pipe = pipe.lock().map_err(|_| {
+        Error::new(
+            Status::GenericFailure,
+            "pipeline poisoned by an earlier panic",
         )
-        .into_js())
+    })?;
+    let mut doc = match source.format {
+        InputFormat::Pdf => pipe
+            .convert(&source.bytes, None, &source.name)
+            .map_err(convert_err)?,
+        InputFormat::Image => pipe
+            .convert_image(&source.bytes, &source.name)
+            .map_err(convert_err)?,
+        other => {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "Pipeline handles pdf and image inputs (the ML pipeline); got '{}'. \
+                     Use convertFile / convert for other formats.",
+                    other.as_str()
+                ),
+            ))
+        }
+    };
+    doc.strict_markdown = strict;
+    Ok(render_doc(
+        doc,
+        cfg,
+        source.name,
+        source.format.as_str().to_string(),
+        "success".to_string(),
+    ))
+}
+
+/// The streaming producer body: convert through the warm pipeline and push
+/// Markdown chunks through the threadsafe callback. PDF streams page by page
+/// (each page's Markdown emitted in order as it finishes); an image converts in
+/// one step and streams as a single chunk through the same interface.
+fn stream_pipeline(
+    pipe: &Mutex<RsPipeline>,
+    path: &str,
+    cfg: &ConvertConfig,
+    strict: bool,
+    callback: &ThreadsafeFunction<Option<String>, ErrorStrategy::CalleeHandled>,
+) {
+    let fail = |e: Error| {
+        callback.call(Err(e), ThreadsafeFunctionCallMode::NonBlocking);
+    };
+    let source = match SourceDocument::from_file(path).map_err(convert_err) {
+        Ok(s) => s,
+        Err(e) => return fail(e),
+    };
+    let mut pipe = match pipe.lock() {
+        Ok(p) => p,
+        Err(_) => {
+            return fail(Error::new(
+                Status::GenericFailure,
+                "pipeline poisoned by an earlier panic",
+            ))
+        }
+    };
+    // The PDF pipeline builds its document from `DoclingDocument::new` defaults,
+    // so tables use the padded GitHub serializer (compact_tables = false),
+    // matching the buffered path.
+    let mut streamer = MarkdownStreamer::new(strict, cfg.image_mode, false);
+    let emit_chunk = |chunk: String| {
+        if !chunk.is_empty() {
+            callback.call(Ok(Some(chunk)), ThreadsafeFunctionCallMode::NonBlocking);
+        }
+    };
+    match source.format {
+        InputFormat::Pdf => {
+            let result =
+                pipe.convert_streaming(&source.bytes, None, &source.name, |nodes, links| {
+                    emit_chunk(streamer.push(&nodes, &links));
+                    Ok(())
+                });
+            if let Err(e) = result {
+                return fail(convert_err(e));
+            }
+        }
+        InputFormat::Image => match pipe.convert_image(&source.bytes, &source.name) {
+            Ok(doc) => emit_chunk(streamer.push(&doc.nodes, &doc.links)),
+            Err(e) => return fail(convert_err(e)),
+        },
+        other => {
+            return fail(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "Pipeline handles pdf and image inputs (the ML pipeline); got '{}'. \
+                     Use DocumentConverter.convertFileStreaming for other formats.",
+                    other.as_str()
+                ),
+            ))
+        }
+    }
+    emit_chunk(streamer.finish());
+    // End-of-stream sentinel.
+    callback.call(Ok(None), ThreadsafeFunctionCallMode::NonBlocking);
+}
+
+pub struct PipelineFileTask {
+    pipe: Arc<Mutex<RsPipeline>>,
+    strict: bool,
+    path: String,
+    cfg: ConvertConfig,
+}
+
+impl Task for PipelineFileTask {
+    type Output = RawResult;
+    type JsValue = ConvertResult;
+
+    fn compute(&mut self) -> Result<RawResult> {
+        let source = SourceDocument::from_file(&self.path).map_err(convert_err)?;
+        run_pipeline(&self.pipe, source, &self.cfg, self.strict)
+    }
+
+    fn resolve(&mut self, _env: Env, output: RawResult) -> Result<ConvertResult> {
+        Ok(output.into_js())
+    }
+}
+
+pub struct PipelineBytesTask {
+    pipe: Arc<Mutex<RsPipeline>>,
+    strict: bool,
+    // `Option` so `compute` can take ownership of the (non-Copy) source.
+    source: Option<SourceDocument>,
+    cfg: ConvertConfig,
+}
+
+impl Task for PipelineBytesTask {
+    type Output = RawResult;
+    type JsValue = ConvertResult;
+
+    fn compute(&mut self) -> Result<RawResult> {
+        let source = self
+            .source
+            .take()
+            .ok_or_else(|| Error::new(Status::GenericFailure, "conversion task reused"))?;
+        run_pipeline(&self.pipe, source, &self.cfg, self.strict)
+    }
+
+    fn resolve(&mut self, _env: Env, output: RawResult) -> Result<ConvertResult> {
+        Ok(output.into_js())
     }
 }
 

--- a/crates/docling-node/test/smoke.mjs
+++ b/crates/docling-node/test/smoke.mjs
@@ -115,6 +115,16 @@ async function main() {
       const pipe = new Pipeline()
       assert.throws(() => pipe.convertFile('x.pdf'), /download_dependencies\.sh/)
     })
+
+    await check('Pipeline convertFileAsync rejects (not a sync throw)', async () => {
+      const pipe = new Pipeline()
+      await assert.rejects(pipe.convertFileAsync('x.pdf'), /download_dependencies\.sh/)
+    })
+
+    await check('Pipeline streamFileMarkdown rejects on iteration', async () => {
+      const pipe = new Pipeline()
+      await assert.rejects(pipe.streamFileMarkdown('x.pdf').next(), /download_dependencies\.sh/)
+    })
   } else {
     console.log('  --  ML deps installed; skipping guard checks')
   }
@@ -146,6 +156,58 @@ async function main() {
     assert.equal(streamed, convertFile(file).content)
     assert.ok(streamed.length > 0)
   })
+
+  // Warm-pipeline async + streaming, only when the ML deps are on disk (they
+  // are in the repo dev environment; a fresh CI checkout skips these).
+  if (depsInstalled) {
+    const pdf = new URL('../../../tests/data/pdf/sources/code_and_formula.pdf', import.meta.url)
+      .pathname
+    const { existsSync } = await import('node:fs')
+    if (existsSync(pdf)) {
+      const pipe = new Pipeline()
+
+      await check('Pipeline convertFileAsync resolves with the buffered output', async () => {
+        const buffered = pipe.convertFile(pdf)
+        const res = await pipe.convertFileAsync(pdf)
+        assert.equal(res.status, 'success')
+        assert.equal(res.content, buffered.content)
+      })
+
+      await check('Pipeline convertFileAsync to JSON', async () => {
+        const res = await pipe.convertFileAsync(pdf, { to: 'json' })
+        assert.equal(JSON.parse(res.content).schema_name, 'DoclingDocument')
+      })
+
+      await check('Pipeline convertAsync (bytes) matches convertFileAsync', async () => {
+        const { readFileSync } = await import('node:fs')
+        const res = await pipe.convertAsync({ name: 'doc.pdf', data: readFileSync(pdf) })
+        assert.equal(res.content, (await pipe.convertFileAsync(pdf)).content)
+      })
+
+      await check('Pipeline streamFileMarkdown reproduces the buffered Markdown', async () => {
+        let streamed = ''
+        for await (const chunk of pipe.streamFileMarkdown(pdf)) {
+          streamed += chunk
+        }
+        assert.equal(streamed, pipe.convertFile(pdf).content)
+        assert.ok(streamed.length > 0)
+      })
+
+      await check('Pipeline streamFileMarkdown rejects referenced image mode', async () => {
+        await assert.rejects(
+          pipe.streamFileMarkdown(pdf, { imageMode: 'referenced' }).next(),
+          /placeholder.*embedded|referenced/,
+        )
+      })
+
+      await check('overlapping Pipeline async calls both resolve', async () => {
+        const [a, b] = await Promise.all([pipe.convertFileAsync(pdf), pipe.convertFileAsync(pdf)])
+        assert.equal(a.content, b.content)
+      })
+    } else {
+      console.log('  --  PDF fixture not found; skipping warm-pipeline checks')
+    }
+  }
 
   console.log(`\n${passed} checks passed`)
 }

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -823,3 +823,17 @@ pub fn convert_pages_with_options(
         .no_ocr(no_ocr)
         .process_pages(pages, name)
 }
+
+#[cfg(test)]
+mod send_check {
+    /// The Node bindings (`docling-node`) run a shared [`super::Pipeline`] on
+    /// libuv worker threads (`Arc<Mutex<Pipeline>>`), which is only sound while
+    /// `Pipeline: Send` holds — this fails to compile if a non-`Send` field
+    /// (e.g. an `Rc` or a raw pdfium handle) ever lands in the pipeline.
+    fn assert_send<T: Send>() {}
+
+    #[test]
+    fn pipeline_is_send() {
+        assert_send::<super::Pipeline>();
+    }
+}


### PR DESCRIPTION
The warm PDF/image Pipeline in docling-node was synchronous-only: converting on it blocked the event loop, and the only streaming path (DocumentConverter/ streamFileMarkdown) rebuilt the pipeline - reloading every ONNX model - per call. Closes docling-project/docling.rs#66:

- Pipeline.convertFileAsync / Pipeline.convertAsync: Promise-returning conversion on the libuv thread pool. The pipeline moved from RefCell to Arc<Mutex>, so the mutable model sessions are reachable off the JS thread; overlapping calls on one instance queue in submission order instead of reloading models
- Pipeline.convertFileStreaming + the Pipeline.streamFileMarkdown async generator: PDF pages stream their Markdown in document order as they finish converting (an image arrives as one chunk); concatenating the chunks reproduces the buffered output byte-for-byte. placeholder/embedded image modes only - referenced needs the buffered artifact side-channel
- the (err, chunk) -> async-generator bridge is factored into a shared chunkStream helper used by both the module-level and the Pipeline generators
- docling-pdf gains a compile-time send_check test documenting that Pipeline: Send is what makes the Arc<Mutex> handoff sound
- index.d.ts types, README, pdf-pipeline example updated; smoke test grows guard checks (async rejection, streaming rejection) plus warm-pipeline checks against a real PDF (async == buffered bytes, streaming == buffered bytes, referenced-mode rejection, overlapping Promises) that run when the ML deps are present


Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT