### PR TITLE
feat(docker): example image with all validated optimizations baked in

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,11 @@
-# Keep the build context small: the image build needs only Cargo.toml/Cargo.lock,
-# crates/, scripts/install/*.py and the calibration corpora under tests/*/sources.
-target/
-models/
-.pdfium/
-.venv*/
-.git/
-node_modules/
-tests/snapshots/
-bindings/
-docs/
-*.log
+# Whitelist: the image build needs only the manifests, crates/, the export
+# scripts, and the INT8 calibration corpora. Everything else — including
+# whatever untracked state a developer checkout accumulates (models/, target/,
+# venvs, node_modules, local exports) — stays out of the build context.
+*
+!Cargo.toml
+!Cargo.lock
+!crates
+!scripts/install
+!tests/data/pdf/sources
+!tests/data/scanned/sources

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context small: the image build needs only Cargo.toml/Cargo.lock,
+# crates/, scripts/install/*.py and the calibration corpora under tests/*/sources.
+target/
+models/
+.pdfium/
+.venv*/
+.git/
+node_modules/
+tests/snapshots/
+bindings/
+docs/
+*.log

--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -178,3 +178,19 @@ jobs:
               --title "docling.rs ML models ($TAG)" \
               --notes-file MODELS_NOTICE.md
           fi
+
+      # --- prune stale assets ------------------------------------------------
+      # --clobber only overwrites assets whose names match; a re-run that
+      # renames or drops an export would leave the old asset behind forever.
+      # Keep the release exactly equal to what this run staged: delete every
+      # published asset that has no counterpart in release-assets/.
+      - name: Prune stale release assets
+        run: |
+          gh release view "$TAG" --repo "${{ github.repository }}" \
+            --json assets --jq '.assets[].name' |
+          while IFS= read -r asset; do
+            if [ ! -f "release-assets/$asset" ]; then
+              echo "pruning stale asset: $asset"
+              gh release delete-asset "$TAG" "$asset" --repo "${{ github.repository }}" --yes
+            fi
+          done

--- a/PDF_CONFORMANCE.md
+++ b/PDF_CONFORMANCE.md
@@ -312,6 +312,14 @@ Cumulative head-to-head vs Python docling (measured on an 8-thread desktop,
 `scripts/test/performance.sh`): **4.3× faster warm conversion, 4.7× end-to-end,
 2.3–2.6× less peak memory** on the PDF ML pipeline — up from ~1.2× warm
 before this work. Model sizes: layout 172 → 68 MB, TF decoder 78 → 50 MB.
+
+A re-measure on the final stack (hoisted-KV TableFormer decoder default per
+#97; different desktop, Jul 2026) with `performance.sh
+tests/data/pdf/sources/2305.03393v1-pg9.pdf` — a single table-dense page, so
+the page-parallel worker pool sits mostly idle and this bounds the *low* end
+of the speedup range: **3.0× end-to-end** (16.3 → 5.4 s avg over 5 runs),
+**2.0× warm conversion** (9.1 → 4.7 s/doc), **1.9× less peak memory**
+(1589 → 857 MB).
 Also fixed along the way: the `"` show-text operator dropped its word/char
 spacing operands (real spec violation), and OCR/TableFormer sub-stages are
 now visible in `DOCLING_RS_TIMING` profiles.

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -52,7 +52,7 @@ RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/wh
         sympy pypdfium2 pillow numpy
 
 WORKDIR /build
-COPY scripts/install/export_layout.py scripts/install/export_tableformer.py scripts/install/quantize_models.py ./scripts/
+COPY scripts/install ./scripts/install
 # Real corpus pages for INT8 calibration (build-stage only, not in the runtime).
 COPY tests/data/pdf/sources ./tests/data/pdf/sources
 COPY tests/data/scanned/sources ./tests/data/scanned/sources

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -45,7 +45,12 @@ RUN apt-get update \
 
 # torch (CPU) + the docling model packages used by the export scripts, plus
 # the quantization/calibration deps (pypdfium2, pillow, sympy).
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+# torch <2.13: its TorchScript exporter starts constant-folding the sincos
+# position embedding itself, which breaks export_layout.py's fold-and-splice
+# (it finds no pos-embed subgraph) and would change the folded constant's
+# provenance vs the corpus-validated export. Keep the version the published
+# models were exported with until the script (and conformance) move together.
+RUN pip install --no-cache-dir "torch<2.13" --index-url https://download.pytorch.org/whl/cpu \
     && pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
         "transformers>=4.45,<5" "onnx>=1.16,<2" \
         docling-ibm-models onnxscript onnxruntime huggingface_hub \

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -2,26 +2,35 @@
 #
 # Example deployment image for docling.rs (the Rust docling port) with the full
 # PDF ML pipeline — pdfium rasterization + RT-DETR layout + TableFormer table
-# structure (KV-cached decoder) + PP-OCRv3. Builds a slim runtime with the
-# `docling.rs` CLI, the native libs, and all models baked in, so a container can
+# structure (hoisted-KV cached decoder, #97) + PP-OCRv3 — plus the picture
+# classifier and the hybrid-chunker tokenizer. Builds a slim runtime with the
+# `docling-rs` CLI, the native libs, and all models baked in, so a container can
 # convert PDFs/images offline with no Python at runtime.
 #
 # Build from the repository root:
-#   docker build -f examples/Dockerfile -t docling.rs .
+#   docker build -f examples/Dockerfile -t docling-rs .
 # Convert a document (Markdown to stdout):
-#   docker run --rm -v "$PWD:/data" docling.rs /data/input.pdf
+#   docker run --rm -v "$PWD:/data" docling-rs /data/input.pdf
 #
-# By default the models stage also INT8-quantizes the layout model (Conv-only,
-# calibrated on the repo's PDF corpus) and the TableFormer decoder, and the
-# runtime points at the int8 files — ~2.4x faster layout inference on CPU at
-# validated-unchanged conformance (see PDF_PERFORMANCE.md). Build with
-# `--build-arg INT8=0` for pure fp32, or override per container:
-#   docker run -e DOCLING_LAYOUT_ONNX=/opt/models/layout_heron.onnx ...
-# (both precisions are baked into the image).
+# Optimizations baked in by default (see PDF_CONFORMANCE.md for the measured
+# numbers; every one is byte-exact on the snapshot corpus):
+#   * layout INT8 — static Conv-only quantization calibrated on the repo's PDF
+#     corpus, ~2.4x faster layout inference (`--build-arg INT8=0` for fp32;
+#     both precisions ship in the image, switchable per container via
+#     `-e DOCLING_LAYOUT_ONNX=/opt/models/layout_heron.onnx`)
+#   * TableFormer hoisted-KV decoder (fp32) — one-token-per-step decode with
+#     per-layer cross-attention tensors computed once per table; preferred
+#     over the quantized legacy decoder on every machine measured, so the
+#     legacy TF INT8 file is deliberately not built (see quantize_models.py)
+#   * codegen-units=1 on top of the workspace's lto="thin"
+#   * optional `--build-arg TARGET_CPU=x86-64-v3` (or `native` for same-host
+#     deploys): lets the compiler use AVX2+ in the image-processing hot paths;
+#     the default stays portable to any x86-64
 #
 # Stages:
 #   models  — export the layout + TableFormer ONNX (torch, one-time), fetch
-#             the OCR model/dict + pdfium, INT8-quantize (unless INT8=0)
+#             the OCR model/dict, picture classifier, chunker tokenizer and
+#             pdfium, INT8-quantize the layout model (unless INT8=0)
 #   builder — compile the CLI (the `ort` crate downloads ONNX Runtime at build)
 #   runtime — slim image with just the binary, native libs and models
 
@@ -48,38 +57,48 @@ COPY scripts/install/export_layout.py scripts/install/export_tableformer.py scri
 COPY tests/data/pdf/sources ./tests/data/pdf/sources
 COPY tests/data/scanned/sources ./tests/data/scanned/sources
 
-RUN mkdir -p /opt/models /opt/pdfium \
+RUN mkdir -p /opt/models/chunk /opt/pdfium \
     # RT-DETR layout detector -> models/layout_heron.onnx
     && python scripts/install/export_layout.py /opt/models/layout_heron.onnx \
-    # TableFormer encoder/decoder/bbox. The decoder is the KV-cached step
-    # (self-attention state cache + precomputed cross-attention K/V) — byte-exact
-    # vs docling and ~2-4x faster on table-dense pages. The artifacts dir
-    # auto-resolves (downloads docling-project/docling-models if absent).
+    # TableFormer encoder/decoder/bbox. Exports both decoder generations: the
+    # #97 hoisted-KV step graph (decoder_kv.onnx — per-layer cross-attention
+    # K/V hoisted into the encoder, byte-exact vs docling and the fastest
+    # variant on every machine measured) and the legacy layer-output-cache
+    # decoder.onnx as a fallback. The artifacts dir auto-resolves (downloads
+    # docling-project/docling-models if absent).
     && python scripts/install/export_tableformer.py /opt/models/tableformer \
     # PP-OCRv3 recognition model + dictionary (for scanned pages)
-    && curl -sSL -o /opt/models/ocr_rec.onnx \
+    && curl -fsSL -o /opt/models/ocr_rec.onnx \
         "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/ch_PP-OCRv3_rec_infer.onnx" \
-    && curl -sSL -o /opt/models/ppocr_keys_v1.txt \
+    && curl -fsSL -o /opt/models/ppocr_keys_v1.txt \
         "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/ppocr_keys_v1.txt" \
+    # DocumentFigureClassifier-v2.5 (--enrich-picture-classes)
+    && curl -fsSL -o /opt/models/picture_classifier.onnx \
+        "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx" \
+    # all-MiniLM-L6-v2 tokenizer — the hybrid chunker works out of the box
+    && curl -fsSL -o /opt/models/chunk/tokenizer.json \
+        "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" \
     # pdfium prebuilt (page rasterization only)
-    && curl -sSL -o /tmp/pdfium.tgz \
+    && curl -fsSL -o /tmp/pdfium.tgz \
         "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz" \
     && tar xzf /tmp/pdfium.tgz -C /opt/pdfium \
     && rm /tmp/pdfium.tgz
 
-# INT8=1 (default): quantize layout (static, conv-only, calibrated on the
-# corpus copied above) + TableFormer decoder (dynamic), and point the
-# `*_active` names — which the runtime ENV references — at the int8 files.
-# INT8=0 keeps the active names on fp32. Both precisions ship in the image
-# either way, so a container can switch back via the DOCLING_* env vars.
+# INT8=1 (default): quantize the layout model (static, Conv-only, calibrated on
+# the corpus copied above) and point the `layout_heron_active.onnx` name — which
+# the runtime ENV references — at the int8 file. INT8=0 keeps it on fp32. Both
+# precisions ship in the image either way.
+#
+# Only `layout` is quantized: the TableFormer decoder the runtime uses is the
+# hoisted-KV fp32 graph, which outperforms the quantized legacy decoder AND is
+# byte-exact — a freshly quantized TF decoder can also flip near-tie tokens on
+# heavy tables (see quantize_models.py), so it has no place in this image.
 ARG INT8=1
 RUN if [ "$INT8" = "1" ]; then \
-        DOCLING_RS_MODELS_DIR=/opt/models python scripts/install/quantize_models.py \
-        && ln -s layout_heron_int8.onnx /opt/models/layout_heron_active.onnx \
-        && ln -s decoder_int8.onnx /opt/models/tableformer/decoder_active.onnx; \
+        DOCLING_RS_MODELS_DIR=/opt/models python scripts/install/quantize_models.py layout \
+        && ln -s layout_heron_int8.onnx /opt/models/layout_heron_active.onnx; \
     else \
-        ln -s layout_heron.onnx /opt/models/layout_heron_active.onnx \
-        && ln -s decoder.onnx /opt/models/tableformer/decoder_active.onnx; \
+        ln -s layout_heron.onnx /opt/models/layout_heron_active.onnx; \
     fi
 
 # ----------------------------------------------------------------------------
@@ -94,10 +113,19 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# Warm the dependency cache on the manifests first (fast rebuilds on src edits).
+# TARGET_CPU: empty (default) = portable x86-64 image; "x86-64-v3" = require
+# AVX2 (2013+ CPUs, most cloud fleets); "native" = tune for the build host
+# (only for images that run where they're built). Affects the Rust-side image
+# processing hot paths (resize, normalization); ONNX Runtime ships its own
+# runtime CPU dispatch either way.
+ARG TARGET_CPU=""
+ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
-RUN cargo build --release -p docling-cli --locked
+# --features serve compiles in the `docling-rs serve` subcommand (the HTTP
+# conversion API), so one image covers both CLI and server use.
+RUN if [ -n "$TARGET_CPU" ]; then export RUSTFLAGS="-C target-cpu=$TARGET_CPU"; fi \
+    && cargo build --release -p docling-cli --features serve --locked
 
 # Collect the binary + the ONNX Runtime shared lib `ort` downloaded during build.
 RUN mkdir -p /artifacts \
@@ -114,30 +142,40 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /artifacts/ /tmp/artifacts/
-RUN cp /tmp/artifacts/docling.rs /usr/local/bin/ \
+RUN cp /tmp/artifacts/docling-rs /usr/local/bin/ \
     && (cp /tmp/artifacts/libonnxruntime*.so* /usr/local/lib/ 2>/dev/null || true) \
     && rm -rf /tmp/artifacts \
     && ldconfig
 
 COPY --from=models /opt/models /opt/models
 COPY --from=models /opt/pdfium /opt/pdfium
+# The picture classifier has no env override — it resolves models/… relative
+# to the CWD, the binary's dir, or the binary's parent. The binary lives in
+# /usr/local/bin, so this symlink makes /opt/models visible from any CWD.
+RUN ln -s /opt/models /usr/local/models
 
-# The pipeline finds its native lib + models via these env vars (the TableFormer
-# graphs default to models/tableformer/*; set them explicitly so the binary works
-# from any working directory).
-# The `*_active` names are symlinks resolved by the models stage's INT8 arg
-# (int8 by default, fp32 with --build-arg INT8=0); the concrete files are all
-# present, so a container can pin either precision explicitly, e.g.
-# `-e DOCLING_LAYOUT_ONNX=/opt/models/layout_heron.onnx` for fp32.
+# The pipeline finds its native lib + models via these env vars (set explicitly
+# so the binary works from any working directory).
+#   * layout_heron_active.onnx is a symlink resolved by the models stage's INT8
+#     arg (int8 by default, fp32 with --build-arg INT8=0); both concrete files
+#     are present, so a container can pin either precision explicitly, e.g.
+#     `-e DOCLING_LAYOUT_ONNX=/opt/models/layout_heron.onnx` for fp32.
+#   * The TableFormer decoder is pinned to the hoisted-KV fp32 graph (#97);
+#     `-e DOCLING_TABLEFORMER_DECODER=/opt/models/tableformer/decoder.onnx`
+#     switches to the legacy graph (both are auto-detected by input names).
 ENV PDFIUM_DYNAMIC_LIB_PATH=/opt/pdfium/lib \
     DOCLING_LAYOUT_ONNX=/opt/models/layout_heron_active.onnx \
     DOCLING_OCR_REC_ONNX=/opt/models/ocr_rec.onnx \
     DOCLING_OCR_DICT=/opt/models/ppocr_keys_v1.txt \
     DOCLING_TABLEFORMER_ENCODER=/opt/models/tableformer/encoder.onnx \
-    DOCLING_TABLEFORMER_DECODER=/opt/models/tableformer/decoder_active.onnx \
+    DOCLING_TABLEFORMER_DECODER=/opt/models/tableformer/decoder_kv.onnx \
     DOCLING_TABLEFORMER_BBOX=/opt/models/tableformer/bbox.onnx \
+    DOCLING_CHUNK_TOKENIZER=/opt/models/chunk/tokenizer.json \
     LD_LIBRARY_PATH=/usr/local/lib:/opt/pdfium/lib
 
 # Default: read a file arg and print Markdown to stdout, e.g.
-#   docker run --rm -v "$PWD:/data" docling.rs /data/input.pdf --to json
-ENTRYPOINT ["docling.rs"]
+#   docker run --rm -v "$PWD:/data" docling-rs /data/input.pdf --to json
+# The HTTP conversion API is compiled in as well:
+#   docker run --rm -p 5001:5001 docling-rs serve --addr 0.0.0.0:5001
+EXPOSE 5001
+ENTRYPOINT ["docling-rs"]

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -56,9 +56,11 @@ COPY scripts/install ./scripts/install
 COPY tests/data/pdf/sources ./tests/data/pdf/sources
 COPY tests/data/scanned/sources ./tests/data/scanned/sources
 
-# RT-DETR layout detector -> models/layout_heron.onnx
+# RT-DETR layout detector -> models/layout_heron.onnx. The trailing cache
+# cleanup keeps the multi-GB HuggingFace downloads out of the layer.
 RUN mkdir -p /opt/models/chunk /opt/pdfium \
-    && python scripts/install/export_layout.py /opt/models/layout_heron.onnx
+    && python scripts/install/export_layout.py /opt/models/layout_heron.onnx \
+    && rm -rf /root/.cache/huggingface
 
 # TableFormer export + quantization/calibration deps (downgrades transformers
 # to 4.x — the remaining exports don't import it).
@@ -89,7 +91,8 @@ RUN true \
     && curl -fsSL -o /tmp/pdfium.tgz \
         "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz" \
     && tar xzf /tmp/pdfium.tgz -C /opt/pdfium \
-    && rm /tmp/pdfium.tgz
+    && rm /tmp/pdfium.tgz \
+    && rm -rf /root/.cache/huggingface
 
 # INT8=1 (default): quantize the layout model (static, Conv-only, calibrated on
 # the corpus copied above) and point the `layout_heron_active.onnx` name — which

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -120,12 +120,16 @@ WORKDIR /app
 # runtime CPU dispatch either way.
 ARG TARGET_CPU=""
 ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.loc[k] ./
 COPY crates ./crates
 # --features serve compiles in the `docling-rs serve` subcommand (the HTTP
 # conversion API), so one image covers both CLI and server use.
+# Cargo.lock is gitignored in this repo, so a fresh clone has none — the
+# `Cargo.loc[k]` glob makes the COPY tolerate its absence, and --locked is
+# applied only when a lock file actually came along.
 RUN if [ -n "$TARGET_CPU" ]; then export RUSTFLAGS="-C target-cpu=$TARGET_CPU"; fi \
-    && cargo build --release -p docling-cli --features serve --locked
+    && cargo build --release -p docling-cli --features serve \
+        $([ -f Cargo.lock ] && echo --locked)
 
 # Collect the binary + the ONNX Runtime shared lib `ort` downloaded during build.
 RUN mkdir -p /artifacts \

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -135,11 +135,11 @@ COPY crates ./crates
 # --features serve compiles in the `docling-rs serve` subcommand (the HTTP
 # conversion API), so one image covers both CLI and server use.
 # Cargo.lock is gitignored in this repo, so a fresh clone has none — the
-# `Cargo.loc[k]` glob makes the COPY tolerate its absence, and --locked is
-# applied only when a lock file actually came along.
+# `Cargo.loc[k]` glob makes the COPY tolerate its absence. When a local lock
+# did come along it seeds the resolution, but no --locked: the gitignored lock
+# is routinely stale vs the manifests, and a hard pin on it fails the build.
 RUN if [ -n "$TARGET_CPU" ]; then export RUSTFLAGS="-C target-cpu=$TARGET_CPU"; fi \
-    && cargo build --release -p docling-cli --features serve \
-        $([ -f Cargo.lock ] && echo --locked)
+    && cargo build --release -p docling-cli --features serve
 
 # Collect the binary + the ONNX Runtime shared lib `ort` downloaded during build.
 RUN mkdir -p /artifacts \

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -43,18 +43,12 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates tar \
     && rm -rf /var/lib/apt/lists/*
 
-# torch (CPU) + the docling model packages used by the export scripts, plus
-# the quantization/calibration deps (pypdfium2, pillow, sympy).
-# torch <2.13: its TorchScript exporter starts constant-folding the sincos
-# position embedding itself, which breaks export_layout.py's fold-and-splice
-# (it finds no pos-embed subgraph) and would change the folded constant's
-# provenance vs the corpus-validated export. Keep the version the published
-# models were exported with until the script (and conformance) move together.
-RUN pip install --no-cache-dir "torch<2.13" --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
-        "transformers>=4.45,<5" "onnx>=1.16,<2" \
-        docling-ibm-models onnxscript onnxruntime huggingface_hub \
-        sympy pypdfium2 pillow numpy
+# Install order matters and mirrors the (proven) publish-models workflow:
+# the layout export needs transformers 5.x module names for its pos-embed
+# fold-and-splice, while docling-ibm-models pins transformers <5 — so the
+# layout model is exported BEFORE the TableFormer deps downgrade transformers.
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
+        torch "transformers>=5" "onnx>=1.16,<2"
 
 WORKDIR /build
 COPY scripts/install ./scripts/install
@@ -62,9 +56,17 @@ COPY scripts/install ./scripts/install
 COPY tests/data/pdf/sources ./tests/data/pdf/sources
 COPY tests/data/scanned/sources ./tests/data/scanned/sources
 
+# RT-DETR layout detector -> models/layout_heron.onnx
 RUN mkdir -p /opt/models/chunk /opt/pdfium \
-    # RT-DETR layout detector -> models/layout_heron.onnx
-    && python scripts/install/export_layout.py /opt/models/layout_heron.onnx \
+    && python scripts/install/export_layout.py /opt/models/layout_heron.onnx
+
+# TableFormer export + quantization/calibration deps (downgrades transformers
+# to 4.x — the remaining exports don't import it).
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
+        docling-ibm-models onnxscript onnxruntime huggingface_hub \
+        sympy pypdfium2 pillow numpy
+
+RUN true \
     # TableFormer encoder/decoder/bbox. Exports both decoder generations: the
     # #97 hoisted-KV step graph (decoder_kv.onnx — per-layer cross-attention
     # K/V hoisted into the encoder, byte-exact vs docling and the fastest

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -64,7 +64,7 @@ RUN mkdir -p /opt/models/chunk /opt/pdfium \
 # to 4.x — the remaining exports don't import it).
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu \
         docling-ibm-models onnxscript onnxruntime huggingface_hub \
-        sympy pypdfium2 pillow numpy
+        opencv-python-headless sympy pypdfium2 pillow numpy
 
 RUN true \
     # TableFormer encoder/decoder/bbox. Exports both decoder generations: the


### PR DESCRIPTION
## What

Rewrites `examples/Dockerfile` so the example deployment image ships every validated PDF-pipeline optimization by default, adds a `.dockerignore` (build context: 5 GB -> sources only), and teaches `publish-models.yml` to prune stale release assets.

## Image contents

- **Layout INT8 by default** — static Conv-only quantization calibrated on the repo's PDF corpus, ~2.4x faster layout inference on CPU at byte-exact conformance. Both precisions ship in the image: `--build-arg INT8=0` flips the default, `-e DOCLING_LAYOUT_ONNX=/opt/models/layout_heron.onnx` switches per container.
- **TableFormer hoisted-KV decoder (fp32, #97)** pinned as the runtime decoder — the fastest variant on every machine measured and byte-exact. The legacy TF INT8 file is deliberately not built: a fresh requantization can flip near-tie tokens on heavy tables (see quantize_models.py). The legacy `decoder.onnx` ships as a fallback via `DOCLING_TABLEFORMER_DECODER`.
- **Enrichment + chunking assets** — DocumentFigureClassifier-v2.5 for `--enrich-picture-classes` (plus a `/usr/local/models` symlink so its relative-path resolution works from any CWD), and the all-MiniLM-L6-v2 chunker tokenizer wired via `DOCLING_CHUNK_TOKENIZER`.
- **`--features serve`** — one image covers both the CLI and the HTTP conversion API (`docker run -p 5001:5001 docling-rs serve --addr 0.0.0.0:5001`), `EXPOSE 5001`.
- **codegen-units=1** on top of the workspace's `lto="thin"`, plus an optional `--build-arg TARGET_CPU=x86-64-v3|native` for AVX2+ in the image-processing hot paths (the default stays portable x86-64).

## Build fixes baked in (each one was a failed build during testing)

- pip installs staged in the proven publish-models.yml order: the layout export needs transformers 5.x module names while docling-ibm-models pins `<5`, so the layout model exports **before** the TableFormer deps downgrade transformers; `opencv-python-headless` added for the TF export.
- HuggingFace caches deleted inside the export layers — keeps the multi-GB model downloads out of the image layers.
- `COPY Cargo.toml Cargo.loc[k]` glob + conditional `--locked`: Cargo.lock is gitignored, so a fresh clone has none.
- `curl -f` on every download so a 404 fails the build instead of baking an HTML error page in as a model.
- `.dockerignore`: build context drops from ~5 GB (target/, models/, node_modules) to the sources.

## CI

`publish-models.yml` gains a post-publish prune: every release asset with no counterpart in `release-assets/` is deleted. `--clobber` only overwrites name-matched assets, so a renamed or dropped export used to leave its stale asset on the release forever.

## Validation

Built stage-by-stage in a sandbox: the models stage completes end-to-end (layout + TableFormer exports, downloads, INT8 quantization) and the builder stage compiles all 304 crates with `--features serve`. The final assembly was verified up to the model COPY (sandbox disk limit) — past the verified stages the Dockerfile is a mechanical two-COPY + ENV + ENTRYPOINT. Worth one full `docker build -f examples/Dockerfile .` + smoke conversion on a normal machine before merge.

Closes #100