### PR TITLE
fix(pypi): resolve release version from the workspace like npm-publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,10 +11,11 @@
 # repair itself) and uploaded with `pypa/gh-action-pypi-publish`.
 #
 # Trigger: manual only (workflow_dispatch), mirroring npm-publish.yml. By default
-# it builds the checked-out ref at the version already declared in
-# crates/docling-py/pyproject.toml; pass `version` (or a release `tag`) to
-# override. Run it from the Actions tab (or `gh workflow run pypi-publish.yml`,
-# optionally `-f version=0.16.0`).
+# it builds the checked-out ref at the current workspace version (the root
+# Cargo.toml — same source npm-publish.yml uses), so the PyPI version tracks the
+# crates automatically; pass `version` (or a release `tag`) to override. Run it
+# from the Actions tab (or `gh workflow run pypi-publish.yml`, optionally
+# `-f version=0.16.0`).
 #
 # No secrets: publishing uses PyPI Trusted Publishing (OIDC), like
 # docling-core's pypi.yml. This requires a one-time setup on PyPI — add a trusted
@@ -37,7 +38,7 @@ on:
         required: false
         default: ""
       version:
-        description: "Override the PyPI version (e.g. 0.16.0). Blank = tag, or the version in pyproject.toml."
+        description: "Override the PyPI version (e.g. 0.16.0). Blank = tag, or workspace version from the root Cargo.toml."
         required: false
         default: ""
 

--- a/crates/docling-py/Cargo.toml
+++ b/crates/docling-py/Cargo.toml
@@ -10,7 +10,10 @@
 # Build/test locally per this crate's README.md.
 [package]
 name = "docling-py"
-version = "0.15.1"
+# Fallback for local builds only — pyproject.toml's [project].version is what
+# maturin ships, and CI (pypi-publish.yml) patches that from the workspace
+# version at publish time.
+version = "0.34.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/docling-project/docling.rs"

--- a/crates/docling-py/pyproject.toml
+++ b/crates/docling-py/pyproject.toml
@@ -8,7 +8,9 @@ build-backend = "maturin"
 
 [project]
 name = "docling-rs"
-version = "0.15.1"
+# Fallback for local maturin builds — pypi-publish.yml overwrites this with the
+# workspace version (root Cargo.toml) on every release.
+version = "0.34.0"
 description = "Rust port of docling (docling.rs): convert PDF/DOCX/HTML/... to Markdown or docling JSON. Python bindings."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
pypi-publish.yml fell back to the version hardcoded in pyproject.toml, so every default-input run shipped 0.15.1. Mirror npm-publish.yml's chain - explicit version input, else the release tag, else the workspace version from the root Cargo.toml - and always patch [project].version before the sdist build so wheels inherit it. The versions left in docling-py's Cargo.toml/pyproject.toml are now just local-build fallbacks (synced to 0.34.0, commented as such).
