### PR TITLE
fix(ci): rebase the deps-update branch onto current master before push

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -74,6 +74,15 @@ jobs:
           git checkout -B deps/cargo-update
           git add Cargo.lock crates/docling-py/Cargo.lock
           git commit -m "chore(deps): weekly cargo update"
+          # Rebase onto master as of *now*, not as of job start: GitHub diffs a
+          # new branch against the current default branch, and if master gained
+          # a .github/workflows/ change while this job ran, the push would be
+          # rejected as a workflow update the token may not be allowed to make.
+          # (The RELEASE_PAT still needs the `workflow` scope for the weeks
+          # when the previous deps/cargo-update branch predates a workflow
+          # change on master — the force-push then legitimately rewrites it.)
+          git fetch origin master
+          git rebase origin/master
           git push --force -u origin deps/cargo-update
           {
             echo "Scheduled \`cargo update\` of both committed lockfiles;"


### PR DESCRIPTION
The weekly job checked out master at job start and pushed a new branch minutes later; GitHub diffs a new branch against the default branch at push time, so a workflow-file change merged to master mid-run made the push look like a workflow update and the PAT (no workflow scope) was rejected. Fetch + rebase right before pushing so the branch never trails master's workflows. The durable fix is granting RELEASE_PAT the workflow scope — the rolling branch will still legitimately rewrite workflow files whenever they changed on master since the previous week.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT