### PR TITLE
fix(ci): quote the ep-features test filter — YAML chokes on trailing ::

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: cargo check -p docling-cli --features "${{ matrix.features }}"
 
       - name: Test docling-pdf EP selection with GPU features
-        run: cargo test -p docling-pdf --lib --features "${{ matrix.features }}" ep::
+        run: 'cargo test -p docling-pdf --lib --features "${{ matrix.features }}" ep::'
 
   publish:
     name: release & publish


### PR DESCRIPTION
A plain YAML scalar can't end in a colon (the parser reads it as a mapping key), so the ep:: test-name filter in the ep-features job made the whole workflow file invalid and CI stopped running on master.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT