### PR TITLE
debug(pdf): log chosen layout/TableFormer model paths under DOCLING_R…

### DIFF
--- a/crates/docling-pdf/src/layout.rs
+++ b/crates/docling-pdf/src/layout.rs
@@ -97,6 +97,9 @@ impl LayoutModel {
             "models/layout_heron.onnx",
             "models/layout_heron_int8.onnx",
         );
+        if crate::timing::enabled() {
+            eprintln!("docling-pdf: layout model: {path}");
+        }
         let session = Session::builder()
             .map_err(|e| format!("layout: builder: {e}"))?
             // Let inference use the available cores (ort otherwise defaults low);

--- a/crates/docling-pdf/src/tableformer.rs
+++ b/crates/docling-pdf/src/tableformer.rs
@@ -138,6 +138,9 @@ impl TableFormer {
         });
         let bbx = std::env::var("DOCLING_TABLEFORMER_BBOX")
             .unwrap_or_else(|_| crate::resolve_asset("models/tableformer/bbox.onnx"));
+        if crate::timing::enabled() {
+            eprintln!("docling-pdf: tableformer decoder: {dec}");
+        }
         if [&enc, &dec, &bbx]
             .iter()
             .any(|p| !std::path::Path::new(p).exists())

--- a/crates/docling-pdf/src/timing.rs
+++ b/crates/docling-pdf/src/timing.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
-fn enabled() -> bool {
+pub(crate) fn enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| std::env::var("DOCLING_RS_TIMING").is_ok())
 }


### PR DESCRIPTION
…S_TIMING

Which decoder variant actually loaded (legacy vs KV, fp32 vs int8) was invisible — the preference order, env overrides, and what a release happens to host all feed the choice, which made 'why didn't the KV speedup show up' undiagnosable from timing output alone. With DOCLING_RS_TIMING=1 the layout and TableFormer loaders now print the resolved model path once at load.