### PR TITLE
perf(tableformer): prefer the KV-cache decoder by default

### DIFF
--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -443,9 +443,11 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
      executes the legacy graph's full-prefix re-projection as one efficient
      batched GEMM, so the O(n²) FLOPs don't become O(n²) wall time until
      tables get much larger. The Rust loop auto-detects either graph (input
-     names) and prefers the smaller legacy file by default; point
-     `DOCLING_TABLEFORMER_DECODER` at `decoder_kv(_int8).onnx` for
-     very-large-table workloads.
+     names) and now prefers `decoder_kv(_int8).onnx` by default — re-measured
+     warm it is ~13% faster on ordinary corpus tables and ~17% on the
+     huge-table page (2305.03393v1-pg9), byte-identical output (91/91), for
+     +36 MB on disk; point `DOCLING_TABLEFORMER_DECODER` at the legacy
+     `decoder(_int8).onnx` to trade the speed back for the smaller file.
 3. ~~**Layout batching for the parallel path**: the pool currently runs batch-1
    inference per page.~~ **Done (issue #73)**: each pool worker drains the work
    channel opportunistically (whatever is already rendered, up to

--- a/crates/docling-pdf/src/tableformer.rs
+++ b/crates/docling-pdf/src/tableformer.rs
@@ -108,24 +108,26 @@ impl TableFormer {
             .unwrap_or_else(|_| crate::resolve_asset("models/tableformer/encoder.onnx"));
         // Decoder preference (explicit override wins): INT8 variants first
         // unless DOCLING_RS_FP32 opts out; within a precision the true-KV-cache
-        // export (`decoder_kv*`, one token per step) ranks behind the legacy
-        // layer-output-cache graph it matches byte-for-byte — measured parity on
-        // corpus-sized tables (ORT batches the legacy graph's prefix
-        // re-projection efficiently), so the smaller legacy file stays the
-        // default and `decoder_kv*` serves very-large-table workloads, where its
-        // O(past) step cost wins.
+        // export (`decoder_kv*`, one token per step, O(past) step cost) ranks
+        // ahead of the legacy layer-output-cache graph it matches byte-for-byte
+        // (91/91 snapshot corpus exact with either). Re-measured warm on the
+        // corpus fixtures: the KV graph is ~13% faster on ordinary tables
+        // (2206.01062) and ~17% on the huge-table page (2305.03393v1-pg9),
+        // for +36 MB on disk — table-heavy single-page PDFs are exactly where
+        // the pipeline is tightest against Python docling, so speed wins the
+        // default and the legacy file stays as the smaller fallback.
         let dec = std::env::var("DOCLING_TABLEFORMER_DECODER").unwrap_or_else(|_| {
             let candidates: &[&str] = if crate::fp32_forced() {
                 &[
-                    "models/tableformer/decoder.onnx",
                     "models/tableformer/decoder_kv.onnx",
+                    "models/tableformer/decoder.onnx",
                 ]
             } else {
                 &[
-                    "models/tableformer/decoder_int8.onnx",
                     "models/tableformer/decoder_kv_int8.onnx",
-                    "models/tableformer/decoder.onnx",
+                    "models/tableformer/decoder_int8.onnx",
                     "models/tableformer/decoder_kv.onnx",
+                    "models/tableformer/decoder.onnx",
                 ]
             };
             candidates


### PR DESCRIPTION
The legacy layer-output-cache decoder was the default on a measured parity that no longer holds: warm re-measurement puts decoder_kv ~13% ahead on ordinary corpus tables (2206.01062) and ~17% on the huge-table page (2305.03393v1-pg9) — the exact fixture where the pipeline was slightly behind warm Python docling in performance.sh (0.9x). Output is byte-identical (snapshot corpus 91/91 exact with either graph); the cost is +36 MB on disk. DOCLING_TABLEFORMER_DECODER still overrides to the legacy file for memory-tight deployments.