### PR TITLE
perf(ocr): batch same-width PP-OCRv3 rec line crops (#75)

### DIFF
--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -476,11 +476,22 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
      borrowed `&str`.
    - RTL merge is O(n²) (string prepend + `Vec::remove(0)`,
      `dp_lines.rs:87-155`); accumulate reversed and flip once per line.
-6. **OCR line batching** (`ocr.rs::recognize`): lines are recognized one at a
-   time on one thread (deliberately, for CTC determinism). Batching same-width
-   buckets keeps determinism per line and would speed scanned documents
-   several-fold; alternatively run multiple single-thread recognitions across
-   the existing worker pool.
+6. ~~**OCR line batching** (`ocr.rs::recognize`): lines are recognized one at
+   a time on one thread (deliberately, for CTC determinism). Batching
+   same-width buckets keeps determinism per line.~~ **Done on this branch**
+   (`ocr.rs::recognize_batch`): each page's line crops are gathered first and
+   equal-width lines share one recognition run (page order, batches capped at
+   16). Same-width batching is **bit-identical** to sequential runs (verified:
+   max output diff 0.0 over the scanned corpus's crops); the snapshot corpus
+   is unchanged. Measured `ocr.page`: 195 → 176 ms on `ocr_test.pdf`, 682 →
+   587 ms over `nemotron_multipage.pdf`'s 4 pages (−10–14%). The
+   "several-fold" hope required *padded* batches (PaddleOCR-style, pad to
+   bucket max): measured on the real crops, padding perturbs the valid
+   region's probabilities by up to 0.34 through the model's global-attention
+   blocks and changes the decoded text on 16/20 lines — off the table for a
+   byte-stable pipeline. The remaining lever is running same-width buckets
+   across the page-worker pool's idle threads (needs one extra session per
+   worker: `ort`'s `Session::run` takes `&mut self`).
 7. **ort session options**: checked — ONNX Runtime's C-API default is already
    `ORT_ENABLE_ALL`, so an explicit optimization level gains nothing.
    `with_optimized_model_path` (caching the optimized graph on disk) could

--- a/crates/docling-pdf/src/ocr.rs
+++ b/crates/docling-pdf/src/ocr.rs
@@ -5,6 +5,8 @@
 //! is recognised and decoded with CTC — producing [`TextCell`]s the normal
 //! layout assembly then consumes. This avoids a separate text-detection model.
 
+use std::collections::BTreeMap;
+
 use image::{imageops, imageops::FilterType, Rgb, RgbImage};
 use ort::session::Session;
 use ort::value::Tensor;
@@ -14,10 +16,71 @@ use crate::pdfium_backend::TextCell;
 
 const REC_HEIGHT: u32 = 48;
 
+/// Cap on lines per recognition run: bounds peak input-tensor memory
+/// (16 × 3 × 48 × 2400 px ≈ 22 MB f32) without costing measurable batching
+/// benefit — same-width groups are rarely larger.
+const REC_BATCH: usize = 16;
+
+/// A text-line crop prepared for recognition: resized to the fixed model
+/// height, normalised to `[-1, 1]`, laid out CHW.
+struct PrepLine {
+    /// Width after the aspect-preserving resize to `REC_HEIGHT`.
+    w: usize,
+    /// `3 * REC_HEIGHT * w` values.
+    data: Vec<f32>,
+}
+
+/// Prepare one line crop, or `None` for a degenerate (zero-sized) crop.
+fn prep_line(line: &RgbImage) -> Option<PrepLine> {
+    let (w, h) = line.dimensions();
+    if w == 0 || h == 0 {
+        return None;
+    }
+    let new_w = ((w as f32) * REC_HEIGHT as f32 / h as f32)
+        .round()
+        .clamp(8.0, 2400.0) as u32;
+    let resized = imageops::resize(line, new_w, REC_HEIGHT, FilterType::Triangle);
+    let n = (REC_HEIGHT * new_w) as usize;
+    // Normalise to [-1, 1]: (x/255 - 0.5) / 0.5.
+    let mut data = vec![0f32; 3 * n];
+    for (i, px) in resized.pixels().enumerate() {
+        data[i] = px[0] as f32 / 127.5 - 1.0;
+        data[n + i] = px[1] as f32 / 127.5 - 1.0;
+        data[2 * n + i] = px[2] as f32 / 127.5 - 1.0;
+    }
+    Some(PrepLine {
+        w: new_w as usize,
+        data,
+    })
+}
+
 pub struct OcrModel {
     rec: Session,
     /// CTC classes: index 0 = blank, 1..=6623 = dictionary, 6624 = space.
     chars: Vec<String>,
+}
+
+/// Greedy CTC decode of one row's `(T, C)` probabilities.
+fn decode_row(chars: &[String], probs: &[f32], nc: usize) -> String {
+    let mut out = String::new();
+    let mut prev = 0usize;
+    for row in probs.chunks_exact(nc) {
+        let mut best = 0usize;
+        let mut bestv = row[0];
+        for (c, &v) in row.iter().enumerate().skip(1) {
+            if v > bestv {
+                bestv = v;
+                best = c;
+            }
+        }
+        if best != prev && best != 0 {
+            if let Some(ch) = chars.get(best) {
+                out.push_str(ch);
+            }
+        }
+        prev = best;
+    }
+    out
 }
 
 fn luma(p: &Rgb<u8>) -> f32 {
@@ -66,25 +129,22 @@ impl OcrModel {
         Ok(Self { rec, chars })
     }
 
-    /// Recognise a single text-line image → string (CTC greedy decode).
-    fn recognize(&mut self, line: &RgbImage) -> Result<String, String> {
-        let (w, h) = line.dimensions();
-        if w == 0 || h == 0 {
-            return Ok(String::new());
+    /// Recognise a batch of prepared *same-width* lines in one session run.
+    ///
+    /// Only equal widths ever share a run: same-width batching is
+    /// bit-identical to one-at-a-time recognition (each sample keeps its own
+    /// data and per-sample kernel reduction order — verified empirically on
+    /// the scanned corpus), whereas width-padding leaks into the real
+    /// timesteps through the model's global-attention blocks and measurably
+    /// changes low-confidence characters.
+    fn recognize_batch(&mut self, w: usize, batch: &[&PrepLine]) -> Result<Vec<String>, String> {
+        let n = batch.len();
+        let hw = REC_HEIGHT as usize * w;
+        let mut data = vec![0f32; n * 3 * hw];
+        for (i, pl) in batch.iter().enumerate() {
+            data[i * 3 * hw..(i + 1) * 3 * hw].copy_from_slice(&pl.data);
         }
-        let new_w = ((w as f32) * REC_HEIGHT as f32 / h as f32)
-            .round()
-            .clamp(8.0, 2400.0) as u32;
-        let resized = imageops::resize(line, new_w, REC_HEIGHT, FilterType::Triangle);
-        let n = (REC_HEIGHT * new_w) as usize;
-        // Normalise to [-1, 1]: (x/255 - 0.5) / 0.5.
-        let mut data = vec![0f32; 3 * n];
-        for (i, px) in resized.pixels().enumerate() {
-            data[i] = px[0] as f32 / 127.5 - 1.0;
-            data[n + i] = px[1] as f32 / 127.5 - 1.0;
-            data[2 * n + i] = px[2] as f32 / 127.5 - 1.0;
-        }
-        let input = Tensor::from_array(([1usize, 3, REC_HEIGHT as usize, new_w as usize], data))
+        let input = Tensor::from_array(([n, 3, REC_HEIGHT as usize, w], data))
             .map_err(|e| format!("ocr: input tensor: {e}"))?;
         let outputs = self
             .rec
@@ -95,26 +155,15 @@ impl OcrModel {
             .map_err(|e| format!("ocr: extract rec: {e}"))?;
         let t_len = shape[1] as usize;
         let nc = shape[2] as usize;
-        let mut out = String::new();
-        let mut prev = 0usize;
-        for t in 0..t_len {
-            let base = t * nc;
-            let mut best = 0usize;
-            let mut bestv = probs[base];
-            for c in 1..nc {
-                if probs[base + c] > bestv {
-                    bestv = probs[base + c];
-                    best = c;
-                }
-            }
-            if best != prev && best != 0 {
-                if let Some(ch) = self.chars.get(best) {
-                    out.push_str(ch);
-                }
-            }
-            prev = best;
-        }
-        Ok(out)
+        Ok((0..n)
+            .map(|i| {
+                decode_row(
+                    &self.chars,
+                    &probs[i * t_len * nc..(i + 1) * t_len * nc],
+                    nc,
+                )
+            })
+            .collect())
     }
 
     /// OCR a page: produce text cells (page points) for every line found inside
@@ -126,7 +175,10 @@ impl OcrModel {
         scale: f32,
     ) -> Result<Vec<TextCell>, String> {
         let (iw, ih) = img.dimensions();
-        let mut cells = Vec::new();
+        // Gather every line crop on the page first, so equal-width lines can
+        // share a recognition run regardless of which region they came from.
+        let mut bboxes: Vec<(f32, f32, f32, f32)> = Vec::new();
+        let mut lines: Vec<PrepLine> = Vec::new();
         for region in regions {
             if !is_text_label(region.label) {
                 continue;
@@ -141,18 +193,43 @@ impl OcrModel {
             let crop = imageops::crop_imm(img, l, t, r - l, b - t).to_image();
             for (lx, ly, rx, ry) in segment_lines(&crop) {
                 let line = imageops::crop_imm(&crop, lx, ly, rx - lx, ry - ly).to_image();
-                let text = self.recognize(&line)?.trim().to_string();
-                if text.is_empty() {
+                let Some(pl) = prep_line(&line) else {
                     continue;
-                }
-                cells.push(TextCell {
-                    text,
-                    l: (l + lx) as f32 / scale,
-                    t: (t + ly) as f32 / scale,
-                    r: (l + rx) as f32 / scale,
-                    b: (t + ry) as f32 / scale,
-                });
+                };
+                bboxes.push((
+                    (l + lx) as f32 / scale,
+                    (t + ly) as f32 / scale,
+                    (l + rx) as f32 / scale,
+                    (t + ry) as f32 / scale,
+                ));
+                lines.push(pl);
             }
+        }
+
+        // Group page-order line indices by exact width (BTreeMap: run order is
+        // deterministic) and recognise each group batched.
+        let mut by_width: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        for (ix, pl) in lines.iter().enumerate() {
+            by_width.entry(pl.w).or_default().push(ix);
+        }
+        let mut texts = vec![String::new(); lines.len()];
+        for (w, ixs) in by_width {
+            for chunk in ixs.chunks(REC_BATCH) {
+                let batch: Vec<&PrepLine> = chunk.iter().map(|&i| &lines[i]).collect();
+                for (&i, text) in chunk.iter().zip(self.recognize_batch(w, &batch)?) {
+                    texts[i] = text;
+                }
+            }
+        }
+
+        // Emit cells in page order, exactly as the sequential walk did.
+        let mut cells = Vec::new();
+        for ((l, t, r, b), text) in bboxes.into_iter().zip(texts) {
+            let text = text.trim().to_string();
+            if text.is_empty() {
+                continue;
+            }
+            cells.push(TextCell { text, l, t, r, b });
         }
         Ok(cells)
     }


### PR DESCRIPTION
Each page's line crops are now gathered up front (bboxes + prepared CHW tensors) and equal-width lines share one recognition run, in page order, batches capped at 16 (bounds the input tensor at ~22 MB f32). Cells still emit in page order; empty-text lines are filtered as before.

Why equal widths only, not width buckets with padding: PP-OCRv3 rec is SVTR-based and its global-attention blocks see the whole sequence, so right-padding leaks into the real timesteps. Measured on the scanned corpus's actual line crops (onnxruntime, single thread):

- same-width batch vs one-at-a-time: bit-identical (max prob diff 0.0);
- pad-to-bucket-max (PaddleOCR style): valid-region probabilities move by up to 0.34 and the greedy-CTC text changes on 16/20 lines.

A byte-stable pipeline therefore cannot pad — this is the deterministic subset of the issue's batching proposal, as PDF_CONFORMANCE.md's optimization notes anticipated.

DOCLING_RS_TIMING=1 on the scanned fixtures (4 cores):

- ocr_test.pdf: ocr.page 195 ms -> 176 ms
- nemotron_multipage.pdf (4 pages): ocr.page 682 ms -> 587 ms

(-10-14%: the win is bounded by bucket sparsity — 34 lines span 21 distinct widths on nemotron — and per-run dispatch overhead being small next to the conv compute, which batching does not reduce.)

Output is unchanged: under DOCLING_RS_PDF_THREADS=1 (the byte-stable protocol from the determinism note) the snapshot harness produces an IDENTICAL drift set with and without this change — same 22 files, same per-file diff-line counts, 69/91 both ways; that drift is environmental (models in this environment are rebuilt from source, the committed snapshots predate them) and not attributable to this patch. Markdown regression suite green. The CTC decode
is factored into decode_row (per row over the batched output), and the per-line preprocessing into prep_line; recognize(1 line) is subsumed by recognize_batch. PDF_CONFORMANCE.md item 6 updated with the numbers and the padding counter-evidence.

Closes #75


Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT