### PR TITLE
feat: optional enrichment models — picture classification + CodeFormula (#76)

### DIFF
--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -87,6 +87,22 @@ jobs:
         continue-on-error: true
         run: python scripts/install/quantize_models.py tableformer-decoder
 
+      # --- CodeFormula VLM (optional — the enrichment models are opt-in) ---
+      # CodeFormulaV2 (Idefics3/SmolVLM-class, Apache-2.0) exported to the
+      # three-graph ONNX set the Rust `--enrich-code`/`--enrich-formula`
+      # passes run; the export script verifies the graphs argmax-identical to
+      # transformers.generate before writing them.
+      - name: Install CodeFormula export deps
+        continue-on-error: true
+        id: cf-deps
+        run: pip install "transformers>=4.46" onnxruntime pillow huggingface_hub
+
+      - name: Export CodeFormula
+        if: steps.cf-deps.outcome == 'success'
+        continue-on-error: true
+        id: cf-export
+        run: python scripts/install/export_code_formula.py models/code_formula
+
       # --- pdfium + OCR + chunk tokenizer (re-hosted third-party assets) ---
       # The tokenizer is all-MiniLM-L6-v2's tokenizer.json (Apache-2.0), the
       # default docling's HybridChunker counts tokens with; re-hosted so the
@@ -103,6 +119,10 @@ jobs:
             "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/ppocr_keys_v1.txt"
           curl -fsSL -o third-party/chunk_tokenizer.json \
             "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
+          # DocumentFigureClassifier-v2.5 (Apache-2.0) ships its ONNX graph
+          # upstream — re-hosted as-is for --enrich-picture-classes.
+          curl -fsSL -o third-party/picture_classifier.onnx \
+            "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx"
 
       # --- stage + publish -------------------------------------------------
       # GitHub release assets can't contain "/", so tableformer/*.onnx is
@@ -132,6 +152,13 @@ jobs:
           stage models/tableformer/decoder_kv.onnx decoder_kv.onnx
           stage models/tableformer/decoder_kv_int8.onnx decoder_kv_int8.onnx
           stage models/tableformer/bbox.onnx bbox.onnx
+          stage third-party/picture_classifier.onnx picture_classifier.onnx
+          # CodeFormula graphs flatten with a cf_ prefix (release assets are
+          # one flat namespace).
+          stage models/code_formula/vision.onnx cf_vision.onnx
+          stage models/code_formula/embed.onnx cf_embed.onnx
+          stage models/code_formula/decoder_kv.onnx cf_decoder_kv.onnx
+          stage models/code_formula/tokenizer.json cf_tokenizer.json
           echo "staged:"
           ls -la release-assets/
 

--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -103,6 +103,11 @@ jobs:
         id: cf-export
         run: python scripts/install/export_code_formula.py models/code_formula
 
+      - name: Quantize CodeFormula decoder (dynamic INT8)
+        if: steps.cf-export.outcome == 'success' && steps.quant-deps.outcome == 'success'
+        continue-on-error: true
+        run: python scripts/install/quantize_models.py code-formula-decoder
+
       # --- pdfium + OCR + chunk tokenizer (re-hosted third-party assets) ---
       # The tokenizer is all-MiniLM-L6-v2's tokenizer.json (Apache-2.0), the
       # default docling's HybridChunker counts tokens with; re-hosted so the
@@ -158,6 +163,7 @@ jobs:
           stage models/code_formula/vision.onnx cf_vision.onnx
           stage models/code_formula/embed.onnx cf_embed.onnx
           stage models/code_formula/decoder_kv.onnx cf_decoder_kv.onnx
+          stage models/code_formula/decoder_kv_int8.onnx cf_decoder_kv_int8.onnx
           stage models/code_formula/tokenizer.json cf_tokenizer.json
           echo "staged:"
           ls -la release-assets/

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,7 +28,7 @@ phased plan is kept at the end as history.)
 | **Performance** | PDF ML pipeline **4.3× faster warm / 4.7× end-to-end** than Python docling at 2.3–2.6× less peak RAM (INT8 + SIMD, conformance-validated); declarative formats 20–60× warm, ~60× less RAM; details + methodology in [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md) |
 | **Models** | docling's own checkpoints (layout heron, TableFormer, PP-OCRv3, Whisper tiny), format-converted to ONNX by `scripts/export_*.py` — no retraining; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
 | **Tracking upstream** | See [§9](#9-keeping-up-with-upstream-docling): conformance is measured against the *latest published* docling on demand, so an upstream release that changes output surfaces as a concrete per-fixture diff |
-| **Not ported (by design)** | VLM pipelines and enrichment models (§5); inline formatting is baked into text rather than structured fields (§4) |
+| **Not ported (by design)** | VLM full-page pipelines (§5); inline formatting is baked into text rather than structured fields (§4). The optional enrichment models (picture classification, code, formulas) **are** ported — opt-in `do_picture_classification` / `do_code_enrichment` / `do_formula_enrichment`, ONNX like the rest of the stack |
 
 ---
 
@@ -314,10 +314,15 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
 
 **Out of scope by design:**
 
-- **VLM pipelines** (SmolDocling / remote VLM) and **enrichment models** (picture
-  classification, formula understanding, code understanding). Model-bound; out of
+- **VLM full-page pipelines** (SmolDocling / remote VLM). Model-bound; out of
   scope for the discriminative port. (**Audio/ASR is now done** — see §2; the
-  only container gap is AVI, which symphonia cannot demux.)
+  only container gap is AVI, which symphonia cannot demux. The **enrichment
+  models are now done** too: DocumentFigureClassifier-v2.5 for
+  `do_picture_classification` and CodeFormulaV2 — an Idefics3-class VLM,
+  exported to a three-graph ONNX set with a KV-cached greedy decode verified
+  token-identical to `transformers.generate` — for `do_code_enrichment` /
+  `do_formula_enrichment`; opt-in flags on the converter/CLI/Python bindings,
+  conformance-checked by `scripts/conformance/enrich_conformance.sh`.)
 
 **Now migrated (previously listed here):**
 
@@ -627,7 +632,7 @@ compares against the docling version actually installed, so it won't flag
 differences that are really just a stale committed corpus.
 
 What this cannot absorb automatically: upstream features that need new model
-*architectures* (VLM pipeline, enrichment models — out of scope per §5) and
+*architectures* (the VLM full-page pipeline — out of scope per §5) and
 places where the document models intentionally differ (§4). Those are
 documented divergences rather than drift.
 

--- a/MODELS_NOTICE.md
+++ b/MODELS_NOTICE.md
@@ -10,7 +10,7 @@ code (see [`LICENSE`](./LICENSE)) under their upstream terms:
 | RT-DETR layout model (`layout_heron.onnx`) | [`docling-project/docling-layout-heron`](https://huggingface.co/docling-project/docling-layout-heron) | Apache-2.0 |
 | TableFormer (`tableformer/{encoder,decoder,bbox}.onnx`) | [`docling-project/docling-models`](https://huggingface.co/docling-project/docling-models) (`model_artifacts/tableformer/accurate`) | CDLA-Permissive-2.0 / Apache-2.0 |
 | DocumentFigureClassifier (`picture_classifier.onnx`) | [`docling-project/DocumentFigureClassifier-v2.5`](https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5) (upstream's own ONNX, re-hosted unmodified) | Apache-2.0 |
-| CodeFormulaV2 (`cf_{vision,embed,decoder_kv}.onnx` + `cf_tokenizer.json`) | [`docling-project/CodeFormulaV2`](https://huggingface.co/docling-project/CodeFormulaV2) | Apache-2.0 |
+| CodeFormulaV2 (`cf_{vision,embed,decoder_kv}.onnx` + `cf_tokenizer.json`; `cf_decoder_kv_int8.onnx` is a post-training quantization of the same export) | [`docling-project/CodeFormulaV2`](https://huggingface.co/docling-project/CodeFormulaV2) | Apache-2.0 |
 
 `scripts/install/export_layout.py`, `scripts/install/export_tableformer.py` and
 `scripts/install/export_code_formula.py` do the conversion (PyTorch → ONNX via

--- a/MODELS_NOTICE.md
+++ b/MODELS_NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party model notice
 
-`docling.rs`'s PDF/image pipeline uses two ONNX graphs that are **format
+`docling.rs`'s PDF/image pipeline uses ONNX graphs that are **format
 conversions of docling-project's own PyTorch models**, not weights docling.rs
 trains or modifies. They're licensed separately from docling.rs's own MIT
 code (see [`LICENSE`](./LICENSE)) under their upstream terms:
@@ -9,10 +9,13 @@ code (see [`LICENSE`](./LICENSE)) under their upstream terms:
 |---|---|---|
 | RT-DETR layout model (`layout_heron.onnx`) | [`docling-project/docling-layout-heron`](https://huggingface.co/docling-project/docling-layout-heron) | Apache-2.0 |
 | TableFormer (`tableformer/{encoder,decoder,bbox}.onnx`) | [`docling-project/docling-models`](https://huggingface.co/docling-project/docling-models) (`model_artifacts/tableformer/accurate`) | CDLA-Permissive-2.0 / Apache-2.0 |
+| DocumentFigureClassifier (`picture_classifier.onnx`) | [`docling-project/DocumentFigureClassifier-v2.5`](https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5) (upstream's own ONNX, re-hosted unmodified) | Apache-2.0 |
+| CodeFormulaV2 (`cf_{vision,embed,decoder_kv}.onnx` + `cf_tokenizer.json`) | [`docling-project/CodeFormulaV2`](https://huggingface.co/docling-project/CodeFormulaV2) | Apache-2.0 |
 
-`scripts/install/export_layout.py` and `scripts/install/export_tableformer.py` do the
-conversion (PyTorch → ONNX via `torch.onnx.export`); no weights are retrained,
-fine-tuned, or otherwise altered. `.github/workflows/publish-models.yml` runs
+`scripts/install/export_layout.py`, `scripts/install/export_tableformer.py` and
+`scripts/install/export_code_formula.py` do the conversion (PyTorch → ONNX via
+`torch.onnx.export`); no weights are retrained, fine-tuned, or otherwise
+altered. `.github/workflows/publish-models.yml` runs
 that conversion (and re-hosts pdfium + the OCR model alongside it) and
 publishes everything as GitHub Release assets on this repo (tag `models-v1`),
 fetched by `scripts/install/download_dependencies.sh` — see that script and

--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -98,6 +98,29 @@ bounded by these, so raising it further is a model problem, not a serialization
 one: every laid-out block kind now carries provenance, so the ±2 figure sits at
 the geometry-ignored ceiling.
 
+## Enrichment models (opt-in)
+
+docling's optional enrichment stages are ported behind the same flags
+(`--enrich-picture-classes` / `--enrich-code` / `--enrich-formula`, docling's
+`do_picture_classification` / `do_code_enrichment` / `do_formula_enrichment`)
+and validated by `scripts/conformance/enrich_conformance.sh` against Python
+docling 2.112's output on the enrichment fixtures
+(`tests/data/pdf/groundtruth-enriched/`):
+
+| Fixture | Check | Result |
+|---|---|---|
+| code_and_formula.pdf | Markdown, `--enrich-code --enrich-formula` | **byte-exact** (CodeFormulaV2's code rewrite, `JavaScript` language, formula LaTeX) |
+| picture_classification.pdf | JSON classification annotation + meta | same class ranking; confidences match to ~3 decimals |
+
+The CodeFormulaV2 export (`scripts/install/export_code_formula.py`) verifies
+its three ONNX graphs' greedy decode **token-identical** to
+`transformers.generate` before writing them. The residual confidence drift on
+the classifier comes from the crops: docling re-renders each region through
+pdfium at the enrichment scale, while docling.rs resizes from the existing
+scale-2 page render — sub-pixel differences the classifier's softmax sees in
+the third decimal, and that the VLM's argmax decoding absorbs entirely on the
+fixtures.
+
 ## How the pipeline works
 
 pdfium extracts the glyph layer and renders each page to a bitmap; an ONNX stack

--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -114,7 +114,16 @@ docling 2.112's output on the enrichment fixtures
 
 The CodeFormulaV2 export (`scripts/install/export_code_formula.py`) verifies
 its three ONNX graphs' greedy decode **token-identical** to
-`transformers.generate` before writing them. The residual confidence drift on
+`transformers.generate` before writing them. Its decoder also ships as a
+dynamic INT8 quantization (`scripts/install/quantize_models.py
+code-formula-decoder`, ~655 → ~165 MB, 4× less decoder RAM) that is preferred
+automatically when present (`DOCLING_RS_FP32=1` opts out). Unlike the layout /
+TableFormer INT8 models it is *near*-exact rather than byte-exact: greedy VLM
+decoding has near-tie tokens that weight rounding can flip — on the fixture
+the only drift is one extra blank line in the code block, and per-channel /
+fp32-lm_head variants flip it identically, so the smaller per-tensor file is
+kept. The conformance script gates fp32 byte-exact and allows the int8 leg
+whitespace-only drift. The residual confidence drift on
 the classifier comes from the crops: docling re-renders each region through
 pdfium at the enrichment scale, while docling.rs resizes from the existing
 scale-2 page render — sub-pixel differences the classifier's softmax sees in

--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ curl -fsSL https://raw.githubusercontent.com/docling-project/docling.rs/master/s
 | TableFormer (optional) | `models/tableformer/{encoder,decoder,bbox}.onnx` (+ `.data` sidecars where the export needs them) |
 | Whisper tiny (audio/ASR; skip with `--no-asr`) | `models/asr/{encoder_model,decoder_model}.onnx`, `models/asr/vocab.json` (+ `added_tokens.json` for language selection) |
 | INT8 CPU models (optional; fetch with `--int8`) | `models/layout_heron_int8.onnx`, `models/tableformer/decoder_int8.onnx` |
+| DocumentFigureClassifier (picture classification) | `models/picture_classifier.onnx` |
+| CodeFormulaV2 (code/formula enrichment, ~1.3 GB; fetch with `--enrich`) | `models/code_formula/{vision,embed,decoder_kv}.onnx`, `models/code_formula/tokenizer.json` |
 
 Idempotent — safe to re-run; it skips files already on disk. Pass `--force` to
 re-fetch everything, or set `$DOCLING_RS_MODELS_URL` to fetch from a
@@ -409,6 +411,43 @@ come from Hugging Face (`$DOCLING_RS_ASR_MODELS_URL` overrides, or point
 `DOCLING_ASR_{ENCODER,DECODER,VOCAB}` at explicit files). pdfium is Linux x64
 only for now — other platforms, or building the models from source, need
 [`scripts/install/pdf_setup.sh`](#testing) instead.
+
+### Enrichment models (picture classification, code, formulas)
+
+docling's optional enrichment stages are ported behind the same opt-in flags
+(`PdfPipelineOptions.do_picture_classification` / `do_code_enrichment` /
+`do_formula_enrichment`):
+
+```bash
+docling-rs --enrich-picture-classes doc.pdf   # classify pictures (26 classes)
+docling-rs --enrich-code --enrich-formula doc.pdf
+```
+
+```rust
+let converter = DocumentConverter::new()
+    .do_picture_classification(true)
+    .do_code_enrichment(true)
+    .do_formula_enrichment(true);
+```
+
+* **Picture classification** — `docling-project/DocumentFigureClassifier-v2.5`
+  (EfficientNet, 26 figure classes: `bar_chart`, `logo`, `signature`, …). The
+  full prediction distribution lands on the JSON picture item as docling's
+  `classification` annotation + `meta.classification`; Markdown is unchanged.
+* **Code enrichment** — `docling-project/CodeFormulaV2` (an Idefics3/SmolVLM-
+  class VLM exported to ONNX by `scripts/install/export_code_formula.py`, its
+  greedy decode verified token-identical to `transformers.generate`). Rewrites
+  each code block from its ~120 dpi crop and fills the JSON `code_language`.
+* **Formula enrichment** — the same VLM decodes display formulas to LaTeX:
+  Markdown renders `$$…$$` instead of `<!-- formula-not-decoded -->`, and the
+  JSON formula item carries the LaTeX in `text` (raw glyphs stay in `orig`).
+
+Both models load lazily on the first matching region (a missing model warns
+once and skips that pass), and are shared pipeline-wide like TableFormer. The
+Python bindings take the same three `do_*` kwargs. Mind that CodeFormula is an
+autoregressive 256M-parameter VLM — expect seconds per code/formula region on
+CPU. `scripts/conformance/enrich_conformance.sh` checks the enriched output
+against Python docling's on the enrichment test PDFs.
 
 ### INT8 models (faster PDF conversion on CPU — the default)
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ curl -fsSL https://raw.githubusercontent.com/docling-project/docling.rs/master/s
 | PP-OCRv3 rec + dictionary | `models/ocr_rec.onnx`, `models/ppocr_keys_v1.txt` |
 | TableFormer (optional) | `models/tableformer/{encoder,decoder,bbox}.onnx` (+ `.data` sidecars where the export needs them) |
 | Whisper tiny (audio/ASR; skip with `--no-asr`) | `models/asr/{encoder_model,decoder_model}.onnx`, `models/asr/vocab.json` (+ `added_tokens.json` for language selection) |
-| INT8 CPU models (optional; fetch with `--int8`) | `models/layout_heron_int8.onnx`, `models/tableformer/decoder_int8.onnx` |
+| INT8 CPU models (optional; fetch with `--int8`) | `models/layout_heron_int8.onnx`, `models/tableformer/decoder_int8.onnx` (+ `models/code_formula/decoder_kv_int8.onnx` with `--enrich`) |
 | DocumentFigureClassifier (picture classification) | `models/picture_classifier.onnx` |
 | CodeFormulaV2 (code/formula enrichment, ~1.3 GB; fetch with `--enrich`) | `models/code_formula/{vision,embed,decoder_kv}.onnx`, `models/code_formula/tokenizer.json` |
 
@@ -446,7 +446,14 @@ Both models load lazily on the first matching region (a missing model warns
 once and skips that pass), and are shared pipeline-wide like TableFormer. The
 Python bindings take the same three `do_*` kwargs. Mind that CodeFormula is an
 autoregressive 256M-parameter VLM — expect seconds per code/formula region on
-CPU. `scripts/conformance/enrich_conformance.sh` checks the enriched output
+CPU. Its decoder also ships as dynamic INT8 (`decoder_kv_int8.onnx`, ~165 MB
+vs ~655 MB fp32 — 4× less decoder RAM) — fetched with `--enrich` and preferred
+automatically when present, like the other INT8 models. Unlike those, it is
+*near*-exact rather than byte-exact: greedy decoding has occasional near-tie
+tokens the weight rounding can flip (on the conformance fixture, one extra
+blank line inside the code block). `DOCLING_RS_FP32=1` opts back into the
+byte-exact fp32 decoder.
+`scripts/conformance/enrich_conformance.sh` checks the enriched output
 against Python docling's on the enrichment test PDFs.
 
 ### INT8 models (faster PDF conversion on CPU — the default)

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -3,7 +3,7 @@
 //! A stand-in for `docling.cli.main`; the full Typer-style CLI (batch mode,
 //! pipeline options) is a later phase.
 //!
-//! Usage: docling-rs [--strict] [--to md|json] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--use-web-browser] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --to md|json       output format (default: md). `json` emits docling-core's
 //!                      native DoclingDocument JSON (export_to_dict).
 //!   --images MODE      picture handling for Markdown (mirrors docling's
@@ -35,6 +35,19 @@
 //!                      from Rust) so stylesheet-driven `display:none` elements
 //!                      (e.g. a collapsed nav menu) are dropped before parsing.
 //!                      Requires building with `--features web-browser`.
+//!   --enrich-picture-classes
+//!                      classify each detected picture (PDF/image input) with the
+//!                      DocumentFigureClassifier model; the 26-class prediction
+//!                      distribution lands in the JSON picture item (docling's
+//!                      do_picture_classification). Needs
+//!                      models/picture_classifier.onnx.
+//!   --enrich-code      rewrite detected code blocks (and detect their language)
+//!                      with the CodeFormulaV2 VLM (docling's do_code_enrichment).
+//!                      Needs models/code_formula/. Slow on CPU: an autoregressive
+//!                      generation per code block.
+//!   --enrich-formula   decode display formulas to LaTeX with CodeFormulaV2
+//!                      (docling's do_formula_enrichment); Markdown then renders
+//!                      $$latex$$ instead of the formula placeholder comment.
 
 use std::io::{self, Write};
 use std::path::Path;
@@ -51,6 +64,9 @@ fn main() -> ExitCode {
     let mut no_table_former = false;
     let mut no_ocr = false;
     let mut use_web_browser = false;
+    let mut enrich_picture_classes = false;
+    let mut enrich_code = false;
+    let mut enrich_formula = false;
     let mut bench_warm: Option<usize> = None;
     let mut path: Option<String> = None;
     let mut args = std::env::args().skip(1);
@@ -62,6 +78,11 @@ fn main() -> ExitCode {
             "--no-table-former" => no_table_former = true,
             "--no-ocr" => no_ocr = true,
             "--use-web-browser" => use_web_browser = true,
+            // Opt-in enrichment models (docling CLI flag names): picture
+            // classification, code rewrite + language, formula LaTeX.
+            "--enrich-picture-classes" => enrich_picture_classes = true,
+            "--enrich-code" => enrich_code = true,
+            "--enrich-formula" => enrich_formula = true,
             "--to" => to = args.next().unwrap_or_default(),
             "--images" => images = args.next().unwrap_or_default(),
             // Hidden benchmarking aid: load the PDF/image pipeline once, then time
@@ -131,7 +152,10 @@ fn main() -> ExitCode {
         .fetch_images(fetch_images)
         .no_table_former(no_table_former)
         .no_ocr(no_ocr)
-        .use_web_browser(use_web_browser);
+        .use_web_browser(use_web_browser)
+        .do_picture_classification(enrich_picture_classes)
+        .do_code_enrichment(enrich_code)
+        .do_formula_enrichment(enrich_formula);
 
     // Stream Markdown by default: print each chunk as the converter produces it
     // (page by page for PDF). JSON needs the whole tree, and the referenced image

--- a/crates/docling-core/src/chunker.rs
+++ b/crates/docling-core/src/chunker.rs
@@ -458,6 +458,20 @@ impl Walker {
                     }],
                 );
             }
+            // An enriched display formula chunks like docling's formula item:
+            // the LaTeX is the chunk text.
+            Node::Formula { latex, .. } => {
+                let self_ref = self.alloc.text();
+                let body = format!("$${}$$", latex);
+                self.emit(
+                    body.clone(),
+                    vec![ChunkItem {
+                        self_ref,
+                        kind: ChunkItemKind::Text,
+                        text: body,
+                    }],
+                );
+            }
             Node::Code { text, .. } => {
                 let self_ref = self.alloc.text();
                 let body = format!("```\n{}\n```", unescape_text(text));

--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -774,8 +774,29 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
                 out.push(depth, "</text>".to_string());
                 *i += 1;
             }
-            Node::Code { language, text } => {
+            Node::Code {
+                language,
+                text,
+                orig: _,
+            } => {
                 emit_code(out, depth, language.as_deref(), text, None);
+                *i += 1;
+            }
+            // A CodeFormula-decoded display formula: a `<formula>` element like
+            // the inline-math one, with the layout location when present.
+            Node::Formula {
+                latex, location, ..
+            } => {
+                if let Some(loc) = location {
+                    out.push(depth, "<formula>".to_string());
+                    push_location(out, depth + 1, loc);
+                    if !latex.is_empty() {
+                        out.push(depth + 1, escape_text(latex));
+                    }
+                    out.push(depth, "</formula>".to_string());
+                } else {
+                    out.push(depth, format!("<formula>{}</formula>", escape_text(latex)));
+                }
                 *i += 1;
             }
             Node::PageFurniture {
@@ -801,7 +822,9 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
                 emit_table(out, depth, t);
                 *i += 1;
             }
-            Node::Picture { caption, image } => {
+            // Classifier predictions are JSON-only; DocLang keeps the plain
+            // `<picture>` shape.
+            Node::Picture { caption, image, .. } => {
                 emit_picture(out, depth, caption.as_deref(), image.as_ref(), None);
                 *i += 1;
             }
@@ -1286,7 +1309,7 @@ fn emit_furniture(out: &mut Out, depth: i32, layer: ContentLayer, inner: &Node) 
         // pixels (docling's referenced-asset conversion skips furniture, so the
         // image stays a base64 data URI), then a caption that carries its own
         // `<href>`/`<layer>` head when the caption is a link.
-        Node::Picture { caption, image } => {
+        Node::Picture { caption, image, .. } => {
             let caption = caption.as_deref().filter(|c| !c.trim().is_empty());
             out.push(depth, "<picture>".to_string());
             out.push(depth + 1, token.clone());
@@ -1426,7 +1449,7 @@ fn emit_located(out: &mut Out, depth: i32, location: &[u16; 4], inner: &Node) {
         Node::Paragraph { text } => {
             emit_text_element(out, depth, "text", "text", text, Some(location));
         }
-        Node::Picture { caption, image } => {
+        Node::Picture { caption, image, .. } => {
             emit_picture(
                 out,
                 depth,
@@ -1441,7 +1464,7 @@ fn emit_located(out: &mut Out, depth: i32, location: &[u16; 4], inner: &Node) {
             t.location = Some(*location);
             emit_table(out, depth, &t);
         }
-        Node::Code { language, text } => {
+        Node::Code { language, text, .. } => {
             emit_code(out, depth, language.as_deref(), text, Some(location));
         }
         // Other node kinds carry no location today — render them as-is.
@@ -1737,6 +1760,7 @@ mod tests {
         export_to_doclang(&[Node::Code {
             language: language.map(String::from),
             text: text.into(),
+            orig: None,
         }])
     }
 

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -88,6 +88,10 @@ pub enum Node {
     Code {
         language: Option<String>,
         text: String,
+        /// The original (pre-enrichment) text when the CodeFormula model
+        /// rewrote `text`: docling keeps the raw extraction in the JSON `orig`
+        /// field while `text` carries the model output. `None` → `orig == text`.
+        orig: Option<String>,
     },
     /// A table. The first row is treated as the header.
     Table(Table),
@@ -96,6 +100,21 @@ pub enum Node {
     Picture {
         caption: Option<String>,
         image: Option<PictureImage>,
+        /// DocumentPictureClassifier predictions (all classes, descending
+        /// confidence), when the picture-classification enrichment ran.
+        /// Serialized as docling's `classification` annotation + `meta` field
+        /// on the JSON picture item; Markdown/DocLang output is unaffected.
+        classification: Option<Vec<PictureClass>>,
+    },
+    /// A display-math formula item decoded by the CodeFormula enrichment:
+    /// `latex` is the model's LaTeX (no `$$` wrapping), `orig` the raw glyph
+    /// text extracted from the PDF. Markdown renders `$$latex$$`; JSON emits a
+    /// `formula` text item (docling's un-enriched pipeline instead emits a
+    /// placeholder paragraph — see the PDF assembler).
+    Formula {
+        latex: String,
+        orig: String,
+        location: Option<[u16; 4]>,
     },
     /// A chart (docling's `PictureItem` classified as a chart, carrying a
     /// `PictureTabularChartData` annotation). Markdown and JSON render it exactly
@@ -285,6 +304,15 @@ pub struct FieldItem {
     pub marker: Option<String>,
     pub key: Option<String>,
     pub value: Option<String>,
+}
+
+/// One DocumentPictureClassifier prediction — docling-core's
+/// `PictureClassificationClass` (`class_name` + `confidence`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PictureClass {
+    /// e.g. `bar_chart`, `logo`, `signature` (the classifier's 26-label set).
+    pub class_name: String,
+    pub confidence: f32,
 }
 
 /// An extracted picture's raw encoded bytes plus its mimetype and pixel size —

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -183,14 +183,30 @@ impl Builder {
                 let mark = if *checked { "- [x] " } else { "- [ ] " };
                 Some(self.add_text("text", &format!("{mark}{text}"), parent, json!({})))
             }
-            Node::Code { language, text } => Some(self.add_code(text, language.as_deref(), parent)),
+            Node::Code {
+                language,
+                text,
+                orig,
+            } => Some(self.add_code(text, language.as_deref(), orig.as_deref(), parent)),
+            // A CodeFormula-decoded display formula: `text` carries the LaTeX,
+            // `orig` the raw glyph extraction (docling's enriched shape).
+            Node::Formula { latex, orig, .. } => Some(self.add_formula_item(latex, orig, parent)),
             Node::Table(t) => Some(self.add_table(t, parent)),
-            Node::Picture { caption, image } => {
-                Some(self.add_picture(caption.as_deref(), image.as_ref(), parent))
-            }
+            Node::Picture {
+                caption,
+                image,
+                classification,
+            } => Some(self.add_picture(
+                caption.as_deref(),
+                image.as_ref(),
+                classification.as_deref(),
+                parent,
+            )),
             // A chart is a picture item in the JSON (its data table is
             // DocLang-only); no image payload.
-            Node::Chart { caption, .. } => Some(self.add_picture(caption.as_deref(), None, parent)),
+            Node::Chart { caption, .. } => {
+                Some(self.add_picture(caption.as_deref(), None, None, parent))
+            }
             // A DocLang-only node is omitted from the JSON body.
             Node::DoclangOnly(_) => None,
             Node::Group { label, children } => Some(self.add_group(label, children, parent)),
@@ -297,7 +313,31 @@ impl Builder {
         self_ref
     }
 
-    fn add_code(&mut self, text: &str, language: Option<&str>, parent: &str) -> String {
+    /// A CodeFormula-enriched display formula: `text` is the model's LaTeX
+    /// while `orig` keeps the raw glyph extraction (docling's enriched shape;
+    /// the plain [`Self::add_formula`] above sets both to the same string).
+    fn add_formula_item(&mut self, latex: &str, orig: &str, parent: &str) -> String {
+        let self_ref = format!("#/texts/{}", self.texts.len());
+        self.texts.push(json!({
+            "self_ref": self_ref,
+            "parent": { "$ref": parent },
+            "children": [],
+            "content_layer": "body",
+            "label": "formula",
+            "prov": [],
+            "orig": orig,
+            "text": latex,
+        }));
+        self_ref
+    }
+
+    fn add_code(
+        &mut self,
+        text: &str,
+        language: Option<&str>,
+        orig: Option<&str>,
+        parent: &str,
+    ) -> String {
         let self_ref = format!("#/texts/{}", self.texts.len());
         let raw = unescape_text(text);
         self.texts.push(json!({
@@ -307,7 +347,9 @@ impl Builder {
             "content_layer": "body",
             "label": "code",
             "prov": [],
-            "orig": raw,
+            // With code enrichment, `text` is the model's rewrite while `orig`
+            // keeps the raw extraction; otherwise both are the same string.
+            "orig": orig.map(unescape_text).unwrap_or_else(|| raw.clone()),
             "text": raw,
             "captions": [],
             "references": [],
@@ -455,6 +497,7 @@ impl Builder {
         &mut self,
         caption: Option<&str>,
         image: Option<&crate::PictureImage>,
+        classification: Option<&[crate::PictureClass]>,
         parent: &str,
     ) -> String {
         let self_ref = format!("#/pictures/{}", self.pictures.len());
@@ -464,18 +507,60 @@ impl Builder {
             let cap_ref = self.add_text("caption", cap, &self_ref, json!({}));
             captions.push(json!({ "$ref": cap_ref }));
         }
-        let mut item = json!({
-            "self_ref": self_ref,
-            "parent": { "$ref": parent },
-            "children": [],
-            "content_layer": "body",
-            "label": "picture",
-            "prov": [],
-            "captions": captions,
-            "references": [],
-            "footnotes": [],
-            "annotations": [],
-        });
+        // DocumentPictureClassifier predictions land twice, exactly like
+        // docling 2.x writes them: the (deprecated but still emitted)
+        // `classification` annotation and the newer `meta.classification`
+        // field (whose per-prediction key order differs — pydantic field
+        // order: confidence, created_by, class_name).
+        let annotations = match classification {
+            Some(classes) => json!([{
+                "kind": "classification",
+                "provenance": "DocumentPictureClassifier",
+                "predicted_classes": classes.iter().map(|c| json!({
+                    "class_name": c.class_name,
+                    "confidence": c.confidence as f64,
+                })).collect::<Vec<_>>(),
+            }]),
+            None => json!([]),
+        };
+        // `meta` sits between `content_layer` and `label` in docling's field
+        // order (and `preserve_order` keeps ours byte-compatible), so the item
+        // is built in one shot per shape rather than patched afterwards.
+        let mut item = match classification {
+            Some(classes) => json!({
+                "self_ref": self_ref,
+                "parent": { "$ref": parent },
+                "children": [],
+                "content_layer": "body",
+                "meta": {
+                    "classification": {
+                        "predictions": classes.iter().map(|c| json!({
+                            "confidence": c.confidence as f64,
+                            "created_by": "DocumentPictureClassifier",
+                            "class_name": c.class_name,
+                        })).collect::<Vec<_>>(),
+                    },
+                },
+                "label": "picture",
+                "prov": [],
+                "captions": captions,
+                "references": [],
+                "footnotes": [],
+                "annotations": annotations,
+            }),
+            None => json!({
+                "self_ref": self_ref,
+                "parent": { "$ref": parent },
+                "children": [],
+                "content_layer": "body",
+                "label": "picture",
+                "prov": [],
+                "captions": captions,
+                "references": [],
+                "footnotes": [],
+                "annotations": annotations,
+            }),
+        };
         // docling stores the extracted image as an `ImageRef` (data URI + size).
         if let Some(img) = image {
             item["image"] = json!({
@@ -633,6 +718,7 @@ mod tests {
                 height: 2,
                 data: b"foobar".to_vec(),
             }),
+            classification: None,
         });
         doc
     }

--- a/crates/docling-core/src/lib.rs
+++ b/crates/docling-core/src/lib.rs
@@ -21,7 +21,7 @@ mod markdown;
 pub use doclang::inline_runs_from_markdown;
 pub use document::{
     inline_paragraph_node, ContentLayer, DoclingDocument, FieldItem, InlineRun, ListItemDclx, Node,
-    PictureImage, Script, Table, TableStructure,
+    PictureClass, PictureImage, Script, Table, TableStructure,
 };
 pub use labels::DocItemLabel;
 pub use markdown::{ImageMode, MarkdownStreamer};

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -361,7 +361,7 @@ fn render_one(node: &Node, blocks: &mut Vec<String>, ctx: &mut Ctx) {
             let mark = if *checked { "- [x] " } else { "- [ ] " };
             blocks.push(strict_text(&format!("{mark}{text}"), ctx.strict));
         }
-        Node::Code { language, text } => {
+        Node::Code { language, text, .. } => {
             // Legacy docling never emits a language on the fence; strict keeps it.
             let lang = match language {
                 Some(l) if ctx.strict => l.as_str(),
@@ -369,13 +369,17 @@ fn render_one(node: &Node, blocks: &mut Vec<String>, ctx: &mut Ctx) {
             };
             blocks.push(format!("```{lang}\n{text}\n```"));
         }
+        // A CodeFormula-decoded display formula renders as docling's `$$…$$`
+        // (the un-enriched pipeline emits a placeholder paragraph instead).
+        Node::Formula { latex, .. } => blocks.push(format!("$${latex}$$")),
         Node::Table(table) => {
             let rendered = render_table(table, ctx.compact_tables);
             if !rendered.is_empty() {
                 blocks.push(rendered);
             }
         }
-        Node::Picture { caption, image } => {
+        // Classification predictions don't affect docling's Markdown output.
+        Node::Picture { caption, image, .. } => {
             if let Some(cap) = caption {
                 if !cap.is_empty() {
                     blocks.push(cap.clone());
@@ -860,6 +864,7 @@ mod tests {
         doc.push(Node::Code {
             language: Some("rust".into()),
             text: "let x = 1;".into(),
+            orig: None,
         });
         doc.push(Node::Table(Table {
             rows: vec![vec!["a".into(), "b".into()], vec!["1".into(), "2".into()]],
@@ -870,6 +875,7 @@ mod tests {
         doc.push(Node::Picture {
             caption: Some("Fig 1".into()),
             image: None,
+            classification: None,
         });
         doc.add_paragraph("Last paragraph.");
 

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -22,6 +22,10 @@ tar = "0.4"
 regex = "1.11"
 lopdf = "0.34"
 fast_image_resize = "5.1.4"
+# CodeFormula enrichment decodes its VLM output with the HF tokenizer
+# (models/code_formula/tokenizer.json) — same crate/features as docling-core's
+# chunking tokenizer.
+tokenizers = { version = "0.20", default-features = false, features = ["onig"] }
 
 [lib]
 name = "docling_pdf"

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -5,7 +5,8 @@
 //! assigned to its best-containing region, regions are ordered in reading order
 //! (two-column aware), and each becomes a typed node by its layout label.
 
-use docling_core::{Node, PictureImage, Table};
+use docling_core::{Node, PictureClass, PictureImage, Table};
+use image::RgbImage;
 
 use crate::layout::Region;
 use crate::pdfium_backend::{PdfPage, TextCell};
@@ -963,6 +964,80 @@ fn reconstruct_table(region: &Region, cells: &[TextCell]) -> Vec<Vec<String>> {
     grid
 }
 
+/// The union bbox of the text cells assigned to a region (same >50%-overlap
+/// rule as [`region_text`]), or `None` when no cell lands in it. docling's
+/// LayoutPostprocessor shrinks a regular cluster's bbox to its cells, and the
+/// enrichment crops are taken from that cell-tight box — cropping the raw
+/// detector box instead hands the VLM surrounding chrome (e.g. the `Listing N:`
+/// caption under a code block) that changes its output.
+pub fn region_cell_bbox(region: &Region, cells: &[TextCell]) -> Option<[f32; 4]> {
+    let mut bbox: Option<[f32; 4]> = None;
+    for c in cells {
+        let ca = area(c.l, c.t, c.r, c.b).max(1.0);
+        if inter(region, c.l, c.t, c.r, c.b) / ca <= 0.5 {
+            continue;
+        }
+        bbox = Some(match bbox {
+            None => [c.l, c.t, c.r, c.b],
+            Some([l, t, r, b]) => [l.min(c.l), t.min(c.t), r.max(c.r), b.max(c.b)],
+        });
+    }
+    bbox
+}
+
+/// One region's enrichment-model result, produced by the pipeline's opt-in
+/// passes (issue #76) and applied during assembly.
+#[derive(Debug, Clone)]
+pub enum Enrichment {
+    /// DocumentPictureClassifier predictions, descending confidence.
+    PictureClasses(Vec<PictureClass>),
+    /// CodeFormulaV2 output for a `code` region: the rewritten source text and
+    /// the `<_language_>` prefix (when the model emitted one).
+    Code {
+        language: Option<String>,
+        text: String,
+    },
+    /// CodeFormulaV2 output for a `formula` region: the decoded LaTeX.
+    Formula { latex: String },
+}
+
+/// Crop a region (page points, already expanded by the caller if needed) from
+/// the rendered page image and resize it to `target_scale` pixels per point —
+/// the enrichment-model equivalent of docling's
+/// `page.get_image(scale=…, cropbox=…)`, sourced from the existing
+/// [`crate::pdfium_backend::RENDER_SCALE`] render instead of a fresh pdfium
+/// pass (the page bitmap is already the exact docling render at scale 2).
+pub fn crop_region_scaled(page: &PdfPage, bbox: [f32; 4], target_scale: f32) -> Option<RgbImage> {
+    let s = page.scale;
+    let [l, t, r, b] = bbox;
+    let (iw, ih) = (page.image.width(), page.image.height());
+    let x = (l * s).max(0.0) as u32;
+    let y = (t * s).max(0.0) as u32;
+    if x >= iw || y >= ih {
+        return None;
+    }
+    let w = (((r - l.max(0.0)) * s) as u32).min(iw - x);
+    let h = (((b - t.max(0.0)) * s) as u32).min(ih - y);
+    if w == 0 || h == 0 {
+        return None;
+    }
+    let crop = image::imageops::crop_imm(&page.image, x, y, w, h).to_image();
+    // docling renders the crop at `target_scale` directly; from the scale-2
+    // page render that is a resize to the same pixel geometry
+    // (`round(width_points * scale)`, PIL's BICUBIC ≙ CatmullRom).
+    let tw = ((w as f32 / s) * target_scale).round().max(1.0) as u32;
+    let th = ((h as f32 / s) * target_scale).round().max(1.0) as u32;
+    if (tw, th) == (w, h) {
+        return Some(crop);
+    }
+    Some(image::imageops::resize(
+        &crop,
+        tw,
+        th,
+        image::imageops::FilterType::CatmullRom,
+    ))
+}
+
 /// Crop a layout region from the rendered page image and encode it as PNG (the
 /// figure bytes docling stores on a `PictureItem`). Region coordinates are page
 /// points; the image is rendered at `page.scale`.
@@ -1097,25 +1172,36 @@ pub fn assemble_page(
     page: &PdfPage,
     regions: Vec<Region>,
     table_rows: &[Option<Vec<Vec<String>>>],
+    enrichments: &[Option<Enrichment>],
 ) -> (Vec<Node>, Vec<(String, String)>) {
     let mut nodes: Vec<Node> = Vec::new();
     // Recover this page's hyperlinks (rendered only in strict Markdown).
     let links = resolve_link_anchors(page);
-    // Pair each region with its precomputed TableFormer grid (indexed by original
-    // order) and order by reading order together, so they stay aligned.
-    let mut items: Vec<(Region, Option<Vec<Vec<String>>>)> = regions
+    // Pair each region with its precomputed TableFormer grid and enrichment
+    // (indexed by original order) and order by reading order together, so they
+    // stay aligned.
+    type RegionItem = (Region, Option<Vec<Vec<String>>>, Option<Enrichment>);
+    let mut items: Vec<RegionItem> = regions
         .into_iter()
         .enumerate()
-        .map(|(i, r)| (r, table_rows.get(i).cloned().flatten()))
+        .map(|(i, r)| {
+            (
+                r,
+                table_rows.get(i).cloned().flatten(),
+                enrichments.get(i).cloned().flatten(),
+            )
+        })
         .collect();
     order_regions(&mut items, page.width, page.height, |it| &it.0);
     // Float a margin page number to the front of reading order (docling parity:
     // right_to_left_02's bottom `11` is its first item). Stable, so everything
     // else keeps its order; no-op on pages without such a region.
     let page_h = page.height;
-    items.sort_by_key(|(r, _)| !is_page_number(r, &page.cells, page_h));
-    let table_rows: Vec<Option<Vec<Vec<String>>>> = items.iter().map(|(_, t)| t.clone()).collect();
-    let regions: Vec<Region> = items.into_iter().map(|(r, _)| r).collect();
+    items.sort_by_key(|(r, _, _)| !is_page_number(r, &page.cells, page_h));
+    let table_rows: Vec<Option<Vec<Vec<String>>>> =
+        items.iter().map(|(_, t, _)| t.clone()).collect();
+    let enrichments: Vec<Option<Enrichment>> = items.iter().map(|(_, _, e)| e.clone()).collect();
+    let regions: Vec<Region> = items.into_iter().map(|(r, _, _)| r).collect();
     // docling emits a figure's caption *before* the image marker. Pair each
     // picture with the caption region nearest below it and consume that caption,
     // so it isn't also emitted in its own (lower) reading-order position.
@@ -1210,11 +1296,16 @@ pub fn assemble_page(
             let caption = caption_for[i]
                 .map(|ci| region_text(&regions[ci], &page.cells))
                 .filter(|t| !t.is_empty());
+            let classification = match &enrichments[i] {
+                Some(Enrichment::PictureClasses(classes)) => Some(classes.clone()),
+                _ => None,
+            };
             nodes.push(located(
                 loc,
                 Node::Picture {
                     caption,
                     image: crate::timing::timed("crop_region", || crop_region(page, region)),
+                    classification,
                 },
             ));
             continue;
@@ -1294,11 +1385,19 @@ pub fn assemble_page(
                     }),
                 ));
             }
-            // docling does not decode formulas in the standard pipeline; it emits
-            // a placeholder comment rather than the (garbled) raw glyph text.
-            "formula" => nodes.push(Node::Paragraph {
-                text: "<!-- formula-not-decoded -->".into(),
-            }),
+            // With formula enrichment the CodeFormula model decodes the region
+            // to LaTeX; otherwise docling emits a placeholder comment rather
+            // than the (garbled) raw glyph text.
+            "formula" => match &enrichments[i] {
+                Some(Enrichment::Formula { latex }) => nodes.push(Node::Formula {
+                    latex: latex.clone(),
+                    orig: text.clone(),
+                    location: Some(loc),
+                }),
+                _ => nodes.push(Node::Paragraph {
+                    text: "<!-- formula-not-decoded -->".into(),
+                }),
+            },
             // Code blocks: use the space-glyph-only grouping (monospace keeps its
             // source spacing) and emit a fenced block, preserving the line breaks
             // and indentation of the source (unlike prose, which reflows). pdfium
@@ -1313,13 +1412,35 @@ pub fn assemble_page(
                 } else {
                     code
                 };
-                nodes.push(located(
-                    loc,
-                    Node::Code {
+                // With code enrichment the CodeFormula model rewrites the block
+                // (and names its language); `orig` keeps the raw extraction in
+                // docling's shape — its parser has no line-preserving code
+                // path, so its `orig` is the same code with the lines joined
+                // by single spaces (indentation collapsed).
+                let node = match &enrichments[i] {
+                    Some(Enrichment::Code {
+                        language,
+                        text: enriched,
+                    }) => {
+                        let flat = code
+                            .lines()
+                            .map(str::trim)
+                            .filter(|l| !l.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        Node::Code {
+                            language: language.clone(),
+                            text: enriched.clone(),
+                            orig: Some(flat),
+                        }
+                    }
+                    _ => Node::Code {
                         language: None,
                         text: code,
+                        orig: None,
                     },
-                ));
+                };
+                nodes.push(located(loc, node));
                 // docling emits the `Listing N:` caption after the code block.
                 if let Some(ci) = code_caption_for[i] {
                     let cap = region_text(&regions[ci], &page.cells);
@@ -1751,6 +1872,7 @@ mod tests {
             Node::Picture {
                 caption: None,
                 image: None,
+                classification: None,
             },
             para("Fig. 1. a diagram"),
             para("the most common kind"),

--- a/crates/docling-pdf/src/enrich.rs
+++ b/crates/docling-pdf/src/enrich.rs
@@ -1,0 +1,573 @@
+//! Optional enrichment models (docling's `do_picture_classification` /
+//! `do_code_enrichment` / `do_formula_enrichment`, issue #76).
+//!
+//! * [`PictureClassifier`] — docling-project/DocumentFigureClassifier-v2.5, an
+//!   EfficientNet image classifier over 26 figure classes (bar_chart, logo,
+//!   signature, …). The HF repo ships the ONNX graph as-is; docling's ViT
+//!   preprocessing is 224×224 bilinear + rescale + normalize, and the raw
+//!   logits are softmaxed and sorted descending — the full distribution lands
+//!   on the picture item like docling's `PictureClassificationData`.
+//!
+//! * [`CodeFormula`] — docling-project/CodeFormulaV2, an Idefics3/SmolVLM-class
+//!   VLM that rewrites a code crop as clean source text prefixed with
+//!   `<_language_>`, or a formula crop as LaTeX. Exported to three graphs by
+//!   `scripts/install/export_code_formula.py` (vision tower+connector, token
+//!   embeddings, and a KV-cached Llama decoder step verified argmax-identical
+//!   to `transformers.generate`); this module ports the Idefics3 preprocessing
+//!   (longest-edge 2048 resize → multiple-of-512 resize → 512×512 tiling + a
+//!   squashed global tile), the tiled `<image>` prompt, and the greedy decode.
+
+use image::RgbImage;
+use ort::session::Session;
+use ort::value::Tensor;
+use tokenizers::Tokenizer;
+
+use docling_core::PictureClass;
+
+/// docling crops enrichment inputs at `images_scale` pixels per point:
+/// 2.0 for the picture classifier, 1.67 (≈120 dpi) for CodeFormula.
+pub const CLASSIFIER_SCALE: f32 = 2.0;
+pub const CODE_FORMULA_SCALE: f32 = 1.67;
+/// CodeFormula expands the region box by 18% of its size on every side
+/// (docling's `expansion_factor`) before cropping.
+pub const CODE_FORMULA_EXPANSION: f32 = 0.18;
+
+// ---------------------------------------------------------------------------
+// Picture classifier
+// ---------------------------------------------------------------------------
+
+/// The 26 classes of DocumentFigureClassifier-v2.5, indexed by model class id
+/// (`config.json` `id2label`).
+const PICTURE_CLASSES: [&str; 26] = [
+    "logo",
+    "photograph",
+    "icon",
+    "engineering_drawing",
+    "line_chart",
+    "bar_chart",
+    "other",
+    "table",
+    "flow_chart",
+    "screenshot_from_computer",
+    "signature",
+    "screenshot_from_manual",
+    "geographical_map",
+    "pie_chart",
+    "page_thumbnail",
+    "stamp",
+    "music",
+    "calendar",
+    "qr_code",
+    "bar_code",
+    "full_page_image",
+    "scatter_plot",
+    "chemistry_structure",
+    "topographical_map",
+    "crossword_puzzle",
+    "box_plot",
+];
+
+const CLASSIFIER_SIDE: u32 = 224;
+/// ViT preprocessing constants from the model's `preprocessor_config.json`.
+const CLASSIFIER_MEAN: [f32; 3] = [0.485, 0.456, 0.406];
+const CLASSIFIER_STD: [f32; 3] = [0.478_539_44, 0.473_286_4, 0.474_341_63];
+
+pub struct PictureClassifier {
+    session: Session,
+}
+
+impl PictureClassifier {
+    /// Load from `DOCLING_PICTURE_CLASSIFIER_ONNX` /
+    /// `models/picture_classifier(_int8).onnx`. `None` when the graph is
+    /// absent — the caller warns once and skips classification.
+    pub fn load_with(intra: usize) -> Option<Self> {
+        let path = crate::model_path(
+            "DOCLING_PICTURE_CLASSIFIER_ONNX",
+            "models/picture_classifier.onnx",
+            "models/picture_classifier_int8.onnx",
+        );
+        if !std::path::Path::new(&path).exists() {
+            eprintln!(
+                "docling-pdf: picture classifier model not found ({path}); \
+                 picture classification skipped. Run scripts/install/download_dependencies.sh."
+            );
+            return None;
+        }
+        let session = Session::builder()
+            .ok()?
+            .with_intra_threads(intra)
+            .ok()?
+            .commit_from_file(&path)
+            .map_err(|e| eprintln!("docling-pdf: picture classifier load {path}: {e}"))
+            .ok()?;
+        Some(Self { session })
+    }
+
+    /// Classify one picture crop: the full 26-class distribution, descending
+    /// confidence (docling attaches all predicted classes, not just the top).
+    pub fn classify(&mut self, crop: &RgbImage) -> Result<Vec<PictureClass>, String> {
+        let resized = image::imageops::resize(
+            crop,
+            CLASSIFIER_SIDE,
+            CLASSIFIER_SIDE,
+            image::imageops::FilterType::Triangle,
+        );
+        let n = (CLASSIFIER_SIDE * CLASSIFIER_SIDE) as usize;
+        let mut data = vec![0f32; 3 * n];
+        for (i, px) in resized.pixels().enumerate() {
+            for c in 0..3 {
+                data[c * n + i] = (px[c] as f32 / 255.0 - CLASSIFIER_MEAN[c]) / CLASSIFIER_STD[c];
+            }
+        }
+        let input = Tensor::from_array((
+            [
+                1usize,
+                3,
+                CLASSIFIER_SIDE as usize,
+                CLASSIFIER_SIDE as usize,
+            ],
+            data,
+        ))
+        .map_err(|e| format!("picture classifier: input: {e}"))?;
+        let outputs = self
+            .session
+            .run(ort::inputs!["input" => input])
+            .map_err(|e| format!("picture classifier: inference: {e}"))?;
+        let (_, logits) = outputs[0]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("picture classifier: output: {e}"))?;
+        // softmax → (class, prob) sorted descending, like docling's engine.
+        let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let exp: Vec<f32> = logits.iter().map(|&v| (v - max).exp()).collect();
+        let sum: f32 = exp.iter().sum();
+        let mut preds: Vec<PictureClass> = exp
+            .iter()
+            .enumerate()
+            .map(|(i, &e)| PictureClass {
+                class_name: PICTURE_CLASSES.get(i).copied().unwrap_or("other").into(),
+                confidence: e / sum,
+            })
+            .collect();
+        preds.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
+        Ok(preds)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodeFormula (Idefics3 VLM)
+// ---------------------------------------------------------------------------
+
+/// Which prompt the model gets for a region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeFormulaKind {
+    Code,
+    Formula,
+}
+
+/// Idefics3 processor constants (CodeFormulaV2's `preprocessor_config.json` /
+/// tokenizer). The token ids are fixed by the checkpoint's tokenizer.json.
+const TILE: u32 = 512; // max_image_size.longest_edge
+const LONGEST_EDGE: u32 = 2048; // size.longest_edge
+const MAX_IMAGE_SIZE: u32 = 4096; // transformers' hard upper bound
+const IMAGE_SEQ_LEN: usize = 64; // visual tokens per tile
+const IMAGE_TOKEN_ID: i64 = 100270; // <image>
+const EOS_ID: i64 = 100338; // <end_of_utterance>
+const MODEL_MAX_LEN: usize = 8192;
+const HIDDEN: usize = 576;
+const N_LAYERS: usize = 30;
+const N_KV: usize = 3;
+const HEAD_DIM: usize = 64;
+
+pub struct CodeFormula {
+    vision: Session,
+    embed: Session,
+    decoder: Session,
+    tokenizer: Tokenizer,
+}
+
+impl CodeFormula {
+    /// Load the three graphs + tokenizer from `DOCLING_CODE_FORMULA_DIR`
+    /// (default `models/code_formula/`). `None` when absent, with a one-time
+    /// warning from the caller's slot.
+    pub fn load_with(intra: usize) -> Option<Self> {
+        let dir = std::env::var("DOCLING_CODE_FORMULA_DIR")
+            .unwrap_or_else(|_| crate::resolve_asset("models/code_formula"));
+        let file = |name: &str| format!("{dir}/{name}");
+        // INT8 variants take priority when present, like the other models.
+        let graph = |base: &str| {
+            let int8 = file(&format!("{base}_int8.onnx"));
+            if !crate::fp32_forced() && std::path::Path::new(&int8).exists() {
+                int8
+            } else {
+                file(&format!("{base}.onnx"))
+            }
+        };
+        for f in [&graph("vision"), &graph("embed"), &graph("decoder_kv")] {
+            if !std::path::Path::new(f.as_str()).exists() {
+                eprintln!(
+                    "docling-pdf: CodeFormula model not found ({f}); code/formula \
+                     enrichment skipped. Run scripts/install/download_dependencies.sh."
+                );
+                return None;
+            }
+        }
+        let load = |p: String| {
+            Session::builder()
+                .ok()?
+                .with_intra_threads(intra)
+                .ok()?
+                .commit_from_file(&p)
+                .map_err(|e| eprintln!("docling-pdf: CodeFormula load {p}: {e}"))
+                .ok()
+        };
+        let tokenizer = Tokenizer::from_file(file("tokenizer.json"))
+            .map_err(|e| eprintln!("docling-pdf: CodeFormula tokenizer: {e}"))
+            .ok()?;
+        Some(Self {
+            vision: load(graph("vision"))?,
+            embed: load(graph("embed"))?,
+            decoder: load(graph("decoder_kv"))?,
+            tokenizer,
+        })
+    }
+
+    /// Run the VLM on a code/formula crop and return the post-processed text
+    /// (still carrying the `<_language_>` prefix for code — see
+    /// [`extract_code_language`]).
+    pub fn predict(&mut self, crop: &RgbImage, kind: CodeFormulaKind) -> Result<String, String> {
+        // Debug aid: dump each crop the VLM sees (compare against docling's
+        // `prepare_element` output when chasing a generation divergence).
+        if let Ok(dir) = std::env::var("DOCLING_RS_ENRICH_DEBUG") {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static N: AtomicUsize = AtomicUsize::new(0);
+            let n = N.fetch_add(1, Ordering::Relaxed);
+            let _ = crop.save(format!("{dir}/rs_crop_{n}.png"));
+        }
+        let (tiles, rows, cols) = preprocess_idefics3(crop);
+        let n_tiles = tiles.len() / (3 * (TILE * TILE) as usize);
+
+        // Vision tower over the tile batch → [T, 64, 576]. (Scoped: the
+        // session outputs hold a mutable borrow of the session until dropped.)
+        let feats: Vec<f32> = {
+            let input = Tensor::from_array(([n_tiles, 3, TILE as usize, TILE as usize], tiles))
+                .map_err(|e| format!("code-formula: vision input: {e}"))?;
+            let outputs = self
+                .vision
+                .run(ort::inputs!["pixel_values" => input])
+                .map_err(|e| format!("code-formula: vision: {e}"))?;
+            let (_, feats) = outputs["image_features"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| format!("code-formula: vision output: {e}"))?;
+            feats.to_vec()
+        };
+
+        // Prompt: the chat template with the single <image> expanded into the
+        // per-tile token grid (transformers' Idefics3Processor layout).
+        let query = match kind {
+            CodeFormulaKind::Code => "<code>",
+            CodeFormulaKind::Formula => "<formula>",
+        };
+        let prompt = format!(
+            "<|start_of_role|>user:{}{query}<end_of_utterance>\nassistant:",
+            image_prompt(rows, cols)
+        );
+        let enc = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| format!("code-formula: tokenize: {e}"))?;
+        let ids: Vec<i64> = enc.get_ids().iter().map(|&v| v as i64).collect();
+        let seq = ids.len();
+
+        // Token embeddings, then scatter the visual tokens into the <image>
+        // positions (Idefics3's inputs_merger).
+        let mut embeds = self.embed_ids(&ids)?;
+        let image_positions: Vec<usize> = ids
+            .iter()
+            .enumerate()
+            .filter(|(_, &t)| t == IMAGE_TOKEN_ID)
+            .map(|(i, _)| i)
+            .collect();
+        if image_positions.len() != n_tiles * IMAGE_SEQ_LEN {
+            return Err(format!(
+                "code-formula: {} image tokens for {} tiles",
+                image_positions.len(),
+                n_tiles
+            ));
+        }
+        for (v, &pos) in image_positions.iter().enumerate() {
+            embeds[pos * HIDDEN..(pos + 1) * HIDDEN]
+                .copy_from_slice(&feats[v * HIDDEN..(v + 1) * HIDDEN]);
+        }
+
+        // Greedy KV-cache decode until <end_of_utterance> (docling caps
+        // generation at the model's 8192 context). The K/V caches stay owned
+        // `ort` values fed straight back into the next step — never extracted
+        // or copied (they grow every step, so per-step copies would be
+        // O(steps²) float traffic; same pattern as the TableFormer decoder).
+        // ort's array constructors reject a 0-length dim, so the zero-`past`
+        // first-step tensors go through the session allocator.
+        let mut cache: Option<(ort::value::DynValue, ort::value::DynValue)> = None;
+        let empty = {
+            let mk = || {
+                Tensor::<f32>::new(
+                    self.decoder.allocator(),
+                    [N_LAYERS, 1, N_KV, 0usize, HEAD_DIM],
+                )
+                .map_err(|e| format!("code-formula: empty kv cache: {e}"))
+            };
+            (mk()?, mk()?)
+        };
+        let mut past_len = 0usize;
+        let mut positions: Vec<i64> = (0..seq as i64).collect();
+        let mut x = embeds;
+        let mut x_seq = seq;
+        let mut out_ids: Vec<u32> = Vec::new();
+        let max_new = MODEL_MAX_LEN.saturating_sub(seq);
+        for _ in 0..max_new {
+            let embeds_t = Tensor::from_array(([1usize, x_seq, HIDDEN], x))
+                .map_err(|e| format!("code-formula: embeds: {e}"))?;
+            let pos_t = Tensor::from_array(([1usize, positions.len()], positions.clone()))
+                .map_err(|e| format!("code-formula: positions: {e}"))?;
+            let next = {
+                let mut out = match cache.as_ref() {
+                    Some((k, v)) => self.decoder.run(ort::inputs![
+                        "inputs_embeds" => embeds_t, "position_ids" => pos_t,
+                        "past_k" => k, "past_v" => v]),
+                    None => self.decoder.run(ort::inputs![
+                        "inputs_embeds" => embeds_t, "position_ids" => pos_t,
+                        "past_k" => &empty.0, "past_v" => &empty.1]),
+                }
+                .map_err(|e| format!("code-formula: decoder: {e}"))?;
+                let (_, logits) = out["logits"]
+                    .try_extract_tensor::<f32>()
+                    .map_err(|e| format!("code-formula: logits: {e}"))?;
+                let next = logits
+                    .iter()
+                    .enumerate()
+                    .max_by(|a, b| a.1.total_cmp(b.1))
+                    .map(|(i, _)| i as i64)
+                    .unwrap_or(EOS_ID);
+                cache = Some((
+                    out.remove("new_k")
+                        .ok_or_else(|| "code-formula: new_k missing".to_string())?,
+                    out.remove("new_v")
+                        .ok_or_else(|| "code-formula: new_v missing".to_string())?,
+                ));
+                next
+            };
+            past_len += x_seq;
+            if next == EOS_ID {
+                break;
+            }
+            out_ids.push(next as u32);
+            x = self.embed_ids(&[next])?;
+            x_seq = 1;
+            positions = vec![past_len as i64];
+        }
+
+        let text = self
+            .tokenizer
+            .decode(&out_ids, false)
+            .map_err(|e| format!("code-formula: decode: {e}"))?;
+        Ok(post_process(&text))
+    }
+
+    fn embed_ids(&mut self, ids: &[i64]) -> Result<Vec<f32>, String> {
+        let input = Tensor::from_array(([1usize, ids.len()], ids.to_vec()))
+            .map_err(|e| format!("code-formula: ids: {e}"))?;
+        let out = self
+            .embed
+            .run(ort::inputs!["input_ids" => input])
+            .map_err(|e| format!("code-formula: embed: {e}"))?;
+        let (_, embeds) = out["inputs_embeds"]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("code-formula: embed output: {e}"))?;
+        Ok(embeds.to_vec())
+    }
+}
+
+/// The `<image>` expansion for a rows×cols tile grid + global tile
+/// (transformers' `Idefics3Processor.replace_image_token`).
+fn image_prompt(rows: u32, cols: u32) -> String {
+    let img = "<image>".repeat(IMAGE_SEQ_LEN);
+    let mut s = String::new();
+    for r in 1..=rows {
+        for c in 1..=cols {
+            s.push_str(&format!("<fake_token_around_image><row_{r}_col_{c}>{img}"));
+        }
+        s.push('\n');
+    }
+    s.push_str(&format!(
+        "\n<fake_token_around_image><global-img>{img}<fake_token_around_image>"
+    ));
+    s
+}
+
+/// Idefics3 image preprocessing: longest-edge 2048 resize (LANCZOS), resize to
+/// multiples of 512, split into 512×512 tiles (row-major) plus the whole image
+/// squashed to 512×512 as the trailing global tile, then `(x/255 - 0.5)/0.5`.
+/// Returns the flattened `[T,3,512,512]` tensor data and the grid shape.
+fn preprocess_idefics3(crop: &RgbImage) -> (Vec<f32>, u32, u32) {
+    use image::imageops::FilterType;
+    // 1. longest edge → 2048 exactly (up- or down-scale), short side rounded
+    //    to even, both clamped below 4096 (rescale_to_max_len).
+    let (w0, h0) = crop.dimensions();
+    let (mut w, mut h) = rescale_to_max_len(w0, h0, LONGEST_EDGE);
+    (h, w) = scale_below_upper_bound(h, w, MAX_IMAGE_SIZE);
+    let img = image::imageops::resize(crop, w, h, FilterType::Lanczos3);
+
+    // 2. ceil each side to a multiple of the 512 tile (resize_for_vision_encoder).
+    let (tw, th) = if w >= h {
+        let tw = w.div_ceil(TILE) * TILE;
+        let th0 = (tw as f64 / (w as f64 / h as f64)) as u32;
+        (tw, th0.div_ceil(TILE) * TILE)
+    } else {
+        let th = h.div_ceil(TILE) * TILE;
+        let tw0 = (th as f64 * (w as f64 / h as f64)) as u32;
+        (tw0.div_ceil(TILE) * TILE, th)
+    };
+    let img = image::imageops::resize(&img, tw, th, FilterType::Lanczos3);
+
+    // 3. tiles (row-major) + the global squash.
+    let (rows, cols) = (th / TILE, tw / TILE);
+    let mut tensor = Vec::with_capacity(((rows * cols + 1) * 3 * TILE * TILE) as usize);
+    for r in 0..rows {
+        for c in 0..cols {
+            let tile = image::imageops::crop_imm(&img, c * TILE, r * TILE, TILE, TILE).to_image();
+            push_normalized(&mut tensor, &tile);
+        }
+    }
+    let global = image::imageops::resize(&img, TILE, TILE, FilterType::Lanczos3);
+    push_normalized(&mut tensor, &global);
+    (tensor, rows, cols)
+}
+
+/// transformers' `_resize_output_size_rescale_to_max_len`: longest edge to
+/// `max_len` exactly, the short side `int(long/aspect)` bumped to even.
+fn rescale_to_max_len(w0: u32, h0: u32, max_len: u32) -> (u32, u32) {
+    let aspect = w0 as f64 / h0 as f64;
+    let (w, h) = if w0 >= h0 {
+        let w = max_len;
+        let mut h = (w as f64 / aspect) as u32;
+        if h % 2 != 0 {
+            h += 1;
+        }
+        (w, h)
+    } else {
+        let h = max_len;
+        let mut w = (h as f64 * aspect) as u32;
+        if w % 2 != 0 {
+            w += 1;
+        }
+        (w, h)
+    };
+    (w.max(1), h.max(1))
+}
+
+/// transformers' `_resize_output_size_scale_below_upper_bound` (a no-op unless
+/// the even-bump pushed a side past the hard 4096 cap).
+fn scale_below_upper_bound(h0: u32, w0: u32, max_len: u32) -> (u32, u32) {
+    let aspect = w0 as f64 / h0 as f64;
+    let (h, w) = if w0 >= h0 && w0 > max_len {
+        let w = max_len;
+        (((w as f64 / aspect) as u32).max(1), w)
+    } else if h0 > w0 && h0 > max_len {
+        let h = max_len;
+        (h, ((h as f64 * aspect) as u32).max(1))
+    } else {
+        (h0, w0)
+    };
+    (h.max(1), w.max(1))
+}
+
+/// Append one 512×512 tile as CHW `(x/255 - 0.5)/0.5`.
+fn push_normalized(tensor: &mut Vec<f32>, tile: &RgbImage) {
+    let n = (TILE * TILE) as usize;
+    let base = tensor.len();
+    tensor.resize(base + 3 * n, 0.0);
+    for (i, px) in tile.pixels().enumerate() {
+        for c in 0..3 {
+            tensor[base + c * n + i] = px[c] as f32 / 255.0 * 2.0 - 1.0;
+        }
+    }
+}
+
+/// docling's CodeFormulaModel post-processing: truncate at
+/// `<end_of_utterance>`, remove the closing/query artifacts, strip leading
+/// whitespace.
+fn post_process(text: &str) -> String {
+    let mut t = match text.find("<end_of_utterance>") {
+        Some(i) => &text[..i],
+        None => text,
+    }
+    .to_string();
+    for tok in ["</code>", "</formula>", "<loc_0><loc_0><loc_500><loc_500>"] {
+        t = t.replace(tok, "");
+    }
+    t.trim_start().to_string()
+}
+
+/// docling's `_extract_code_language`: an output beginning with
+/// `<_language_>` yields `(remainder, Some(language))`.
+pub fn extract_code_language(s: &str) -> (String, Option<String>) {
+    let rest = match s.strip_prefix("<_") {
+        Some(r) => r,
+        None => return (s.to_string(), None),
+    };
+    // The language is everything up to the closing `_>` that contains neither
+    // `_` nor `>` (docling's `[^_>]+`).
+    match rest.find("_>") {
+        Some(end) if !rest[..end].is_empty() && !rest[..end].contains(['_', '>']) => {
+            let lang = rest[..end].to_string();
+            let remainder = rest[end + 2..].trim_start().to_string();
+            (remainder, Some(lang))
+        }
+        _ => (s.to_string(), None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_prefix_extraction() {
+        assert_eq!(
+            extract_code_language("<_JavaScript_> function f() {}"),
+            (
+                "function f() {}".to_string(),
+                Some("JavaScript".to_string())
+            )
+        );
+        assert_eq!(
+            extract_code_language("plain text"),
+            ("plain text".to_string(), None)
+        );
+        assert_eq!(
+            extract_code_language("<_x_y_> t"),
+            ("<_x_y_> t".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn idefics3_grid_matches_processor() {
+        // An 800×300 crop resizes to 2048×768, tiles to 2048×1024 → 4×2 grid
+        // (+ global) — the shape verified against transformers' processor.
+        let img = RgbImage::new(800, 300);
+        let (tensor, rows, cols) = preprocess_idefics3(&img);
+        assert_eq!((rows, cols), (2, 4));
+        assert_eq!(tensor.len(), 9 * 3 * 512 * 512);
+    }
+
+    #[test]
+    fn image_prompt_layout() {
+        let p = image_prompt(1, 2);
+        assert!(p.starts_with("<fake_token_around_image><row_1_col_1><image>"));
+        assert!(p.contains("<row_1_col_2>"));
+        let tail = "<fake_token_around_image><global-img>".to_owned()
+            + &"<image>".repeat(64)
+            + "<fake_token_around_image>";
+        assert!(p.ends_with(&tail));
+        assert_eq!(p.matches("<image>").count(), 3 * 64);
+    }
+}

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -11,6 +11,7 @@
 
 mod assemble;
 mod dp_lines;
+pub mod enrich;
 pub mod layout;
 mod mets;
 mod ocr;
@@ -152,6 +153,37 @@ enum TfSlot {
 
 type SharedTables = Arc<Mutex<TfSlot>>;
 
+/// The same lazy shared-slot pattern for the (rarer still) enrichment models:
+/// one instance per pipeline, loaded on the first region that needs it.
+enum EnrichSlot<T> {
+    Unloaded,
+    /// Load attempted, model files absent — enrichment skipped (warned once).
+    Missing,
+    Ready(T),
+}
+
+type SharedClassifier = Arc<Mutex<EnrichSlot<enrich::PictureClassifier>>>;
+type SharedCodeFormula = Arc<Mutex<EnrichSlot<enrich::CodeFormula>>>;
+
+/// The opt-in enrichment passes, mirroring docling's `PdfPipelineOptions`
+/// flags (`do_picture_classification`, `do_code_enrichment`,
+/// `do_formula_enrichment`). All off by default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EnrichmentOptions {
+    /// Classify each picture with DocumentFigureClassifier (26 classes).
+    pub picture_classification: bool,
+    /// Rewrite code blocks (and detect their language) with CodeFormulaV2.
+    pub code: bool,
+    /// Decode display formulas to LaTeX with CodeFormulaV2.
+    pub formula: bool,
+}
+
+impl EnrichmentOptions {
+    fn any(&self) -> bool {
+        self.picture_classification || self.code || self.formula
+    }
+}
+
 /// A self-contained set of the per-page models (layout, OCR). Each parallel
 /// page-worker owns its own `Worker` so inference runs concurrently without
 /// sharing an ONNX session (`ort`'s `Session::run` is `&mut self`); only the
@@ -162,13 +194,23 @@ struct Worker {
     ocr: Option<ocr::OcrModel>,
     /// Shared TableFormer slot; `None` when `no_table_former`/`no_ocr` skip it.
     tables: Option<SharedTables>,
+    /// Shared enrichment slots; `None` unless the corresponding flag is on.
+    classifier: Option<SharedClassifier>,
+    code_formula: Option<SharedCodeFormula>,
+    enrich: EnrichmentOptions,
     /// Skip layout, OCR, and TableFormer; reconstruct text purely from the PDF's
     /// embedded text layer. See [`Pipeline::no_ocr`].
     no_ocr: bool,
 }
 
 impl Worker {
-    fn load(intra: usize, tables: Option<SharedTables>, no_ocr: bool) -> Result<Self, PdfError> {
+    fn load(
+        intra: usize,
+        tables: Option<SharedTables>,
+        enrich_slots: (Option<SharedClassifier>, Option<SharedCodeFormula>),
+        enrich: EnrichmentOptions,
+        no_ocr: bool,
+    ) -> Result<Self, PdfError> {
         Ok(Self {
             layout: if no_ocr {
                 None
@@ -177,6 +219,9 @@ impl Worker {
             },
             ocr: None,
             tables,
+            classifier: enrich_slots.0,
+            code_formula: enrich_slots.1,
+            enrich,
             no_ocr,
         })
     }
@@ -195,8 +240,9 @@ impl Worker {
             let mut regions = Vec::new();
             assemble::add_orphan_regions(&mut regions, &page.cells);
             let table_rows = vec![None; regions.len()];
+            let enrich_out = vec![None; regions.len()];
             return Ok(timing::timed("assemble_page", || {
-                assemble::assemble_page(page, regions, &table_rows)
+                assemble::assemble_page(page, regions, &table_rows, &enrich_out)
             }));
         }
         let regions = timing::timed("layout.predict", || {
@@ -266,8 +312,109 @@ impl Worker {
                 });
             }
         }
+        // Enrichment passes (opt-in): DocumentPictureClassifier over picture
+        // regions, CodeFormulaV2 over code/formula regions. Same shared-slot
+        // shape as TableFormer — one lazily-loaded instance per pipeline, only
+        // ever locked when a page actually has a matching region.
+        let mut enrich_out: Vec<Option<assemble::Enrichment>> = vec![None; regions.len()];
+        if let Some(slot) = self.classifier.as_ref() {
+            if regions.iter().any(|r| r.label == "picture") {
+                timing::timed("picture_classifier", || {
+                    let mut guard = slot.lock().unwrap();
+                    if matches!(*guard, EnrichSlot::Unloaded) {
+                        *guard = match enrich::PictureClassifier::load_with(intra_threads()) {
+                            Some(m) => EnrichSlot::Ready(m),
+                            None => EnrichSlot::Missing,
+                        };
+                    }
+                    if let EnrichSlot::Ready(model) = &mut *guard {
+                        for (i, r) in regions.iter().enumerate() {
+                            if r.label != "picture" {
+                                continue;
+                            }
+                            let Some(crop) = assemble::crop_region_scaled(
+                                page,
+                                [r.l, r.t, r.r, r.b],
+                                enrich::CLASSIFIER_SCALE,
+                            ) else {
+                                continue;
+                            };
+                            match model.classify(&crop) {
+                                Ok(classes) => {
+                                    enrich_out[i] =
+                                        Some(assemble::Enrichment::PictureClasses(classes));
+                                }
+                                Err(e) => eprintln!("docling-pdf: page {}: {e}", n + 1),
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        if let Some(slot) = self.code_formula.as_ref() {
+            let wants = |label: &str| {
+                (label == "code" && self.enrich.code) || (label == "formula" && self.enrich.formula)
+            };
+            if regions.iter().any(|r| wants(r.label)) {
+                timing::timed("code_formula", || {
+                    let mut guard = slot.lock().unwrap();
+                    if matches!(*guard, EnrichSlot::Unloaded) {
+                        *guard = match enrich::CodeFormula::load_with(intra_threads()) {
+                            Some(m) => EnrichSlot::Ready(m),
+                            None => EnrichSlot::Missing,
+                        };
+                    }
+                    if let EnrichSlot::Ready(model) = &mut *guard {
+                        for (i, r) in regions.iter().enumerate() {
+                            if !wants(r.label) {
+                                continue;
+                            }
+                            // docling crops the postprocessed cluster box — the
+                            // union of the region's text cells, not the raw
+                            // detector box — expanded by 18% per side, at
+                            // ~120 dpi.
+                            let [bl, bt, br, bb] = assemble::region_cell_bbox(r, &page.cells)
+                                .unwrap_or([r.l, r.t, r.r, r.b]);
+                            let (w, h) = (br - bl, bb - bt);
+                            let ex = enrich::CODE_FORMULA_EXPANSION;
+                            let bbox = [bl - w * ex, bt - h * ex, br + w * ex, bb + h * ex];
+                            let Some(crop) = assemble::crop_region_scaled(
+                                page,
+                                bbox,
+                                enrich::CODE_FORMULA_SCALE,
+                            ) else {
+                                continue;
+                            };
+                            let kind = if r.label == "code" {
+                                enrich::CodeFormulaKind::Code
+                            } else {
+                                enrich::CodeFormulaKind::Formula
+                            };
+                            match model.predict(&crop, kind) {
+                                Ok(text) => {
+                                    enrich_out[i] = Some(match kind {
+                                        enrich::CodeFormulaKind::Code => {
+                                            let (code, language) =
+                                                enrich::extract_code_language(&text);
+                                            assemble::Enrichment::Code {
+                                                language,
+                                                text: code,
+                                            }
+                                        }
+                                        enrich::CodeFormulaKind::Formula => {
+                                            assemble::Enrichment::Formula { latex: text }
+                                        }
+                                    });
+                                }
+                                Err(e) => eprintln!("docling-pdf: page {}: {e}", n + 1),
+                            }
+                        }
+                    }
+                });
+            }
+        }
         Ok(timing::timed("assemble_page", || {
-            assemble::assemble_page(page, regions, &table_rows)
+            assemble::assemble_page(page, regions, &table_rows, &enrich_out)
         }))
     }
 }
@@ -331,6 +478,9 @@ pub struct Pipeline {
     pool: Vec<Worker>,
     /// The single TableFormer instance every worker shares (see [`TfSlot`]).
     tables: SharedTables,
+    /// The shared enrichment-model slots (same pattern as [`TfSlot`]).
+    classifier: SharedClassifier,
+    code_formula: SharedCodeFormula,
     /// Desired pool size for multi-page documents.
     target_workers: usize,
     /// Page count at/above which the parallel pool is worth its load cost.
@@ -340,6 +490,8 @@ pub struct Pipeline {
     no_table_former: bool,
     /// Skip layout, OCR, and TableFormer entirely. See [`Pipeline::no_ocr`].
     no_ocr: bool,
+    /// Opt-in enrichment passes. See [`Pipeline::enrichments`].
+    enrich: EnrichmentOptions,
 }
 
 impl Pipeline {
@@ -351,11 +503,24 @@ impl Pipeline {
             primary: None,
             pool: Vec::new(),
             tables: Arc::new(Mutex::new(TfSlot::Unloaded)),
+            classifier: Arc::new(Mutex::new(EnrichSlot::Unloaded)),
+            code_formula: Arc::new(Mutex::new(EnrichSlot::Unloaded)),
             target_workers: pdf_worker_count(),
             parallel_min: pdf_parallel_min(),
             no_table_former: false,
             no_ocr: false,
+            enrich: EnrichmentOptions::default(),
         })
+    }
+
+    /// Enable the opt-in enrichment passes (docling's
+    /// `do_picture_classification` / `do_code_enrichment` /
+    /// `do_formula_enrichment`). Each enabled pass lazily loads its model on
+    /// the first matching region; a missing model warns once and is skipped.
+    /// Set before the first conversion (no effect on already-loaded workers).
+    pub fn enrichments(mut self, opts: EnrichmentOptions) -> Self {
+        self.enrich = opts;
+        self
     }
 
     /// Skip loading and running the TableFormer table-structure model. Table
@@ -392,6 +557,20 @@ impl Pipeline {
         }
     }
 
+    /// The shared enrichment slots for a worker (`None` per model unless its
+    /// flag is on; `no_ocr` skips layout, so there are no regions to enrich).
+    fn enrich_slots(&self) -> (Option<SharedClassifier>, Option<SharedCodeFormula>) {
+        if self.no_ocr || !self.enrich.any() {
+            return (None, None);
+        }
+        (
+            self.enrich
+                .picture_classification
+                .then(|| Arc::clone(&self.classifier)),
+            (self.enrich.code || self.enrich.formula).then(|| Arc::clone(&self.code_formula)),
+        )
+    }
+
     /// Eagerly load the models (the full-intra serial worker: layout + OCR, and
     /// the shared TableFormer unless disabled) so the first conversion doesn't pay
     /// the load cost. Idempotent; respects `no_ocr` / `no_table_former` (with
@@ -408,6 +587,8 @@ impl Pipeline {
             self.primary = Some(Worker::load(
                 intra_threads(),
                 self.tables_slot(),
+                self.enrich_slots(),
+                self.enrich,
                 self.no_ocr,
             )?);
         }
@@ -700,12 +881,15 @@ impl Pipeline {
         }
         let intra = pdf_intra();
         let no_ocr = self.no_ocr;
+        let enrich = self.enrich;
         let tables = self.tables_slot();
+        let enrich_slots = self.enrich_slots();
         let loaded: Vec<Result<Worker, PdfError>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..need)
                 .map(|_| {
                     let tables = tables.clone();
-                    s.spawn(move || Worker::load(intra, tables, no_ocr))
+                    let enrich_slots = enrich_slots.clone();
+                    s.spawn(move || Worker::load(intra, tables, enrich_slots, enrich, no_ocr))
                 })
                 .collect();
             handles.into_iter().map(|h| h.join().unwrap()).collect()
@@ -764,63 +948,77 @@ pub fn convert(
     password: Option<&str>,
     name: &str,
 ) -> Result<DoclingDocument, PdfError> {
-    convert_with_options(bytes, password, name, false, false)
+    convert_with_options(
+        bytes,
+        password,
+        name,
+        false,
+        false,
+        EnrichmentOptions::default(),
+    )
 }
 
 /// Like [`convert`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
-/// [`Pipeline::no_ocr`]).
+/// [`Pipeline::no_ocr`]), and/or enables the enrichment passes (see
+/// [`Pipeline::enrichments`]).
 pub fn convert_with_options(
     bytes: &[u8],
     password: Option<&str>,
     name: &str,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: EnrichmentOptions,
 ) -> Result<DoclingDocument, PdfError> {
     Pipeline::new()?
         .no_table_former(no_table_former)
         .no_ocr(no_ocr)
+        .enrichments(enrich)
         .convert(bytes, password, name)
 }
 
 /// Convenience one-shot image conversion (loads the pipeline per call).
 pub fn convert_image(bytes: &[u8], name: &str) -> Result<DoclingDocument, PdfError> {
-    convert_image_with_options(bytes, name, false, false)
+    convert_image_with_options(bytes, name, false, false, EnrichmentOptions::default())
 }
 
 /// Like [`convert_image`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
-/// [`Pipeline::no_ocr`]).
+/// [`Pipeline::no_ocr`]), and/or enables the enrichment passes.
 pub fn convert_image_with_options(
     bytes: &[u8],
     name: &str,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: EnrichmentOptions,
 ) -> Result<DoclingDocument, PdfError> {
     Pipeline::new()?
         .no_table_former(no_table_former)
         .no_ocr(no_ocr)
+        .enrichments(enrich)
         .convert_image(bytes, name)
 }
 
 /// Convert pre-segmented pages (image + already-known text cells, e.g. METS/hOCR
 /// scans) through the shared layout + assembly pipeline.
 pub fn convert_pages(pages: Vec<PdfPage>, name: &str) -> Result<DoclingDocument, PdfError> {
-    convert_pages_with_options(pages, name, false, false)
+    convert_pages_with_options(pages, name, false, false, EnrichmentOptions::default())
 }
 
 /// Like [`convert_pages`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
-/// [`Pipeline::no_ocr`]).
+/// [`Pipeline::no_ocr`]), and/or enables the enrichment passes.
 pub fn convert_pages_with_options(
     pages: Vec<PdfPage>,
     name: &str,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: EnrichmentOptions,
 ) -> Result<DoclingDocument, PdfError> {
     Pipeline::new()?
         .no_table_former(no_table_former)
         .no_ocr(no_ocr)
+        .enrichments(enrich)
         .process_pages(pages, name)
 }
 

--- a/crates/docling-pdf/src/mets.rs
+++ b/crates/docling-pdf/src/mets.rs
@@ -20,17 +20,25 @@ use crate::pdfium_backend::{PdfPage, TextCell};
 use crate::{convert_pages_with_options, PdfError};
 
 pub fn convert_mets_gbs(bytes: &[u8], name: &str) -> Result<DoclingDocument, PdfError> {
-    convert_mets_gbs_with_options(bytes, name, false, false)
+    convert_mets_gbs_with_options(
+        bytes,
+        name,
+        false,
+        false,
+        crate::EnrichmentOptions::default(),
+    )
 }
 
 /// Like [`convert_mets_gbs`], but optionally skips loading/running TableFormer
 /// (see [`crate::Pipeline::no_table_former`]) and/or layout+OCR+TableFormer
-/// entirely (see [`crate::Pipeline::no_ocr`]).
+/// entirely (see [`crate::Pipeline::no_ocr`]), and/or enables the enrichment
+/// passes (see [`crate::Pipeline::enrichments`]).
 pub fn convert_mets_gbs_with_options(
     bytes: &[u8],
     name: &str,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: crate::EnrichmentOptions,
 ) -> Result<DoclingDocument, PdfError> {
     let mut html: BTreeMap<String, String> = BTreeMap::new();
     let mut tiff: BTreeMap<String, Vec<u8>> = BTreeMap::new();
@@ -92,7 +100,7 @@ pub fn convert_mets_gbs_with_options(
             "mets: no hOCR/TIFF page pairs found in archive".into(),
         ));
     }
-    convert_pages_with_options(pages, name, no_table_former, no_ocr)
+    convert_pages_with_options(pages, name, no_table_former, no_ocr, enrich)
 }
 
 /// Parse an hOCR page: the `ocr_page` bbox gives the page geometry (cells are in

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -62,7 +62,7 @@ PY
 
 | docling.rs | docling counterpart | notes |
 |---|---|---|
-| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
+| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, do_picture_classification=False, do_code_enrichment=False, do_formula_enrichment=False, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
 | `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
 | `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
 | `.initialize_pipeline(format=None)` | same | pre-loads the PDF/image ML models so the first conversion isn't slow and later PDFs reuse the warm pipeline (no-op for non-ML formats; needs the models available) |
@@ -97,7 +97,10 @@ conv = DocumentConverter(format_options={InputFormat.PDF: PdfFormatOption(pipeli
 # shorthand: DocumentConverter(do_ocr=False, do_table_structure=True)
 ```
 
-The Rust engine acts on `do_ocr`, `do_table_structure`, and
+The Rust engine acts on `do_ocr`, `do_table_structure`, the opt-in enrichment
+flags `do_picture_classification` / `do_code_enrichment` /
+`do_formula_enrichment` (they need the enrichment models —
+`scripts/install/download_dependencies.sh --enrich`), and
 `accelerator_options.num_threads` (→ ONNX Runtime intra-op threads via
 `DOCLING_RS_PDF_THREADS`). The remaining `PdfPipelineOptions` fields
 (`images_scale`, `generate_page_images`, `table_structure_options.mode`, …) are

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -138,6 +138,9 @@ class DocumentConverter:
         allowed_formats: Optional[Iterable[InputFormat]] = None,
         do_ocr: bool = True,
         do_table_structure: bool = True,
+        do_picture_classification: bool = False,
+        do_code_enrichment: bool = False,
+        do_formula_enrichment: bool = False,
         fetch_images: bool = False,
         use_web_browser: bool = False,
         artifacts_path=None,
@@ -149,6 +152,15 @@ class DocumentConverter:
         if pipeline is not None:
             do_ocr = pipeline.do_ocr
             do_table_structure = pipeline.do_table_structure
+            do_picture_classification = getattr(
+                pipeline, "do_picture_classification", do_picture_classification
+            )
+            do_code_enrichment = getattr(
+                pipeline, "do_code_enrichment", do_code_enrichment
+            )
+            do_formula_enrichment = getattr(
+                pipeline, "do_formula_enrichment", do_formula_enrichment
+            )
             acc = getattr(pipeline, "accelerator_options", None)
             if acc is not None:
                 if acc.device in (AcceleratorDevice.CUDA, AcceleratorDevice.MPS):
@@ -167,6 +179,9 @@ class DocumentConverter:
             do_ocr=do_ocr,
             do_table_structure=do_table_structure,
             use_web_browser=use_web_browser,
+            do_picture_classification=do_picture_classification,
+            do_code_enrichment=do_code_enrichment,
+            do_formula_enrichment=do_formula_enrichment,
             allowed_formats=(
                 [InputFormat(f).value for f in allowed_formats]
                 if allowed_formats is not None

--- a/crates/docling-py/python/docling_rs/options.py
+++ b/crates/docling-py/python/docling_rs/options.py
@@ -87,7 +87,9 @@ class TableStructureOptions:
 class PdfPipelineOptions:
     """docling's ``PdfPipelineOptions``.
 
-    Acted on by the Rust engine: ``do_ocr``, ``do_table_structure`` and
+    Acted on by the Rust engine: ``do_ocr``, ``do_table_structure``,
+    ``do_picture_classification`` / ``do_code_enrichment`` /
+    ``do_formula_enrichment`` (the opt-in enrichment models) and
     ``accelerator_options.num_threads``. The remaining fields are accepted so
     docling code constructs unchanged, but do not alter the pipeline (images are
     always extracted; the export image mode is chosen by docling-core at
@@ -95,6 +97,9 @@ class PdfPipelineOptions:
 
     do_ocr: bool = True
     do_table_structure: bool = True
+    do_picture_classification: bool = False
+    do_code_enrichment: bool = False
+    do_formula_enrichment: bool = False
     table_structure_options: TableStructureOptions = field(
         default_factory=TableStructureOptions
     )

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -82,6 +82,7 @@ struct PyDocumentConverter {
     pdf_pipeline: std::sync::Arc<std::sync::Mutex<Option<docling::Pipeline>>>,
     no_ocr: bool,
     no_table_former: bool,
+    enrich: docling::EnrichmentOptions,
 }
 
 #[pymethods]
@@ -92,6 +93,12 @@ impl PyDocumentConverter {
     /// * `do_ocr` — run OCR on scanned PDF/image pages (docling's `do_ocr`).
     /// * `do_table_structure` — recover table structure with TableFormer
     ///   (docling's `do_table_structure`).
+    /// * `do_picture_classification` — classify pictures with the
+    ///   DocumentFigureClassifier enrichment model (docling's flag of the same
+    ///   name; needs models/picture_classifier.onnx).
+    /// * `do_code_enrichment` / `do_formula_enrichment` — rewrite code blocks /
+    ///   decode formula LaTeX with the CodeFormulaV2 VLM (docling's flags of
+    ///   the same names; need models/code_formula/).
     /// * `use_web_browser` — render HTML via headless Chrome before parsing.
     ///
     /// Markdown flavour is chosen at export time by docling-core, so there is no
@@ -102,13 +109,20 @@ impl PyDocumentConverter {
         do_ocr = true,
         do_table_structure = true,
         use_web_browser = false,
+        do_picture_classification = false,
+        do_code_enrichment = false,
+        do_formula_enrichment = false,
         allowed_formats = None,
     ))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         fetch_images: bool,
         do_ocr: bool,
         do_table_structure: bool,
         use_web_browser: bool,
+        do_picture_classification: bool,
+        do_code_enrichment: bool,
+        do_formula_enrichment: bool,
         allowed_formats: Option<Vec<String>>,
     ) -> PyResult<Self> {
         // `allowed_formats` (docling's converter arg) restricts which input
@@ -125,15 +139,24 @@ impl PyDocumentConverter {
             }
             None => docling::DocumentConverter::new(),
         };
+        let enrich = docling::EnrichmentOptions {
+            picture_classification: do_picture_classification,
+            code: do_code_enrichment,
+            formula: do_formula_enrichment,
+        };
         Ok(Self {
             inner: base
                 .fetch_images(fetch_images)
                 .no_ocr(!do_ocr)
                 .no_table_former(!do_table_structure)
-                .use_web_browser(use_web_browser),
+                .use_web_browser(use_web_browser)
+                .do_picture_classification(do_picture_classification)
+                .do_code_enrichment(do_code_enrichment)
+                .do_formula_enrichment(do_formula_enrichment),
             pdf_pipeline: std::sync::Arc::new(std::sync::Mutex::new(None)),
             no_ocr: !do_ocr,
             no_table_former: !do_table_structure,
+            enrich,
         })
     }
 
@@ -154,13 +177,15 @@ impl PyDocumentConverter {
         let slot = std::sync::Arc::clone(&self.pdf_pipeline);
         let no_table_former = self.no_table_former;
         let no_ocr = self.no_ocr;
+        let enrich = self.enrich;
         run_interruptible(py, move || {
             let mut slot = slot.lock().unwrap();
             if slot.is_none() {
                 let mut pipeline = docling::Pipeline::new()
                     .map_err(|e| ConversionError::new_err(e.to_string()))?
                     .no_table_former(no_table_former)
-                    .no_ocr(no_ocr);
+                    .no_ocr(no_ocr)
+                    .enrichments(enrich);
                 pipeline
                     .warm_up()
                     .map_err(|e| ConversionError::new_err(e.to_string()))?;

--- a/crates/docling/src/backend/asciidoc.rs
+++ b/crates/docling/src/backend/asciidoc.rs
@@ -124,6 +124,7 @@ impl Parser {
             self.deferred.push(Node::Picture {
                 caption: cap,
                 image: None,
+                classification: None,
             });
             return;
         }

--- a/crates/docling/src/backend/deepseek.rs
+++ b/crates/docling/src/backend/deepseek.rs
@@ -152,6 +152,7 @@ fn emit(label: &str, content: &str, caption: Option<String>, doc: &mut DoclingDo
         "figure" | "image" => doc.push(Node::Picture {
             caption,
             image: None,
+            classification: None,
         }),
         "table" => {
             if let Some(cap) = caption {

--- a/crates/docling/src/backend/doclang.rs
+++ b/crates/docling/src/backend/doclang.rs
@@ -113,6 +113,7 @@ fn walk_body(parent: XmlNode, out: &mut Vec<Node>) {
                 out.push(Node::Code {
                     language,
                     text: code_text(el),
+                    orig: None,
                 });
             }
             "list" => parse_list(el, 0, out),
@@ -888,6 +889,7 @@ fn parse_picture(el: XmlNode) -> Node {
     let picture = Node::Picture {
         caption,
         image: None,
+        classification: None,
     };
     match layer {
         Some(layer) => Node::Furniture {

--- a/crates/docling/src/backend/docling_json.rs
+++ b/crates/docling/src/backend/docling_json.rs
@@ -116,6 +116,7 @@ fn text_item(item: &Value, level: u8, doc: &mut DoclingDocument) {
                 .filter(|s| !s.is_empty() && *s != "unknown")
                 .map(String::from),
             text,
+            orig: None,
         }),
         "list_item" => doc.push(Node::ListItem {
             ordered: item["enumerated"].as_bool().unwrap_or(false),
@@ -265,6 +266,7 @@ fn picture_item(item: &Value, root: &Value, doc: &mut DoclingDocument) {
     doc.push(Node::Picture {
         caption: None,
         image: None,
+        classification: None,
     });
     push_captions(item, root, doc);
 }

--- a/crates/docling/src/backend/docx.rs
+++ b/crates/docling/src/backend/docx.rs
@@ -375,6 +375,7 @@ fn handle_paragraph_inner(
                     doc.push(Node::Picture {
                         caption: None,
                         image,
+                        classification: None,
                     });
                 }
             }
@@ -393,6 +394,7 @@ fn handle_paragraph_inner(
         doc.push(Node::Picture {
             caption: None,
             image,
+            classification: None,
         });
     }
 

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -223,6 +223,7 @@ fn walk_block(
                     nodes.push(Node::Picture {
                         caption: e.attr("alt").filter(|a| !a.is_empty()).map(str::to_string),
                         image: e.attr("src").and_then(|s| images.resolve(s)),
+                        classification: None,
                     });
                 } else if name == "signature" || name == "stamp" {
                     // docling turns these into an image annotated with the kind.
@@ -230,6 +231,7 @@ fn walk_block(
                     nodes.push(Node::Picture {
                         caption: None,
                         image: None,
+                        classification: None,
                     });
                     let mut label = name.to_string();
                     label[..1].make_ascii_uppercase();
@@ -248,6 +250,7 @@ fn walk_block(
                         nodes.push(Node::Picture {
                             caption,
                             image: src.as_deref().and_then(|s| images.resolve(s)),
+                            classification: None,
                         });
                     } else {
                         collect_element(cref, base, None, &mut inline);
@@ -309,6 +312,7 @@ fn handle_block(
                 nodes.push(Node::Code {
                     language: None,
                     text: code,
+                    orig: None,
                 });
             } else {
                 let (text, runs) = render_inline(elem, base);
@@ -328,7 +332,11 @@ fn handle_block(
                 });
             } else {
                 let (language, text) = extract_pre(elem);
-                nodes.push(Node::Code { language, text });
+                nodes.push(Node::Code {
+                    language,
+                    text,
+                    orig: None,
+                });
             }
         }
         "table" => {
@@ -350,6 +358,7 @@ fn handle_block(
         "figure" => nodes.push(Node::Picture {
             caption: figure_caption(elem),
             image: figure_img_src(elem).and_then(|s| images.resolve(&s)),
+            classification: None,
         }),
         "hr" => {}
         // An `<input type="checkbox|radio">` is a checkbox item; its text comes
@@ -1629,6 +1638,7 @@ mod tests {
             vec![Node::Code {
                 language: Some("rust".into()),
                 text: "let x = 1;".into(),
+                orig: None,
             }]
         );
     }
@@ -1667,6 +1677,7 @@ mod tests {
             Node::Picture {
                 image: Some(img),
                 caption,
+                ..
             } => {
                 assert_eq!(caption.as_deref(), Some("k"));
                 assert_eq!(img.mimetype, "image/png");

--- a/crates/docling/src/backend/jats.rs
+++ b/crates/docling/src/backend/jats.rs
@@ -567,6 +567,7 @@ fn add_figure(doc: &mut DoclingDocument, node: XmlNode) {
     doc.push(Node::Picture {
         caption: (!fig_text.is_empty()).then(|| escape_text(&fig_text)),
         image: None,
+        classification: None,
     });
 }
 

--- a/crates/docling/src/backend/markdown.rs
+++ b/crates/docling/src/backend/markdown.rs
@@ -132,6 +132,7 @@ impl MarkdownBackend {
                                 out.push(Node::Code {
                                     language: None,
                                     text,
+                                    orig: None,
                                 });
                             }
                         }
@@ -188,7 +189,11 @@ impl MarkdownBackend {
                         unescape_entities(trimmed)
                     };
                     if !text.is_empty() {
-                        out.push(Node::Code { language, text });
+                        out.push(Node::Code {
+                            language,
+                            text,
+                            orig: None,
+                        });
                     }
                 }
                 Event::Start(Tag::Table(_)) => {
@@ -661,6 +666,7 @@ mod tests {
             vec![Node::Code {
                 language: None,
                 text: "& <".into(),
+                orig: None,
             }]
         );
     }

--- a/crates/docling/src/backend/odf.rs
+++ b/crates/docling/src/backend/odf.rs
@@ -589,6 +589,7 @@ fn emit_frame_graphic(frame: XmlNode, styles: &Styles, doc: &mut DoclingDocument
         doc.push(Node::Picture {
             caption: None,
             image: None,
+            classification: None,
         });
         return true;
     }
@@ -1393,6 +1394,7 @@ fn walk_slide_frame(frame: XmlNode, styles: &Styles, doc: &mut DoclingDocument, 
         doc.push(Node::Picture {
             caption: None,
             image: None,
+            classification: None,
         });
     }
     for tb in frame.descendants().filter(|n| n.has_tag_name("text-box")) {

--- a/crates/docling/src/backend/pptx.rs
+++ b/crates/docling/src/backend/pptx.rs
@@ -291,6 +291,7 @@ fn handle_shape(
                     Node::Picture {
                         caption: None,
                         image: images.get(&rid).cloned(),
+                        classification: None,
                     },
                 );
             }

--- a/crates/docling/src/backend/xlsx.rs
+++ b/crates/docling/src/backend/xlsx.rs
@@ -173,6 +173,7 @@ impl DeclarativeBackend for XlsxBackend {
                                     Node::Picture {
                                         caption: None,
                                         image: dimages.get(&rid).cloned(),
+                                        classification: None,
                                     },
                                 ));
                             }

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -71,6 +71,10 @@ pub struct DocumentConverter {
     no_table_former: bool,
     no_ocr: bool,
     use_web_browser: bool,
+    /// Opt-in PDF/image enrichment models (docling's
+    /// `do_picture_classification` / `do_code_enrichment` /
+    /// `do_formula_enrichment`).
+    enrich: docling_pdf::EnrichmentOptions,
 }
 
 impl DocumentConverter {
@@ -89,6 +93,7 @@ impl DocumentConverter {
             no_table_former: false,
             no_ocr: false,
             use_web_browser: false,
+            enrich: docling_pdf::EnrichmentOptions::default(),
         }
     }
 
@@ -145,6 +150,45 @@ impl DocumentConverter {
     /// without this flag. Implies [`no_table_former`](Self::no_table_former).
     pub fn no_ocr(mut self, disable: bool) -> Self {
         self.no_ocr = disable;
+        self
+    }
+
+    /// Classify each detected picture with the DocumentFigureClassifier model
+    /// (docling's `do_picture_classification`). Off by default.
+    ///
+    /// The full 26-class prediction distribution (bar_chart, logo, signature,
+    /// …) lands on the picture item and is serialized into the docling JSON as
+    /// the `classification` annotation plus the `meta.classification` field.
+    /// Markdown output is unaffected. Needs `models/picture_classifier.onnx`
+    /// (fetched by `scripts/install/download_dependencies.sh`); a missing
+    /// model warns once and skips classification.
+    pub fn do_picture_classification(mut self, enable: bool) -> Self {
+        self.enrich.picture_classification = enable;
+        self
+    }
+
+    /// Rewrite detected code blocks with the CodeFormulaV2 VLM (docling's
+    /// `do_code_enrichment`). Off by default.
+    ///
+    /// The model re-reads the code crop at ~120 dpi, emits the clean source
+    /// text (line breaks included) and identifies the language, which lands in
+    /// the JSON `code_language` field. Needs the `models/code_formula/` graphs
+    /// (fetched by `scripts/install/download_dependencies.sh`); a missing
+    /// model warns once and leaves the block as extracted.
+    pub fn do_code_enrichment(mut self, enable: bool) -> Self {
+        self.enrich.code = enable;
+        self
+    }
+
+    /// Decode display formulas to LaTeX with the CodeFormulaV2 VLM (docling's
+    /// `do_formula_enrichment`). Off by default.
+    ///
+    /// An enriched formula renders as `$$latex$$` in Markdown and as a
+    /// `formula` text item in the JSON, replacing the
+    /// `<!-- formula-not-decoded -->` placeholder. Same model artifacts as
+    /// [`do_code_enrichment`](Self::do_code_enrichment).
+    pub fn do_formula_enrichment(mut self, enable: bool) -> Self {
+        self.enrich.formula = enable;
         self
     }
 
@@ -229,6 +273,7 @@ impl DocumentConverter {
             self.strict,
             self.no_table_former,
             self.no_ocr,
+            self.enrich,
         ))
     }
 
@@ -321,6 +366,7 @@ impl DocumentConverter {
                 &source.name,
                 self.no_table_former,
                 self.no_ocr,
+                self.enrich,
             )
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
             InputFormat::Image => docling_pdf::convert_image_with_options(
@@ -328,6 +374,7 @@ impl DocumentConverter {
                 &source.name,
                 self.no_table_former,
                 self.no_ocr,
+                self.enrich,
             )
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
             InputFormat::MetsGbs => docling_pdf::convert_mets_gbs_with_options(
@@ -335,6 +382,7 @@ impl DocumentConverter {
                 &source.name,
                 self.no_table_former,
                 self.no_ocr,
+                self.enrich,
             )
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
             // Audio → Whisper ASR (symphonia decode + ONNX inference); each

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -49,4 +49,4 @@ pub use docling_core::{
 
 // The reusable PDF/image pipeline (models loaded once, reused across documents),
 // for callers that convert many files or want a warm, startup-excluded measurement.
-pub use docling_pdf::Pipeline;
+pub use docling_pdf::{EnrichmentOptions, Pipeline};

--- a/crates/docling/src/stream.rs
+++ b/crates/docling/src/stream.rs
@@ -77,6 +77,7 @@ pub(crate) fn spawn(
     strict: bool,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: docling_pdf::EnrichmentOptions,
 ) -> MarkdownStream {
     let (tx, rx) = sync_channel::<Result<String, ConversionError>>(CHANNEL_DEPTH);
     let handle = std::thread::spawn(move || {
@@ -87,6 +88,7 @@ pub(crate) fn spawn(
             strict,
             no_table_former,
             no_ocr,
+            enrich,
             &tx,
         )
     });
@@ -99,6 +101,7 @@ pub(crate) fn spawn(
 /// The producer body: convert `source` and push Markdown chunks onto `tx`. Send
 /// failures (the consumer dropped the stream) are treated as a cancel — we stop
 /// quietly.
+#[allow(clippy::too_many_arguments)]
 fn run(
     converter: DocumentConverter,
     source: SourceDocument,
@@ -106,12 +109,21 @@ fn run(
     strict: bool,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: docling_pdf::EnrichmentOptions,
     tx: &std::sync::mpsc::SyncSender<Result<String, ConversionError>>,
 ) {
     match source.format {
         // PDF is the format with internal page-level parallelism, so it gets the
         // true streaming path: emit each page's Markdown in order as it completes.
-        InputFormat::Pdf => run_pdf(&source, image_mode, strict, no_table_former, no_ocr, tx),
+        InputFormat::Pdf => run_pdf(
+            &source,
+            image_mode,
+            strict,
+            no_table_former,
+            no_ocr,
+            enrich,
+            tx,
+        ),
         // Every other backend builds the whole `DoclingDocument` synchronously, so
         // there is no latency to stream away; serialize it through the same chunk
         // API for a uniform interface (one chunk plus the trailing newline).
@@ -125,15 +137,18 @@ fn run_pdf(
     strict: bool,
     no_table_former: bool,
     no_ocr: bool,
+    enrich: docling_pdf::EnrichmentOptions,
     tx: &std::sync::mpsc::SyncSender<Result<String, ConversionError>>,
 ) {
     // The PDF pipeline builds its document from `DoclingDocument::new` defaults, so
     // tables use the padded GitHub serializer (compact_tables = false), matching the
     // buffered PDF path.
     let mut streamer = MarkdownStreamer::new(strict, image_mode, false);
-    let mut pipeline = match docling_pdf::Pipeline::new()
-        .map(|p| p.no_table_former(no_table_former).no_ocr(no_ocr))
-    {
+    let mut pipeline = match docling_pdf::Pipeline::new().map(|p| {
+        p.no_table_former(no_table_former)
+            .no_ocr(no_ocr)
+            .enrichments(enrich)
+    }) {
         Ok(p) => p,
         Err(e) => {
             let _ = tx.send(Err(ConversionError::Parse(e.to_string())));

--- a/scripts/conformance/enrich_conformance.sh
+++ b/scripts/conformance/enrich_conformance.sh
@@ -6,8 +6,13 @@
 # do_picture_classification/do_code_enrichment/do_formula_enrichment on,
 # do_ocr off — the sources have embedded text, so OCR contributes nothing).
 #
-# * code_and_formula.pdf — Markdown must match byte-for-byte: the CodeFormula
-#   VLM's code rewrite and formula LaTeX are compared against docling's.
+# * code_and_formula.pdf — Markdown must match byte-for-byte with the fp32
+#   decoder (DOCLING_RS_FP32=1): the CodeFormula VLM's code rewrite and formula
+#   LaTeX are compared against docling's. When the INT8 decoder is present it
+#   gets a second leg: whitespace-only drift is reported but allowed (greedy
+#   decoding has near-tie tokens the weight rounding can flip — on this
+#   fixture, one extra blank line in the code block), any content difference
+#   fails.
 # * picture_classification.pdf — the JSON picture items must carry docling's
 #   classification annotation + meta with the same class ranking. Confidences
 #   are compared to 2 decimal places: the crops are resized from the page
@@ -34,8 +39,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail=0
 
-echo "== code_and_formula.pdf (--enrich-code --enrich-formula, markdown)"
-"$BIN" --no-stream --enrich-code --enrich-formula \
+echo "== code_and_formula.pdf (--enrich-code --enrich-formula, markdown, fp32)"
+DOCLING_RS_FP32=1 "$BIN" --no-stream --enrich-code --enrich-formula \
   tests/data/pdf/sources/code_and_formula.pdf > "$TMP/cf.md"
 if diff -u "$GT/code_and_formula.md" "$TMP/cf.md" > "$TMP/cf.diff"; then
   echo "   EXACT"
@@ -43,6 +48,24 @@ else
   echo "   DIFFERS:"
   sed 's/^/   /' "$TMP/cf.diff"
   fail=1
+fi
+
+# INT8 decoder leg (runs only when the quantized decoder sits on disk, i.e.
+# what a default `download_dependencies.sh --enrich` install executes).
+if [ -f models/code_formula/decoder_kv_int8.onnx ]; then
+  echo "== code_and_formula.pdf (int8 decoder)"
+  "$BIN" --no-stream --enrich-code --enrich-formula \
+    tests/data/pdf/sources/code_and_formula.pdf > "$TMP/cf8.md"
+  if diff -u "$GT/code_and_formula.md" "$TMP/cf8.md" > "$TMP/cf8.diff"; then
+    echo "   EXACT"
+  elif diff -Bu "$GT/code_and_formula.md" "$TMP/cf8.md" > "$TMP/cf8b.diff"; then
+    echo "   whitespace-only drift (allowed for int8):"
+    sed 's/^/   /' "$TMP/cf8.diff"
+  else
+    echo "   CONTENT DIFFERS (not a whitespace-only int8 drift):"
+    sed 's/^/   /' "$TMP/cf8b.diff"
+    fail=1
+  fi
 fi
 
 echo "== picture_classification.pdf (--enrich-picture-classes, JSON)"

--- a/scripts/conformance/enrich_conformance.sh
+++ b/scripts/conformance/enrich_conformance.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Conformance of the opt-in enrichment models (issue #76) against Python
+# docling's output on the enrichment test PDFs, checked into
+# tests/data/pdf/groundtruth-enriched/ (generated with docling 2.112,
+# do_picture_classification/do_code_enrichment/do_formula_enrichment on,
+# do_ocr off — the sources have embedded text, so OCR contributes nothing).
+#
+# * code_and_formula.pdf — Markdown must match byte-for-byte: the CodeFormula
+#   VLM's code rewrite and formula LaTeX are compared against docling's.
+# * picture_classification.pdf — the JSON picture items must carry docling's
+#   classification annotation + meta with the same class ranking. Confidences
+#   are compared to 2 decimal places: the crops are resized from the page
+#   render rather than re-rendered per region, so the model sees pixels that
+#   differ sub-pixel from docling's and third-decimal drift is expected.
+#
+# Needs the enrichment models on disk (scripts/install/download_dependencies.sh
+# --enrich, or the local exports). CodeFormula runs an autoregressive VLM per
+# code/formula region — expect ~half a minute on CPU.
+#
+# Usage: scripts/conformance/enrich_conformance.sh
+
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.."
+
+export PDFIUM_DYNAMIC_LIB_PATH="${PDFIUM_DYNAMIC_LIB_PATH:-$(pwd)/.pdfium/lib}"
+export DOCLING_RS_SLOW_RESIZE="${DOCLING_RS_SLOW_RESIZE:-1}"
+
+cargo build --release --quiet -p docling-cli
+BIN=./target/release/docling-rs
+GT=tests/data/pdf/groundtruth-enriched
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+
+echo "== code_and_formula.pdf (--enrich-code --enrich-formula, markdown)"
+"$BIN" --no-stream --enrich-code --enrich-formula \
+  tests/data/pdf/sources/code_and_formula.pdf > "$TMP/cf.md"
+if diff -u "$GT/code_and_formula.md" "$TMP/cf.md" > "$TMP/cf.diff"; then
+  echo "   EXACT"
+else
+  echo "   DIFFERS:"
+  sed 's/^/   /' "$TMP/cf.diff"
+  fail=1
+fi
+
+echo "== picture_classification.pdf (--enrich-picture-classes, JSON)"
+"$BIN" --no-stream --to json --enrich-picture-classes \
+  tests/data/pdf/sources/picture_classification.pdf > "$TMP/pc.json"
+if python3 - "$GT/picture_classification.json" "$TMP/pc.json" <<'PY'
+import json
+import sys
+
+gt = json.load(open(sys.argv[1]))
+rs = json.load(open(sys.argv[2]))
+ok = True
+if len(rs.get("pictures", [])) != len(gt["pictures"]):
+    print(f"   picture count: rs {len(rs.get('pictures', []))} vs gt {len(gt['pictures'])}")
+    ok = False
+for i, (a, b) in enumerate(zip(rs.get("pictures", []), gt["pictures"])):
+    for src, name in ((a, "rs"), (b, "gt")):
+        if not src.get("annotations") or "classification" not in (src.get("meta") or {}):
+            print(f"   picture {i}: {name} missing classification annotation/meta")
+            ok = False
+    if not ok:
+        continue
+    pa = a["annotations"][0]["predicted_classes"]
+    pb = b["annotations"][0]["predicted_classes"]
+    # Same ranking on the confident head of the distribution; the long tail of
+    # ~1e-6 classes may reorder from sub-pixel crop differences.
+    ra = [(c["class_name"], round(c["confidence"], 2)) for c in pa[:3]]
+    rb = [(c["class_name"], round(c["confidence"], 2)) for c in pb[:3]]
+    if ra != rb:
+        print(f"   picture {i}: top-3 differs\n    rs {ra}\n    gt {rb}")
+        ok = False
+    ma = [p["class_name"] for p in a["meta"]["classification"]["predictions"][:3]]
+    if ma != [c for c, _ in ra]:
+        print(f"   picture {i}: meta/annotation ranking mismatch: {ma} vs {ra}")
+        ok = False
+    else:
+        print(f"   picture {i}: {ra[0][0]} ({ra[0][1]}) — matches docling")
+sys.exit(0 if ok else 1)
+PY
+then
+  echo "   OK"
+else
+  fail=1
+fi
+
+exit $fail

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -31,6 +31,12 @@
 #   models/chunk/tokenizer.json                   (all-MiniLM-L6-v2's tokenizer,
 #     the HybridChunker's default token counter; falls back to Hugging Face when
 #     the release doesn't host it; skip with --no-chunk)
+#   models/picture_classifier.onnx                (DocumentFigureClassifier-v2.5,
+#     the --enrich-picture-classes model, ~17 MB; falls back to Hugging Face when
+#     the release doesn't host it)
+#   models/code_formula/{vision,embed,decoder_kv}.onnx + tokenizer.json
+#     (CodeFormulaV2, the --enrich-code/--enrich-formula VLM, ~1.3 GB fp32 —
+#     opt-in with --enrich; release-hosted only)
 #
 # Also fetches the INT8-quantized CPU models when the release hosts them (see
 # PDF_CONFORMANCE.md — ~2.4x faster layout inference at unchanged conformance):
@@ -59,6 +65,7 @@ FORCE=false
 WITH_ASR=true
 WITH_INT8=true
 WITH_CHUNK=true
+WITH_ENRICH=false
 for arg in "$@"; do
   case "$arg" in
     --force) FORCE=true ;;
@@ -66,8 +73,9 @@ for arg in "$@"; do
     --int8) WITH_INT8=true ;; # accepted for compatibility; int8 is the default
     --no-int8) WITH_INT8=false ;;
     --no-chunk) WITH_CHUNK=false ;;
+    --enrich) WITH_ENRICH=true ;;
     *)
-      echo "usage: download_dependencies.sh [--force] [--no-asr] [--no-int8] [--no-chunk]" >&2
+      echo "usage: download_dependencies.sh [--force] [--no-asr] [--no-int8] [--no-chunk] [--enrich]" >&2
       exit 2
       ;;
   esac
@@ -139,6 +147,30 @@ if [ "$WITH_CHUNK" = true ]; then
     fetch "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" \
       models/chunk/tokenizer.json
   fi
+fi
+
+# DocumentFigureClassifier (picture classification enrichment, ~17 MB): the
+# `--enrich-picture-classes` / `do_picture_classification` model. Small, so
+# fetched by default — from the release when hosted, else the upstream ONNX
+# straight from Hugging Face (docling-project/DocumentFigureClassifier-v2.5
+# ships the graph itself).
+fetch_optional "$BASE_URL/picture_classifier.onnx" models/picture_classifier.onnx
+if [ ! -f models/picture_classifier.onnx ]; then
+  fetch "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx" \
+    models/picture_classifier.onnx
+fi
+
+if [ "$WITH_ENRICH" = true ]; then
+  # CodeFormulaV2 (code/formula enrichment, ~1.3 GB fp32): the
+  # `--enrich-code`/`--enrich-formula` VLM, exported to ONNX by
+  # scripts/install/export_code_formula.py and hosted with the release
+  # (there is no upstream ONNX export to fall back to). Opt-in (--enrich)
+  # because of its size.
+  mkdir -p models/code_formula
+  fetch "$BASE_URL/cf_vision.onnx" models/code_formula/vision.onnx
+  fetch "$BASE_URL/cf_embed.onnx" models/code_formula/embed.onnx
+  fetch "$BASE_URL/cf_decoder_kv.onnx" models/code_formula/decoder_kv.onnx
+  fetch "$BASE_URL/cf_tokenizer.json" models/code_formula/tokenizer.json
 fi
 
 if [ "$WITH_INT8" = true ]; then

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -36,7 +36,8 @@
 #     the release doesn't host it)
 #   models/code_formula/{vision,embed,decoder_kv}.onnx + tokenizer.json
 #     (CodeFormulaV2, the --enrich-code/--enrich-formula VLM, ~1.3 GB fp32 —
-#     opt-in with --enrich; release-hosted only)
+#     opt-in with --enrich; release-hosted only. With int8 enabled the ~165 MB
+#     decoder_kv_int8.onnx replaces the ~655 MB fp32 decoder)
 #
 # Also fetches the INT8-quantized CPU models when the release hosts them (see
 # PDF_CONFORMANCE.md — ~2.4x faster layout inference at unchanged conformance):
@@ -169,8 +170,19 @@ if [ "$WITH_ENRICH" = true ]; then
   mkdir -p models/code_formula
   fetch "$BASE_URL/cf_vision.onnx" models/code_formula/vision.onnx
   fetch "$BASE_URL/cf_embed.onnx" models/code_formula/embed.onnx
-  fetch "$BASE_URL/cf_decoder_kv.onnx" models/code_formula/decoder_kv.onnx
   fetch "$BASE_URL/cf_tokenizer.json" models/code_formula/tokenizer.json
+  if [ "$WITH_INT8" = true ]; then
+    # INT8 decoder (~165 MB vs ~655 MB fp32) — preferred automatically when
+    # present. Near-exact, not byte-exact: greedy near-tie tokens can flip
+    # (whitespace-only drift on the conformance fixture); fetch with --no-int8
+    # or set DOCLING_RS_FP32=1 at runtime for the byte-exact fp32 graph.
+    fetch_optional "$BASE_URL/cf_decoder_kv_int8.onnx" models/code_formula/decoder_kv_int8.onnx
+  fi
+  if [ "$WITH_INT8" = true ] && [ -f models/code_formula/decoder_kv_int8.onnx ]; then
+    echo "code_formula: int8 decoder present — fp32 decoder_kv.onnx not needed (skipped)"
+  else
+    fetch "$BASE_URL/cf_decoder_kv.onnx" models/code_formula/decoder_kv.onnx
+  fi
 fi
 
 if [ "$WITH_INT8" = true ]; then

--- a/scripts/install/export_code_formula.py
+++ b/scripts/install/export_code_formula.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Export docling's CodeFormulaV2 VLM (code language + formula LaTeX enrichment)
+to ONNX for the Rust pipeline.
+
+CodeFormulaV2 (docling-project/CodeFormulaV2) is an Idefics3 / SmolVLM-256M-class
+model: a SigLIP-base vision tower (512x512 tiles, patch 16), a pixel-shuffle
+connector projecting to the text width, and a 30-layer Llama-style decoder
+(hidden 576, 9 heads / 3 KV heads, head_dim 64, RoPE theta 100000, vocab
+100480, untied lm_head). Python docling drives it with
+`transformers.AutoModelForImageTextToText.generate` (greedy); the Rust port
+needs the same computation as three ONNX graphs plus the HF tokenizer.json:
+
+  vision.onnx     : pixel_values[T,3,512,512]
+                      -> image_features[T,64,576]
+                    (SigLIP tower + pixel-shuffle connector, T = image tiles;
+                     the 512x512 grid yields 1024 patches -> 64 visual tokens)
+  embed.onnx      : input_ids[1,S] -> inputs_embeds[1,S,576]
+                    (token embeddings only; the Rust side scatters the visual
+                     tokens into the <image> positions, exactly like
+                     Idefics3Model.inputs_merger)
+  decoder_kv.onnx : inputs_embeds[1,S,576] + position_ids[1,S]
+                    + past_k/past_v[30,1,3,P,64]
+                      -> logits[1,V] (last position only)
+                         + new_k/new_v[30,1,3,P+S,64]
+                    (a manually written KV-cache Llama step, prefill and decode
+                     in one graph: pass P=0 tensors on the first call, then
+                     S=1 steps; the causal mask `j <= P + i` is built inside)
+
+Like the TableFormer export, the decoder graph re-implements the layer math
+(eager attention) from the checkpoint's own weight modules instead of tracing
+transformers' masking utilities — the trace is shape-generic and verified
+argmax-identical to `model.generate` end-to-end below.
+
+Needs a Python env with torch + transformers (>=4.46 for Idefics3) + onnx:
+    pip install torch transformers onnx pillow
+
+Usage:
+    python scripts/install/export_code_formula.py [out_dir]   # default models/code_formula
+"""
+
+import math
+import os
+import sys
+import warnings
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+warnings.filterwarnings("ignore")
+
+REPO = "docling-project/CodeFormulaV2"
+OUT = sys.argv[1] if len(sys.argv) > 1 else "models/code_formula"
+os.makedirs(OUT, exist_ok=True)
+
+print(f"loading {REPO} ...", flush=True)
+from transformers import AutoModelForImageTextToText, AutoProcessor  # noqa: E402
+
+model = AutoModelForImageTextToText.from_pretrained(REPO, dtype=torch.float32)
+model.eval()
+# The wrapper modules below close over `model`'s submodules without registering
+# them, so the tracer treats the weights as constants — which torch.onnx
+# rejects while they still require grad.
+model.requires_grad_(False)
+processor = AutoProcessor.from_pretrained(REPO)
+
+text_model = model.model.text_model
+vision_model = model.model.vision_model
+connector = model.model.connector
+lm_head = model.lm_head
+cfg = model.config.text_config
+N_LAYERS = cfg.num_hidden_layers
+N_HEADS = cfg.num_attention_heads
+N_KV = cfg.num_key_value_heads
+HEAD_DIM = cfg.head_dim
+EPS = cfg.rms_norm_eps
+# transformers 5.x moved rope_theta into `rope_parameters`; older versions keep
+# the flat attribute. (The composite Idefics3 config carries a stale top-level
+# rope_theta=100000 from training — the text_config value is the one the
+# checkpoint's Llama layers actually run with, and the generate() cross-check
+# below would fail loudly on a mismatch.)
+_rp = getattr(cfg, "rope_parameters", None) or {}
+THETA = _rp.get("rope_theta") if isinstance(_rp, dict) else None
+if THETA is None:
+    THETA = getattr(cfg, "rope_theta", 10000.0)
+
+
+# ---------------------------------------------------------------------------
+# vision.onnx — SigLIP tower + connector. T (tile count) is dynamic.
+# ---------------------------------------------------------------------------
+class Vision(nn.Module):
+    # Idefics3VisionEmbeddings assigns bucketed position ids through a boolean
+    # patch-mask scatter, which traces to a mixed-type ScatterND that
+    # onnxruntime rejects. Every tile the processor produces is exactly
+    # 512x512 (fully valid patches), so the position ids are just
+    # arange(num_patches) — compute the embeddings manually and run the
+    # encoder + connector as-is. Verified against the full vision_model below.
+    def forward(self, pixel_values):
+        emb = vision_model.embeddings.patch_embedding(pixel_values)  # [T,768,32,32]
+        emb = emb.flatten(2).transpose(1, 2)  # [T,1024,768]
+        emb = emb + vision_model.embeddings.position_embedding.weight[None]
+        hidden = vision_model.encoder(inputs_embeds=emb).last_hidden_state
+        hidden = vision_model.post_layernorm(hidden)
+        return connector(hidden)
+
+
+# ---------------------------------------------------------------------------
+# embed.onnx — token embeddings (the <image> positions are overwritten with
+# the vision features by the Rust caller, mirroring Idefics3's inputs_merger).
+# ---------------------------------------------------------------------------
+class Embed(nn.Module):
+    def forward(self, input_ids):
+        return text_model.embed_tokens(input_ids)
+
+
+# ---------------------------------------------------------------------------
+# decoder_kv.onnx — one KV-cached decoder pass over S new positions.
+# ---------------------------------------------------------------------------
+def rms_norm(x, weight):
+    var = x.pow(2).mean(-1, keepdim=True)
+    return weight * (x * torch.rsqrt(var + EPS))
+
+
+class DecoderKV(nn.Module):
+    def forward(self, inputs_embeds, position_ids, past_k, past_v):
+        # RoPE tables for the new positions (Llama convention: the half-split
+        # rotate_half layout with cos/sin repeated across both halves).
+        inv_freq = 1.0 / (
+            THETA
+            ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.float32) / HEAD_DIM)
+        )  # [head_dim/2]
+        freqs = position_ids.to(torch.float32)[..., None] * inv_freq  # [1,S,hd/2]
+        emb = torch.cat([freqs, freqs], dim=-1)  # [1,S,hd]
+        cos = emb.cos()[:, None, :, :]  # [1,1,S,hd]
+        sin = emb.sin()[:, None, :, :]
+
+        def rope(t):
+            half = t.shape[-1] // 2
+            rot = torch.cat([-t[..., half:], t[..., :half]], dim=-1)
+            return t * cos + rot * sin
+
+        past_len = past_k.shape[3]
+        seq_len = inputs_embeds.shape[1]
+        # Causal mask over the concatenated sequence: query i (absolute
+        # position past+i) may attend keys j <= past+i.
+        q_pos = past_len + torch.arange(seq_len)[:, None]
+        k_pos = torch.arange(past_len + seq_len)[None, :]
+        mask = torch.where(
+            k_pos <= q_pos, torch.tensor(0.0), torch.tensor(torch.finfo(torch.float32).min)
+        )  # [S, P+S]
+
+        x = inputs_embeds
+        new_ks, new_vs = [], []
+        for i, layer in enumerate(text_model.layers):
+            attn = layer.self_attn
+            h = rms_norm(x, layer.input_layernorm.weight)
+            q = attn.q_proj(h).view(1, seq_len, N_HEADS, HEAD_DIM).transpose(1, 2)
+            k = attn.k_proj(h).view(1, seq_len, N_KV, HEAD_DIM).transpose(1, 2)
+            v = attn.v_proj(h).view(1, seq_len, N_KV, HEAD_DIM).transpose(1, 2)
+            q, k = rope(q), rope(k)
+            k = torch.cat([past_k[i], k], dim=2)  # [1,kv,P+S,hd]
+            v = torch.cat([past_v[i], v], dim=2)
+            new_ks.append(k)
+            new_vs.append(v)
+            # GQA: each KV head serves n_heads/n_kv query heads.
+            kx = k.repeat_interleave(N_HEADS // N_KV, dim=1)
+            vx = v.repeat_interleave(N_HEADS // N_KV, dim=1)
+            scores = q @ kx.transpose(-1, -2) / math.sqrt(HEAD_DIM) + mask
+            out = F.softmax(scores, dim=-1) @ vx  # [1,heads,S,hd]
+            out = out.transpose(1, 2).reshape(1, seq_len, N_HEADS * HEAD_DIM)
+            x = x + attn.o_proj(out)
+            h = rms_norm(x, layer.post_attention_layernorm.weight)
+            mlp = layer.mlp
+            x = x + mlp.down_proj(F.silu(mlp.gate_proj(h)) * mlp.up_proj(h))
+
+        x = rms_norm(x[:, -1:, :], text_model.norm.weight)
+        logits = lm_head(x)[:, 0, :]  # [1,V]
+        return logits, torch.stack(new_ks, 0), torch.stack(new_vs, 0)
+
+
+# ---------------------------------------------------------------------------
+# Sanity check the hand-written decoder against transformers' generate on a
+# real prompt BEFORE exporting: prefill + a few greedy steps must match.
+# ---------------------------------------------------------------------------
+def greedy_reference(pixel_values, input_ids, n_new):
+    with torch.no_grad():
+        out = model.generate(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            attention_mask=torch.ones_like(input_ids),
+            max_new_tokens=n_new,
+            do_sample=False,
+            use_cache=True,
+        )
+    return out[0, input_ids.shape[1]:].tolist()
+
+
+def greedy_manual(vision_mod, embed_mod, dec, pixel_values, input_ids, n_new):
+    image_token = model.config.image_token_id
+    with torch.no_grad():
+        feats = vision_mod(pixel_values)  # [T,64,576]
+        embeds = embed_mod(input_ids)  # [1,S,576]
+        flat = feats.reshape(-1, feats.shape[-1])
+        positions = (input_ids[0] == image_token).nonzero(as_tuple=True)[0]
+        assert positions.numel() == flat.shape[0], (positions.numel(), flat.shape)
+        embeds[0, positions] = flat
+        past_k = torch.zeros(N_LAYERS, 1, N_KV, 0, HEAD_DIM)
+        past_v = torch.zeros(N_LAYERS, 1, N_KV, 0, HEAD_DIM)
+        pos = torch.arange(input_ids.shape[1])[None, :]
+        toks = []
+        x = embeds
+        for _ in range(n_new):
+            logits, past_k, past_v = dec(x, pos, past_k, past_v)
+            t = int(logits.argmax(-1))
+            toks.append(t)
+            if t == model.config.eos_token_id:
+                break
+            x = embed_mod(torch.tensor([[t]]))
+            pos = torch.tensor([[past_k.shape[3]]])
+        return toks
+
+
+print("verifying the manual decoder against transformers.generate ...", flush=True)
+from PIL import Image, ImageDraw  # noqa: E402
+
+img = Image.new("RGB", (400, 120), (255, 255, 255))
+ImageDraw.Draw(img).text((10, 40), "x = 1 + 2", fill=(0, 0, 0))
+messages = [
+    {"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "<code>"}]}
+]
+prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
+inputs = processor(text=[prompt], images=[img], return_tensors="pt")
+pv = inputs["pixel_values"][0]  # [T,3,512,512]
+ids = inputs["input_ids"]
+
+vision = Vision().eval()
+embed = Embed().eval()
+decoder = DecoderKV().eval()
+
+N_CHECK = 12
+# generate() wants the batched [B, num_images, C, H, W] layout; the manual
+# path (and the ONNX graphs) run the flattened tile batch [T, C, H, W].
+ref = greedy_reference(inputs["pixel_values"], ids, N_CHECK)
+got = greedy_manual(vision, embed, decoder, pv, ids.clone(), N_CHECK)
+assert got == ref[: len(got)], f"manual decode diverges:\n  ref {ref}\n  got {got}"
+print(f"  greedy tokens match transformers.generate ({got[:8]}...)", flush=True)
+
+# ---------------------------------------------------------------------------
+# Export the three graphs.
+# ---------------------------------------------------------------------------
+with torch.no_grad():
+    print("exporting vision.onnx ...", flush=True)
+    torch.onnx.export(
+        vision,
+        (pv,),
+        f"{OUT}/vision.onnx",
+        input_names=["pixel_values"],
+        output_names=["image_features"],
+        dynamic_axes={"pixel_values": {0: "tiles"}, "image_features": {0: "tiles"}},
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+    print("exporting embed.onnx ...", flush=True)
+    torch.onnx.export(
+        Embed().eval(),
+        (ids,),
+        f"{OUT}/embed.onnx",
+        input_names=["input_ids"],
+        output_names=["inputs_embeds"],
+        dynamic_axes={"input_ids": {1: "seq"}, "inputs_embeds": {1: "seq"}},
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+    print("exporting decoder_kv.onnx ...", flush=True)
+    embeds0 = embed(ids)
+    pos0 = torch.arange(ids.shape[1])[None, :]
+    pk = torch.zeros(N_LAYERS, 1, N_KV, 3, HEAD_DIM)
+    pv0 = torch.zeros(N_LAYERS, 1, N_KV, 3, HEAD_DIM)
+    torch.onnx.export(
+        decoder,
+        (embeds0, pos0, pk, pv0),
+        f"{OUT}/decoder_kv.onnx",
+        input_names=["inputs_embeds", "position_ids", "past_k", "past_v"],
+        output_names=["logits", "new_k", "new_v"],
+        dynamic_axes={
+            "inputs_embeds": {1: "seq"},
+            "position_ids": {1: "seq"},
+            "past_k": {3: "past"},
+            "past_v": {3: "past"},
+            "new_k": {3: "total"},
+            "new_v": {3: "total"},
+        },
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+# The Rust side decodes with the HF tokenizer.json (tokenizers crate).
+import shutil  # noqa: E402
+
+from huggingface_hub import hf_hub_download  # noqa: E402
+
+for f in ["tokenizer.json"]:
+    shutil.copyfile(hf_hub_download(REPO, f), f"{OUT}/{f}")
+
+# ---------------------------------------------------------------------------
+# Verify the exported graphs against torch end-to-end (greedy, zero-len prefill
+# cache exercises the dynamic `past` axis at P=0).
+# ---------------------------------------------------------------------------
+print("verifying ONNX graphs with onnxruntime ...", flush=True)
+import numpy as np  # noqa: E402
+import onnxruntime as ort  # noqa: E402
+
+sv = ort.InferenceSession(f"{OUT}/vision.onnx", providers=["CPUExecutionProvider"])
+se = ort.InferenceSession(f"{OUT}/embed.onnx", providers=["CPUExecutionProvider"])
+sd = ort.InferenceSession(f"{OUT}/decoder_kv.onnx", providers=["CPUExecutionProvider"])
+
+feats = sv.run(None, {"pixel_values": pv.numpy()})[0]
+with torch.no_grad():
+    tfeats = vision(pv).numpy()
+dv = float(np.abs(feats - tfeats).max())
+print(f"  vision max|diff| = {dv:.2e}", flush=True)
+assert dv < 5e-4, "vision graph diverges from torch"
+
+embeds = se.run(None, {"input_ids": ids.numpy()})[0]
+image_token = model.config.image_token_id
+positions = (ids[0] == image_token).nonzero(as_tuple=True)[0].numpy()
+embeds[0, positions] = feats.reshape(-1, feats.shape[-1])
+
+toks = []
+pk = np.zeros((N_LAYERS, 1, N_KV, 0, HEAD_DIM), dtype=np.float32)
+pvv = np.zeros((N_LAYERS, 1, N_KV, 0, HEAD_DIM), dtype=np.float32)
+pos = np.arange(ids.shape[1], dtype=np.int64)[None, :]
+x = embeds
+for _ in range(N_CHECK):
+    logits, pk, pvv = sd.run(
+        None,
+        {"inputs_embeds": x, "position_ids": pos, "past_k": pk, "past_v": pvv},
+    )
+    t = int(logits.argmax(-1)[0])
+    toks.append(t)
+    if t == model.config.eos_token_id:
+        break
+    x = se.run(None, {"input_ids": np.array([[t]], dtype=np.int64)})[0]
+    pos = np.array([[pk.shape[3]]], dtype=np.int64)
+
+assert toks == ref[: len(toks)], f"ONNX decode diverges:\n  ref {ref}\n  got {toks}"
+print(f"  ONNX greedy tokens match transformers.generate: {toks}", flush=True)
+print(f"wrote {OUT}/vision.onnx, embed.onnx, decoder_kv.onnx, tokenizer.json", flush=True)

--- a/scripts/install/quantize_models.py
+++ b/scripts/install/quantize_models.py
@@ -16,6 +16,16 @@ PDF_CONFORMANCE.md for the measured speed/quality numbers):
   autoregressive tag decoder. Output is byte-identical on the corpus;
   ~10% faster table-structure decode, 78 -> 50 MB.
 
+* **code-formula-decoder** — dynamic INT8 of the CodeFormulaV2 KV-cache
+  decoder step (the enrichment VLM; needs the --enrich models). Not in the
+  default target list because the fp32 export is opt-in too. ~655 -> ~165 MB
+  (4x less decoder RAM). NEAR-exact, not byte-exact: greedy decoding has
+  occasional near-tie tokens the weight rounding can flip - on the
+  conformance fixture the only drift is one extra blank line inside the
+  code block (per-channel and fp32-lm_head variants flip it identically,
+  so per-tensor is kept for the smaller file). DOCLING_RS_FP32=1 restores
+  the byte-exact fp32 decoder.
+
 Usage (from the repo root, models fetched by scripts/install/download_dependencies.sh):
 
     uv venv .venv-quant && uv pip install --python .venv-quant/bin/python \
@@ -145,6 +155,49 @@ def quantize_tableformer_decoder():
         print(f"tableformer-decoder: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
 
 
+def quantize_code_formula_decoder():
+    """Dynamic INT8 (weights-only MatMul) of the CodeFormulaV2 KV-cache decoder
+    step — the autoregressive stage that dominates enrichment latency. Same
+    recipe as the TableFormer decoder. Near-exact (see the module docstring);
+    re-run scripts/conformance/enrich_conformance.sh after re-quantizing.
+    ~655 -> ~165 MB."""
+    import onnx
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    src = f"{MODELS}/code_formula/decoder_kv.onnx"
+    if not os.path.exists(src):
+        print(f"code-formula-decoder: {src} not found — skipping")
+        return
+    tmp = f"{MODELS}/code_formula/decoder_kv_fold.onnx"
+    dst = f"{MODELS}/code_formula/decoder_kv_int8.onnx"
+
+    # torch's exporter emits the Linear weights as `Constant` *nodes*, but
+    # `MatMulConstBOnly` only quantizes MatMuls whose B is an *initializer* —
+    # so fold every tensor-valued Constant into an initializer first (the
+    # unfolded graph quantizes to a byte-identical no-op).
+    m = onnx.load(src)
+    keep = []
+    for node in m.graph.node:
+        t = next((a.t for a in node.attribute if a.name == "value"), None)
+        if node.op_type == "Constant" and t is not None:
+            t.name = node.output[0]
+            m.graph.initializer.append(t)
+        else:
+            keep.append(node)
+    del m.graph.node[:]
+    m.graph.node.extend(keep)
+    del m.graph.value_info[:]
+    onnx.save(m, tmp, save_as_external_data=True, location="decoder_kv_fold.onnx.data")
+
+    print("code-formula-decoder: dynamic INT8 quantization...", flush=True)
+    quantize_dynamic(
+        tmp, dst, weight_type=QuantType.QInt8, extra_options={"MatMulConstBOnly": True}
+    )
+    os.remove(tmp)
+    os.remove(f"{tmp}.data")
+    print(f"code-formula-decoder: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
+
+
 def main():
     targets = sys.argv[1:] or ["layout", "tableformer-decoder"]
     for t in targets:
@@ -152,8 +205,13 @@ def main():
             quantize_layout()
         elif t == "tableformer-decoder":
             quantize_tableformer_decoder()
+        elif t == "code-formula-decoder":
+            quantize_code_formula_decoder()
         else:
-            sys.exit(f"unknown target {t!r} (expected: layout, tableformer-decoder)")
+            sys.exit(
+                f"unknown target {t!r} "
+                "(expected: layout, tableformer-decoder, code-formula-decoder)"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/data/pdf/groundtruth-enriched/code_and_formula.json
+++ b/tests/data/pdf/groundtruth-enriched/code_and_formula.json
@@ -1,0 +1,539 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "code_and_formula",
+  "origin": {
+    "mimetype": "application/pdf",
+    "binary_hash": 8967166443255744998,
+    "filename": "code_and_formula.pdf"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/texts/1"
+      },
+      {
+        "$ref": "#/texts/2"
+      },
+      {
+        "$ref": "#/texts/3"
+      },
+      {
+        "$ref": "#/texts/5"
+      },
+      {
+        "$ref": "#/texts/6"
+      },
+      {
+        "$ref": "#/texts/7"
+      },
+      {
+        "$ref": "#/texts/8"
+      },
+      {
+        "$ref": "#/texts/9"
+      },
+      {
+        "$ref": "#/texts/10"
+      },
+      {
+        "$ref": "#/texts/11"
+      },
+      {
+        "$ref": "#/texts/12"
+      },
+      {
+        "$ref": "#/texts/13"
+      },
+      {
+        "$ref": "#/texts/14"
+      },
+      {
+        "$ref": "#/texts/15"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 667.0764932,
+            "r": 315.91596292,
+            "b": 654.4839197682998,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            23
+          ]
+        }
+      ],
+      "orig": "JavaScript Code Example",
+      "text": "JavaScript Code Example",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 642.2184558,
+            "r": 477.4826813,
+            "b": 502.00488987723304,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 498.7564557999996,
+            "r": 477.4786962599997,
+            "b": 454.1848898772331,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            298
+          ]
+        }
+      ],
+      "orig": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,",
+      "text": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,"
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/4"
+        }
+      ],
+      "content_layer": "body",
+      "label": "code",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 134.239,
+            "t": 425.6004704,
+            "r": 263.2239743999999,
+            "b": 385.2544592,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            60
+          ]
+        }
+      ],
+      "orig": "function add(a, b) { return a + b; } console.log(add(3, 5));",
+      "text": "function add(a, b) {\n    return a + b;\n}\nconsole.log(add(3, 5));",
+      "captions": [
+        {
+          "$ref": "#/texts/4"
+        }
+      ],
+      "references": [],
+      "footnotes": [],
+      "code_language": "JavaScript"
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/texts/3"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "caption",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 223.155,
+            "t": 441.96945579999965,
+            "r": 388.09381307999996,
+            "b": 433.2628898772331,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            36
+          ]
+        }
+      ],
+      "orig": "Listing 1: Simple JavaScript Program",
+      "text": "Listing 1: Simple JavaScript Program"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 372.8294558,
+            "r": 477.48168504000006,
+            "b": 232.61588987723349,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 229.36745580000002,
+            "r": 477.4786962599997,
+            "b": 184.79488987723346,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            298
+          ]
+        }
+      ],
+      "orig": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,",
+      "text": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,"
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "furniture",
+      "label": "page_footer",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 303.13300000000004,
+            "t": 96.16945580000004,
+            "r": 308.1143,
+            "b": 87.46288987723347,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            1
+          ]
+        }
+      ],
+      "orig": "1",
+      "text": "1"
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.768,
+            "t": 716.9665078484375,
+            "r": 191.52723582,
+            "b": 704.3739344167373,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
+      "orig": "Formula",
+      "text": "Formula",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.768,
+            "t": 692.1084704484375,
+            "r": 477.4826813,
+            "b": 551.8949045256705,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.768,
+            "t": 548.6464704484371,
+            "r": 477.4816850399999,
+            "b": 492.1189045256704,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            369
+          ]
+        }
+      ],
+      "orig": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt.",
+      "text": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt."
+    },
+    {
+      "self_ref": "#/texts/11",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "formula",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 280.554,
+            "t": 478.98812004843694,
+            "r": 330.69662335999993,
+            "b": 468.2089045256704,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
+      "orig": "a 2 +8 = 12",
+      "text": "a ^ { 2 } + 8 = 1 2"
+    },
+    {
+      "self_ref": "#/texts/12",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.76800000000003,
+            "t": 458.98247044843697,
+            "r": 477.4816850400001,
+            "b": 318.76890452567045,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/13",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.76800000000003,
+            "t": 315.5204704484371,
+            "r": 477.48367755999976,
+            "b": 247.03790452567057,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            415
+          ]
+        }
+      ],
+      "orig": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.",
+      "text": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat."
+    },
+    {
+      "self_ref": "#/texts/14",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.76800000000003,
+            "t": 243.7894704484371,
+            "r": 477.48367755999976,
+            "b": 175.30690452567046,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            415
+          ]
+        }
+      ],
+      "orig": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.",
+      "text": "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat."
+    },
+    {
+      "self_ref": "#/texts/15",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "furniture",
+      "label": "page_footer",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 303.13300000000004,
+            "t": 146.0584704484371,
+            "r": 308.1143,
+            "b": 137.35190452567053,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            1
+          ]
+        }
+      ],
+      "orig": "1",
+      "text": "1"
+    }
+  ],
+  "pictures": [],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 595.2760009765625,
+        "height": 841.8900146484375
+      },
+      "page_no": 2
+    }
+  }
+}

--- a/tests/data/pdf/groundtruth-enriched/code_and_formula.md
+++ b/tests/data/pdf/groundtruth-enriched/code_and_formula.md
@@ -1,0 +1,32 @@
+## JavaScript Code Example
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,
+
+```
+function add(a, b) {
+    return a + b;
+}
+console.log(add(3, 5));
+```
+
+Listing 1: Simple JavaScript Program
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,
+
+## Formula
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt.
+
+$$a ^ { 2 } + 8 = 1 2$$
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.

--- a/tests/data/pdf/groundtruth-enriched/picture_classification.json
+++ b/tests/data/pdf/groundtruth-enriched/picture_classification.json
@@ -1,0 +1,888 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "picture_classification",
+  "origin": {
+    "mimetype": "application/pdf",
+    "binary_hash": 6445357065749877499,
+    "filename": "picture_classification.pdf"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/texts/1"
+      },
+      {
+        "$ref": "#/pictures/0"
+      },
+      {
+        "$ref": "#/texts/3"
+      },
+      {
+        "$ref": "#/texts/4"
+      },
+      {
+        "$ref": "#/texts/5"
+      },
+      {
+        "$ref": "#/pictures/1"
+      },
+      {
+        "$ref": "#/texts/7"
+      },
+      {
+        "$ref": "#/texts/8"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 667.0764932,
+            "r": 252.35512382,
+            "b": 654.4839197682998,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
+      "orig": "Figures Example",
+      "text": "Figures Example",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 642.2184558,
+            "r": 477.4826813,
+            "b": 502.00488987723304,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/pictures/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "caption",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 226.891,
+            "t": 262.75545579999994,
+            "r": 384.35487429999984,
+            "b": 254.04888987723348,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            35
+          ]
+        }
+      ],
+      "orig": "Figure 1: This is an example image.",
+      "text": "Figure 1: This is an example image."
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 133.768,
+            "t": 238.84545579999997,
+            "r": 477.48168504000006,
+            "b": 122.54288987723339,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            747
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "furniture",
+      "label": "page_footer",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 303.13300000000004,
+            "t": 96.16945579999992,
+            "r": 308.1143,
+            "b": 87.46288987723335,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            1
+          ]
+        }
+      ],
+      "orig": "1",
+      "text": "1"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.768,
+            "t": 664.0394558,
+            "r": 477.48168504000006,
+            "b": 523.8258898772331,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            887
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/pictures/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "caption",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 226.891,
+            "t": 268.6794558,
+            "r": 384.35487429999984,
+            "b": 259.97288987723346,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            35
+          ]
+        }
+      ],
+      "orig": "Figure 2: This is an example image.",
+      "text": "Figure 2: This is an example image."
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 133.768,
+            "t": 245.6084558,
+            "r": 477.48168504000006,
+            "b": 117.35088987723339,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            804
+          ]
+        }
+      ],
+      "orig": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.",
+      "text": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum."
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "furniture",
+      "label": "page_footer",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 303.13300000000004,
+            "t": 96.16945579999992,
+            "r": 308.1143,
+            "b": 87.46288987723335,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            1
+          ]
+        }
+      ],
+      "orig": "2",
+      "text": "2"
+    }
+  ],
+  "pictures": [
+    {
+      "self_ref": "#/pictures/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/2"
+        }
+      ],
+      "content_layer": "body",
+      "meta": {
+        "classification": {
+          "predictions": [
+            {
+              "confidence": 0.9989230036735535,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "bar_chart"
+            },
+            {
+              "confidence": 0.0006355401710607111,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "line_chart"
+            },
+            {
+              "confidence": 0.00021971913520246744,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "table"
+            },
+            {
+              "confidence": 5.856509233126417e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "scatter_plot"
+            },
+            {
+              "confidence": 5.580821380135603e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "box_plot"
+            },
+            {
+              "confidence": 3.2323598134098575e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "pie_chart"
+            },
+            {
+              "confidence": 2.248175769636873e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "other"
+            },
+            {
+              "confidence": 1.8378181266598403e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "screenshot_from_computer"
+            },
+            {
+              "confidence": 1.143320059782127e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "flow_chart"
+            },
+            {
+              "confidence": 4.4517169044411276e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "engineering_drawing"
+            },
+            {
+              "confidence": 3.934483174816705e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "calendar"
+            },
+            {
+              "confidence": 3.49479910255468e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "geographical_map"
+            },
+            {
+              "confidence": 2.2770173018216155e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "icon"
+            },
+            {
+              "confidence": 2.171245114368503e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "full_page_image"
+            },
+            {
+              "confidence": 1.5278498040061095e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "logo"
+            },
+            {
+              "confidence": 1.2464073506635032e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "screenshot_from_manual"
+            },
+            {
+              "confidence": 9.276046739614685e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "page_thumbnail"
+            },
+            {
+              "confidence": 7.837383009245968e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "chemistry_structure"
+            },
+            {
+              "confidence": 6.703733106405707e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "qr_code"
+            },
+            {
+              "confidence": 4.1256174654336064e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "music"
+            },
+            {
+              "confidence": 2.567095407357556e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "topographical_map"
+            },
+            {
+              "confidence": 2.3420237482696393e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "bar_code"
+            },
+            {
+              "confidence": 1.1750945816402236e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "photograph"
+            },
+            {
+              "confidence": 1.0333488376090827e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "stamp"
+            },
+            {
+              "confidence": 7.85262628255623e-08,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "crossword_puzzle"
+            },
+            {
+              "confidence": 5.4340667077212856e-08,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "signature"
+            }
+          ]
+        }
+      },
+      "label": "picture",
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 134.70913696289062,
+            "t": 487.69866943359375,
+            "r": 475.6763610839844,
+            "b": 282.34991455078125,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
+      "captions": [
+        {
+          "$ref": "#/texts/2"
+        }
+      ],
+      "references": [],
+      "footnotes": [],
+      "annotations": [
+        {
+          "kind": "classification",
+          "provenance": "DocumentPictureClassifier",
+          "predicted_classes": [
+            {
+              "class_name": "bar_chart",
+              "confidence": 0.9989230036735535
+            },
+            {
+              "class_name": "line_chart",
+              "confidence": 0.0006355401710607111
+            },
+            {
+              "class_name": "table",
+              "confidence": 0.00021971913520246744
+            },
+            {
+              "class_name": "scatter_plot",
+              "confidence": 5.856509233126417e-05
+            },
+            {
+              "class_name": "box_plot",
+              "confidence": 5.580821380135603e-05
+            },
+            {
+              "class_name": "pie_chart",
+              "confidence": 3.2323598134098575e-05
+            },
+            {
+              "class_name": "other",
+              "confidence": 2.248175769636873e-05
+            },
+            {
+              "class_name": "screenshot_from_computer",
+              "confidence": 1.8378181266598403e-05
+            },
+            {
+              "class_name": "flow_chart",
+              "confidence": 1.143320059782127e-05
+            },
+            {
+              "class_name": "engineering_drawing",
+              "confidence": 4.4517169044411276e-06
+            },
+            {
+              "class_name": "calendar",
+              "confidence": 3.934483174816705e-06
+            },
+            {
+              "class_name": "geographical_map",
+              "confidence": 3.49479910255468e-06
+            },
+            {
+              "class_name": "icon",
+              "confidence": 2.2770173018216155e-06
+            },
+            {
+              "class_name": "full_page_image",
+              "confidence": 2.171245114368503e-06
+            },
+            {
+              "class_name": "logo",
+              "confidence": 1.5278498040061095e-06
+            },
+            {
+              "class_name": "screenshot_from_manual",
+              "confidence": 1.2464073506635032e-06
+            },
+            {
+              "class_name": "page_thumbnail",
+              "confidence": 9.276046739614685e-07
+            },
+            {
+              "class_name": "chemistry_structure",
+              "confidence": 7.837383009245968e-07
+            },
+            {
+              "class_name": "qr_code",
+              "confidence": 6.703733106405707e-07
+            },
+            {
+              "class_name": "music",
+              "confidence": 4.1256174654336064e-07
+            },
+            {
+              "class_name": "topographical_map",
+              "confidence": 2.567095407357556e-07
+            },
+            {
+              "class_name": "bar_code",
+              "confidence": 2.3420237482696393e-07
+            },
+            {
+              "class_name": "photograph",
+              "confidence": 1.1750945816402236e-07
+            },
+            {
+              "class_name": "stamp",
+              "confidence": 1.0333488376090827e-07
+            },
+            {
+              "class_name": "crossword_puzzle",
+              "confidence": 7.85262628255623e-08
+            },
+            {
+              "class_name": "signature",
+              "confidence": 5.4340667077212856e-08
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "self_ref": "#/pictures/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/6"
+        }
+      ],
+      "content_layer": "body",
+      "meta": {
+        "classification": {
+          "predictions": [
+            {
+              "confidence": 0.9951556921005249,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "geographical_map"
+            },
+            {
+              "confidence": 0.004328129813075066,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "engineering_drawing"
+            },
+            {
+              "confidence": 0.0002828954893629998,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "topographical_map"
+            },
+            {
+              "confidence": 8.250963583122939e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "flow_chart"
+            },
+            {
+              "confidence": 5.40164255653508e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "screenshot_from_computer"
+            },
+            {
+              "confidence": 4.1973260522354394e-05,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "line_chart"
+            },
+            {
+              "confidence": 9.419441084901337e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "bar_chart"
+            },
+            {
+              "confidence": 9.290942216466647e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "screenshot_from_manual"
+            },
+            {
+              "confidence": 6.9929551500536036e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "full_page_image"
+            },
+            {
+              "confidence": 6.011740879330318e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "chemistry_structure"
+            },
+            {
+              "confidence": 5.815365511807613e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "scatter_plot"
+            },
+            {
+              "confidence": 4.0808768062561285e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "other"
+            },
+            {
+              "confidence": 4.051324594911421e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "table"
+            },
+            {
+              "confidence": 1.7149955056083854e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "calendar"
+            },
+            {
+              "confidence": 1.1059661346735083e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "icon"
+            },
+            {
+              "confidence": 1.087649138753477e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "page_thumbnail"
+            },
+            {
+              "confidence": 1.0244710892948206e-06,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "logo"
+            },
+            {
+              "confidence": 8.777870448284375e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "pie_chart"
+            },
+            {
+              "confidence": 8.600738965469645e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "box_plot"
+            },
+            {
+              "confidence": 8.364200994037674e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "crossword_puzzle"
+            },
+            {
+              "confidence": 4.6474917780869873e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "music"
+            },
+            {
+              "confidence": 4.172465821739024e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "photograph"
+            },
+            {
+              "confidence": 2.7129735258313303e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "qr_code"
+            },
+            {
+              "confidence": 1.7795780138385453e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "stamp"
+            },
+            {
+              "confidence": 1.2964436280071823e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "signature"
+            },
+            {
+              "confidence": 1.0748919265779477e-07,
+              "created_by": "DocumentPictureClassifier",
+              "class_name": "bar_code"
+            }
+          ]
+        }
+      },
+      "label": "picture",
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 218.88284301757812,
+            "t": 514.0193481445312,
+            "r": 392.1819763183594,
+            "b": 283.26318359375,
+            "coord_origin": "BOTTOMLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
+      "captions": [
+        {
+          "$ref": "#/texts/6"
+        }
+      ],
+      "references": [],
+      "footnotes": [],
+      "annotations": [
+        {
+          "kind": "classification",
+          "provenance": "DocumentPictureClassifier",
+          "predicted_classes": [
+            {
+              "class_name": "geographical_map",
+              "confidence": 0.9951556921005249
+            },
+            {
+              "class_name": "engineering_drawing",
+              "confidence": 0.004328129813075066
+            },
+            {
+              "class_name": "topographical_map",
+              "confidence": 0.0002828954893629998
+            },
+            {
+              "class_name": "flow_chart",
+              "confidence": 8.250963583122939e-05
+            },
+            {
+              "class_name": "screenshot_from_computer",
+              "confidence": 5.40164255653508e-05
+            },
+            {
+              "class_name": "line_chart",
+              "confidence": 4.1973260522354394e-05
+            },
+            {
+              "class_name": "bar_chart",
+              "confidence": 9.419441084901337e-06
+            },
+            {
+              "class_name": "screenshot_from_manual",
+              "confidence": 9.290942216466647e-06
+            },
+            {
+              "class_name": "full_page_image",
+              "confidence": 6.9929551500536036e-06
+            },
+            {
+              "class_name": "chemistry_structure",
+              "confidence": 6.011740879330318e-06
+            },
+            {
+              "class_name": "scatter_plot",
+              "confidence": 5.815365511807613e-06
+            },
+            {
+              "class_name": "other",
+              "confidence": 4.0808768062561285e-06
+            },
+            {
+              "class_name": "table",
+              "confidence": 4.051324594911421e-06
+            },
+            {
+              "class_name": "calendar",
+              "confidence": 1.7149955056083854e-06
+            },
+            {
+              "class_name": "icon",
+              "confidence": 1.1059661346735083e-06
+            },
+            {
+              "class_name": "page_thumbnail",
+              "confidence": 1.087649138753477e-06
+            },
+            {
+              "class_name": "logo",
+              "confidence": 1.0244710892948206e-06
+            },
+            {
+              "class_name": "pie_chart",
+              "confidence": 8.777870448284375e-07
+            },
+            {
+              "class_name": "box_plot",
+              "confidence": 8.600738965469645e-07
+            },
+            {
+              "class_name": "crossword_puzzle",
+              "confidence": 8.364200994037674e-07
+            },
+            {
+              "class_name": "music",
+              "confidence": 4.6474917780869873e-07
+            },
+            {
+              "class_name": "photograph",
+              "confidence": 4.172465821739024e-07
+            },
+            {
+              "class_name": "qr_code",
+              "confidence": 2.7129735258313303e-07
+            },
+            {
+              "class_name": "stamp",
+              "confidence": 1.7795780138385453e-07
+            },
+            {
+              "class_name": "signature",
+              "confidence": 1.2964436280071823e-07
+            },
+            {
+              "class_name": "bar_code",
+              "confidence": 1.0748919265779477e-07
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 2
+    }
+  }
+}

--- a/tests/data/pdf/groundtruth-enriched/picture_classification.md
+++ b/tests/data/pdf/groundtruth-enriched/picture_classification.md
@@ -1,0 +1,21 @@
+## Figures Example
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Figure 1: This is an example image.
+
+<!-- image -->
+
+Bar chart
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Figure 2: This is an example image.
+
+<!-- image -->
+
+Geographical map
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.


### PR DESCRIPTION
Closes #76 — ports docling's opt-in enrichment stages to the ONNX pipeline behind the same flags: `do_picture_classification`, `do_code_enrichment`, `do_formula_enrichment` (CLI: `--enrich-picture-classes` / `--enrich-code` / `--enrich-formula`; the Python bindings take the same kwargs and read them from `PdfPipelineOptions`).

## Models

- **Picture classification** — `docling-project/DocumentFigureClassifier-v2.5` (EfficientNet, 26 figure classes). Upstream ships the ONNX graph; re-hosted as `picture_classifier.onnx` by `publish-models.yml` and fetched by `download_dependencies.sh` by default (~17 MB, HF fallback when the release doesn't host it).
- **Code/formula** — `docling-project/CodeFormulaV2`, an Idefics3/SmolVLM-class VLM (SigLIP tower + pixel-shuffle connector + 30-layer Llama decoder). New `scripts/install/export_code_formula.py` exports three graphs (vision, embeddings, hand-written KV-cache decoder step — same approach as the TableFormer export) and **verifies the ONNX greedy decode token-identical to `transformers.generate`** before writing. Hosted as `cf_*.onnx` + `cf_tokenizer.json`; fetched with `download_dependencies.sh --enrich` (~1.3 GB fp32, hence opt-in).

## Pipeline

- `enrich.rs`: classifier preprocessing (ViT 224×224) and the VLM runtime — full Idefics3 preprocessing (longest-edge 2048 resize, multiple-of-512 resize, 512×512 tiling + squashed global tile), tiled `<image>` prompt, `tokenizers`-crate encoding, greedy KV-cache decode whose caches stay owned `ort` values (no per-step copies; zero-`past` first step allocates through the session allocator).
- Shared lazy model slots per pipeline like TableFormer; a missing model warns once and skips the pass. Code/formula crops use the **cell-tight cluster bbox** (docling's postprocessed box — the raw detector box hands the VLM the `Listing N:` caption and changes its output), expanded 18 % at ~120 dpi.
- Document model: `Node::Picture` gains `classification`, `Node::Code` gains `orig`, new `Node::Formula` (LaTeX + `orig`; Markdown `$$…$$`, JSON `formula` item) — serialized across Markdown/JSON/DocLang/chunker.

## Conformance

`scripts/conformance/enrich_conformance.sh`, groundtruth from Python docling 2.112 checked into `tests/data/pdf/groundtruth-enriched/`:

| Fixture | Check | Result |
|---|---|---|
| code_and_formula.pdf | Markdown, `--enrich-code --enrich-formula` | **byte-exact** (code rewrite, `JavaScript` language, formula LaTeX; enriched JSON items match field-for-field) |
| picture_classification.pdf | JSON classification annotation + meta | same class ranking; confidences match to ~3 decimals |

Non-enriched output unchanged (flags default off): full test suite green, PDF groundtruth still 5/14 byte-exact, pytest 25/25, clippy (stable + 1.96 MSRV) and fmt clean.

After merge, run the **publish models** workflow once so `picture_classifier.onnx` and the `cf_*` assets land in the `models-v1` release (the classifier works via the HF fallback until then). Node bindings expose no pipeline toggles yet, so enrichment flags there are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT)_