### PR TITLE
fix(pypi): actually fall back to the workspace version in Resolve ver…

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -58,21 +58,23 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      # Version override: patch [project].version in pyproject.toml before the
-      # sdist is built so every wheel (built from the sdist) inherits it. No
-      # override → keep the version already declared in the file.
+      # Version resolution mirrors npm-publish.yml: explicit `version` input,
+      # else the release `tag`, else the workspace version from the root
+      # Cargo.toml (NOT pyproject.toml — the version committed there is a
+      # local-build fallback that release.sh never bumps). The resolved version
+      # is always patched into [project].version before the sdist is built so
+      # every wheel (built from the sdist) inherits it.
       - name: Resolve version
         shell: bash
         working-directory: crates/docling-py
         run: |
           v="${{ inputs.version }}"
           if [ -z "$v" ] && [ -n "${{ inputs.tag }}" ]; then v="${{ inputs.tag }}"; v="${v#v}"; fi
-          if [ -n "$v" ]; then
-            sed -i.bak -E "0,/^version = \".*\"/s//version = \"$v\"/" pyproject.toml && rm -f pyproject.toml.bak
-            echo "Building docling-rs $v"
-          else
-            echo "Building docling-rs $(grep -m1 '^version = ' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/') (from pyproject.toml)"
+          if [ -z "$v" ]; then
+            v="$(grep -m1 '^version = ' ../../Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
           fi
+          sed -i.bak -E "0,/^version = \".*\"/s//version = \"$v\"/" pyproject.toml && rm -f pyproject.toml.bak
+          echo "Building docling-rs $v"
 
       - uses: actions/setup-python@v5
         with:

--- a/crates/docling-py/Cargo.toml
+++ b/crates/docling-py/Cargo.toml
@@ -13,7 +13,7 @@ name = "docling-py"
 # Fallback for local builds only — pyproject.toml's [project].version is what
 # maturin ships, and CI (pypi-publish.yml) patches that from the workspace
 # version at publish time.
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/docling-project/docling.rs"

--- a/crates/docling-py/pyproject.toml
+++ b/crates/docling-py/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "maturin"
 name = "docling-rs"
 # Fallback for local maturin builds — pypi-publish.yml overwrites this with the
 # workspace version (root Cargo.toml) on every release.
-version = "0.34.0"
+version = "0.35.0"
 description = "Rust port of docling (docling.rs): convert PDF/DOCX/HTML/... to Markdown or docling JSON. Python bindings."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
…sion

08853a3 documented the version chain (input -> tag -> workspace root Cargo.toml, like npm-publish.yml) but only updated the comments - the Resolve version step still kept pyproject.toml's committed version on blank-input runs, which is a local-build fallback release.sh never bumps. That is how the v0.35.0 release shipped crates at 0.35.0 while a default-input pypi run built 0.34.0 again.

Implement the chain for real: blank version + blank tag now reads the workspace version from the root Cargo.toml and always patches [project].version before the sdist build. Also sync the committed local-build fallbacks in docling-py's Cargo.toml/pyproject.toml to 0.35.0.


Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT