### PR TITLE
feat(#79): wasm32 target — declarative converters in the browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,45 @@ jobs:
       - name: Test docling-pdf EP selection with GPU features
         run: 'cargo test -p docling-pdf --lib --features "${{ matrix.features }}" ep::'
 
+  # The declarative converters compile for the browser (#79): check the
+  # feature-sliced `docling` on wasm32, build the wasm-bindgen crate, and log
+  # the gzipped module size (the number docs/README quote — ~1.8 MB).
+  wasm:
+    name: wasm32 (declarative converters)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable + wasm32 target)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      - name: Check docling (no default features) on wasm32
+        run: cargo check -p docling --no-default-features --target wasm32-unknown-unknown --locked
+
+      - name: Build docling-wasm (release)
+        run: cargo build -p docling-wasm --target wasm32-unknown-unknown --release --locked
+
+      - name: Host-side tests
+        run: cargo test -p docling-wasm --locked
+
+      - name: Module size
+        run: |
+          wasm=target/wasm32-unknown-unknown/release/docling_wasm.wasm
+          gzip -9 -c "$wasm" | wc -c | xargs -I{} echo "docling_wasm.wasm: $(stat -c%s "$wasm") bytes raw, {} bytes gzipped"
+
   publish:
     name: release & publish
     needs: [lint, test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
 
   # The declarative converters compile for the browser (#79): check the
   # feature-sliced `docling` on wasm32, build the wasm-bindgen crate, and log
-  # the gzipped module size (the number docs/README quote — ~1.8 MB).
+  # the gzipped module size (the number docs/README quote — ~1.9 MB).
   wasm:
     name: wasm32 (declarative converters)
     runs-on: ubuntu-latest
@@ -201,6 +201,9 @@ jobs:
 
       - name: Check docling (no default features) on wasm32
         run: cargo check -p docling --no-default-features --target wasm32-unknown-unknown --locked
+
+      - name: Check docling (pdf-text) on wasm32
+        run: cargo check -p docling --no-default-features --features pdf-text --target wasm32-unknown-unknown --locked
 
       - name: Build docling-wasm (release)
         run: cargo build -p docling-wasm --target wasm32-unknown-unknown --release --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Keep target/ small enough to cache and restore: no incremental artifacts
+  # (useless for one-shot CI builds, gigabytes on disk) and no debuginfo in
+  # dev/test binaries (the bulk of a debug target; tests behave the same,
+  # backtraces just lose line numbers). Without this the cached target/ grew
+  # past 6 GB compressed (~20 GB unpacked) and cache *restore* started dying
+  # with ENOSPC on the runner disk — which is also why every cache key below
+  # carries a `v2` generation: the old oversized entries must never match.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
   # Rust version for the style/lint gates. Pinned on purpose: rustfmt and clippy
   # change their output/lints between releases, so a floating `stable` would let
   # a new toolchain fail CI on otherwise-unrelated commits. Bump this manually
@@ -50,14 +60,27 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-lint-
+          key: ${{ runner.os }}-cargo-v2-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-lint-
 
       - name: Format
         run: cargo fmt --all --check
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true
 
   test:
     name: test (stable)
@@ -78,8 +101,8 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-test-
+          key: ${{ runner.os }}-cargo-v2-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-test-
 
       # Pure-Rust unit tests + the output-regression suite. The PDF/image/METS
       # snapshot tests need pdfium + the ONNX models, so they are NOT run here —
@@ -88,6 +111,19 @@ jobs:
       # (a Cargo.toml change without its lock update fails here).
       - name: Test
         run: cargo test --workspace --locked
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true
 
   # Validate the declared `rust-version` floors against the committed
   # Cargo.lock (rust-lang.org/2023/08/29/committing-lockfiles: a committed
@@ -115,14 +151,27 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-msrv-
+          key: ${{ runner.os }}-cargo-v2-msrv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-msrv-
 
       - name: Check docling-core on ${{ env.MSRV_CORE }}
         run: cargo +${{ env.MSRV_CORE }} check -p docling-core --locked
 
       - name: Check workspace on ${{ env.MSRV_WORKSPACE }}
         run: cargo +${{ env.MSRV_WORKSPACE }} check --workspace --locked
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true
 
   # Build-verify the GPU execution-provider features (#74) without GPU
   # runners: `cargo check` proves the feature plumbing and the EP registration
@@ -165,14 +214,27 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-ep-${{ matrix.slug }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-ep-${{ matrix.slug }}-
+          key: ${{ runner.os }}-cargo-v2-ep-${{ matrix.slug }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-ep-${{ matrix.slug }}-
 
       - name: Check docling-cli with GPU features
         run: cargo check -p docling-cli --features "${{ matrix.features }}"
 
       - name: Test docling-pdf EP selection with GPU features
         run: 'cargo test -p docling-pdf --lib --features "${{ matrix.features }}" ep::'
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true
 
   # The declarative converters compile for the browser (#79): check the
   # feature-sliced `docling` on wasm32, build the wasm-bindgen crate, and log
@@ -196,8 +258,8 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-wasm-
+          key: ${{ runner.os }}-cargo-v2-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-wasm-
 
       - name: Check docling (no default features) on wasm32
         run: cargo check -p docling --no-default-features --target wasm32-unknown-unknown --locked
@@ -215,6 +277,19 @@ jobs:
         run: |
           wasm=target/wasm32-unknown-unknown/release/docling_wasm.wasm
           gzip -9 -c "$wasm" | wc -c | xargs -I{} echo "docling_wasm.wasm: $(stat -c%s "$wasm") bytes raw, {} bytes gzipped"
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true
 
   publish:
     name: release & publish
@@ -245,8 +320,8 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-publish-
+          key: ${{ runner.os }}-cargo-v2-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-v2-publish-
 
       # Decide the next version from conventional commits since the last tag (or
       # use force_version on a manual dispatch); if there is one, bump + commit +
@@ -279,3 +354,16 @@ jobs:
           else
             gh release create "$tag" --title "$tag" --notes-file "$notes" --verify-tag
           fi
+
+      # actions/cache saves target/ in its post-step, i.e. after this runs:
+      # drop what is cheap to recreate (incremental data shouldn't exist with
+      # CARGO_INCREMENTAL=0; examples and final bin-crate executables relink
+      # in seconds — the compiled library deps are what's worth keeping), so
+      # the cache stays well under the runner's disk headroom.
+      - name: Trim target before cache save
+        if: always()
+        shell: bash
+        run: |
+          rm -rf target/debug/examples target/debug/incremental \
+                 target/release/examples target/release/incremental
+          find target/debug target/release -maxdepth 1 -type f ! -name '*.d' -size +5M -exec rm -f {} + 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # ONNX Runtime profiler output (written to CWD when session profiling is on)
 onnxruntime_profile_*.json
 
+# wasm-bindgen output for the docling-wasm demo (built from source, see its README)
+crates/docling-wasm/www/pkg/
+
 # Secrets — never commit (holds CARGO_REGISTRY_TOKEN)
 .env
 .env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "docling-wasm"
+version = "0.41.2"
+dependencies = [
+ "console_error_panic_hook",
+ "docling",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "crates/docling-rag",
     # HTTP conversion API (docling-serve analogue): axum server over the converter.
     "crates/docling-serve",
+    # wasm32 build of the declarative converters (browser/edge, issue #79).
+    "crates/docling-wasm",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ on a 1913-page document — see [`docs/PDF_CONFORMANCE.md`](./docs/PDF_CONFORMAN
 | `docling-cli` | command-line interface | `docling.cli` |
 | `docling-node` | Node.js / Bun N-API bindings | https://www.npmjs.com/package/docling.rs |
 | `docling-py` | Python bindings | https://pypi.org/project/docling-rs |
+| `docling-wasm` | WebAssembly bindings (declarative converters in the browser) | — |
 | `docling-rag` | RAG layer: chunking, embeddings, vector search, REST API | — |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ builds from [`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfil
 URL inputs make the server fetch outbound (SSRF surface): it binds loopback by
 default — front it with a policy proxy or pass `--no-url-fetch`.
 
+## In the browser — `docling-wasm`
+
+The declarative converters (everything except the PDF/image/audio ML
+pipelines) compile to `wasm32-unknown-unknown`:
+[`crates/docling-wasm`](./crates/docling-wasm) exposes
+`convert(bytes, filename, to)` → Markdown / docling JSON / DocLang via
+`wasm-bindgen`, so DOCX/HTML/XLSX/PPTX/EPUB/… convert **fully client-side** —
+no server, ~1.8 MB gzipped module, no models to download. Python docling has
+no equivalent. The crate ships a drop-a-file demo page; the `docling` library
+crate itself grew the feature slices behind this (`pdf` / `asr` /
+`fetch-images`, all in the default set — a plain `cargo build` is unchanged).
+
 ## The API
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ pipelines) compile to `wasm32-unknown-unknown`:
 [`crates/docling-wasm`](./crates/docling-wasm) exposes
 `convert(bytes, filename, to)` → Markdown / docling JSON / DocLang via
 `wasm-bindgen`, so DOCX/HTML/XLSX/PPTX/EPUB/… convert **fully client-side** —
-no server, ~1.9 MB gzipped module, no models to download. Digital PDFs
-convert too: the `pdf-text` feature runs docling-pdf's pure-Rust text-layer
-parser (the same extraction as `--no-ocr` — flat paragraphs, no
-headings/tables/pictures), while scanned PDFs get a clear "needs OCR" error.
-Python docling has no equivalent. The crate ships a drop-a-file demo page;
-the `docling` library crate itself grew the feature slices behind this
-(`pdf` / `asr` / `fetch-images`, all in the default set — a plain
-`cargo build` is unchanged — plus the opt-in `pdf-text`).
+no server, ~1.9 MB gzipped module, no models to download — something Python
+docling has no equivalent for. Digital PDFs convert too: the opt-in
+`pdf-text` feature runs docling-pdf's pure-Rust text-layer parser (the same
+extraction as `--no-ocr`: flat paragraphs, no headings/tables/pictures),
+while scanned PDFs get a clear "needs OCR" error instead of an empty
+document. The crate ships a drop-a-file demo page under
+[`www/`](./crates/docling-wasm/www). Native builds are untouched: the
+feature slices behind this (`pdf` / `asr` / `fetch-images`) all stay in the
+`docling` default set, so a plain `cargo build` is unchanged.
 
 ## The API
 

--- a/README.md
+++ b/README.md
@@ -105,10 +105,14 @@ pipelines) compile to `wasm32-unknown-unknown`:
 [`crates/docling-wasm`](./crates/docling-wasm) exposes
 `convert(bytes, filename, to)` → Markdown / docling JSON / DocLang via
 `wasm-bindgen`, so DOCX/HTML/XLSX/PPTX/EPUB/… convert **fully client-side** —
-no server, ~1.8 MB gzipped module, no models to download. Python docling has
-no equivalent. The crate ships a drop-a-file demo page; the `docling` library
-crate itself grew the feature slices behind this (`pdf` / `asr` /
-`fetch-images`, all in the default set — a plain `cargo build` is unchanged).
+no server, ~1.9 MB gzipped module, no models to download. Digital PDFs
+convert too: the `pdf-text` feature runs docling-pdf's pure-Rust text-layer
+parser (the same extraction as `--no-ocr` — flat paragraphs, no
+headings/tables/pictures), while scanned PDFs get a clear "needs OCR" error.
+Python docling has no equivalent. The crate ships a drop-a-file demo page;
+the `docling` library crate itself grew the feature slices behind this
+(`pdf` / `asr` / `fetch-images`, all in the default set — a plain
+`cargo build` is unchanged — plus the opt-in `pdf-text`).
 
 ## The API
 
@@ -782,7 +786,7 @@ on a 1913-page document — see [`docs/PDF_CONFORMANCE.md`](./docs/PDF_CONFORMAN
 | `docling-cli` | command-line interface | `docling.cli` |
 | `docling-node` | Node.js / Bun N-API bindings | https://www.npmjs.com/package/docling.rs |
 | `docling-py` | Python bindings | https://pypi.org/project/docling-rs |
-| `docling-wasm` | WebAssembly bindings (declarative converters in the browser) | — |
+| `docling-wasm` | WebAssembly bindings (declarative converters + PDF text layer in the browser) | — |
 | `docling-rag` | RAG layer: chunking, embeddings, vector search, REST API | — |
 
 ## License

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -106,6 +106,12 @@ fn main() -> ExitCode {
                     return ExitCode::from(2);
                 }
             }
+            _ if arg.starts_with("--") => {
+                eprintln!(
+                    "error: unknown flag '{arg}' (enrichment flags: --enrich-picture-classes, --enrich-code, --enrich-formula)"
+                );
+                return ExitCode::from(2);
+            }
             _ => path = Some(arg),
         }
     }

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -12,6 +12,22 @@ categories.workspace = true
 rust-version.workspace = true
 
 [features]
+default = ["ml"]
+# The full pipeline: pdfium page rendering + ONNX layout/OCR/TableFormer/
+# enrichment. Without it only the pure-Rust text-layer path remains
+# (`convert_text_layer` — lopdf content-stream parsing + the docling-parse
+# line sanitizer, the same extraction `--no-ocr` uses), which compiles for
+# wasm32-unknown-unknown.
+ml = [
+    "dep:pdfium-render",
+    "dep:ort",
+    "dep:image",
+    "dep:fast_image_resize",
+    "dep:tokenizers",
+    "dep:flate2",
+    "dep:tar",
+    "dep:regex",
+]
 # GPU execution providers (#74). Each feature makes `ort` link/download an
 # ONNX Runtime binary that contains that provider; which provider actually
 # runs is chosen at startup via DOCLING_RS_EP (default: cpu). CPU stays the
@@ -22,25 +38,25 @@ rust-version.workspace = true
 # are separate shared libraries (libonnxruntime_providers_*.so) that must sit
 # next to the binary at runtime — without the copy, registration fails with a
 # bare "cannot open shared object file" even on a machine with a working GPU.
-cuda = ["ort/cuda", "ort/copy-dylibs"]
-tensorrt = ["ort/tensorrt", "ort/copy-dylibs"]
-directml = ["ort/directml", "ort/copy-dylibs"]
-coreml = ["ort/coreml", "ort/copy-dylibs"]
+cuda = ["ml", "ort/cuda", "ort/copy-dylibs"]
+tensorrt = ["ml", "ort/tensorrt", "ort/copy-dylibs"]
+directml = ["ml", "ort/directml", "ort/copy-dylibs"]
+coreml = ["ml", "ort/coreml", "ort/copy-dylibs"]
 
 [dependencies]
 docling-core = { path = "../docling-core", version = "0.41.2" }
-pdfium-render = "0.8"
-ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-rustls"] }
-image = "0.25"
-flate2 = "1"
-tar = "0.4"
-regex = "1.11"
+pdfium-render = { version = "0.8", optional = true }
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-rustls"], optional = true }
+image = { version = "0.25", optional = true }
+flate2 = { version = "1", optional = true }
+tar = { version = "0.4", optional = true }
+regex = { version = "1.11", optional = true }
 lopdf = "0.34"
-fast_image_resize = "5.1.4"
+fast_image_resize = { version = "5.1.4", optional = true }
 # CodeFormula enrichment decodes its VLM output with the HF tokenizer
 # (models/code_formula/tokenizer.json) — same crate/features as docling-core's
 # chunking tokenizer.
-tokenizers = { version = "0.20", default-features = false, features = ["onig"] }
+tokenizers = { version = "0.20", default-features = false, features = ["onig"], optional = true }
 
 [lib]
 name = "docling_pdf"

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -6,6 +6,7 @@
 //! (two-column aware), and each becomes a typed node by its layout label.
 
 use docling_core::{Node, PictureClass, PictureImage, Table};
+#[cfg(feature = "ml")]
 use image::RgbImage;
 
 use crate::layout::Region;
@@ -1007,6 +1008,7 @@ pub enum Enrichment {
 /// `page.get_image(scale=…, cropbox=…)`, sourced from the existing
 /// [`crate::pdfium_backend::RENDER_SCALE`] render instead of a fresh pdfium
 /// pass (the page bitmap is already the exact docling render at scale 2).
+#[cfg(feature = "ml")]
 pub fn crop_region_scaled(page: &PdfPage, bbox: [f32; 4], target_scale: f32) -> Option<RgbImage> {
     let s = page.scale;
     let [l, t, r, b] = bbox;
@@ -1041,6 +1043,7 @@ pub fn crop_region_scaled(page: &PdfPage, bbox: [f32; 4], target_scale: f32) -> 
 /// Crop a layout region from the rendered page image and encode it as PNG (the
 /// figure bytes docling stores on a `PictureItem`). Region coordinates are page
 /// points; the image is rendered at `page.scale`.
+#[cfg(feature = "ml")]
 fn crop_region(page: &PdfPage, region: &Region) -> Option<PictureImage> {
     let s = page.scale;
     let (iw, ih) = (page.image.width(), page.image.height());
@@ -1300,11 +1303,17 @@ pub fn assemble_page(
                 Some(Enrichment::PictureClasses(classes)) => Some(classes.clone()),
                 _ => None,
             };
+            // Without the page render (text-layer-only build) a picture keeps
+            // its caption/classification but carries no cropped pixels.
+            #[cfg(feature = "ml")]
+            let image = crate::timing::timed("crop_region", || crop_region(page, region));
+            #[cfg(not(feature = "ml"))]
+            let image: Option<PictureImage> = None;
             nodes.push(located(
                 loc,
                 Node::Picture {
                     caption,
-                    image: crate::timing::timed("crop_region", || crop_region(page, region)),
+                    image,
                     classification,
                 },
             ));

--- a/crates/docling-pdf/src/layout.rs
+++ b/crates/docling-pdf/src/layout.rs
@@ -5,9 +5,13 @@
 //! `post_process_object_detection` (sigmoid → top-k over query×class →
 //! center-to-corners boxes scaled to the page).
 
+#[cfg(feature = "ml")]
 use image::imageops::FilterType;
+#[cfg(feature = "ml")]
 use image::RgbImage;
+#[cfg(feature = "ml")]
 use ort::session::Session;
+#[cfg(feature = "ml")]
 use ort::value::Tensor;
 
 /// The 17 canonical layout classes, indexed by the model's class id
@@ -43,10 +47,12 @@ pub struct Region {
     pub b: f32,
 }
 
+#[cfg(feature = "ml")]
 /// Base confidence threshold (docling-ibm-models `base_threshold`): the raw
 /// RT-DETR floor before docling's `LayoutPostprocessor` applies its stricter
 /// per-label thresholds ([`label_threshold`]).
 const THRESHOLD: f32 = 0.3;
+#[cfg(feature = "ml")]
 const SIDE: u32 = 640;
 
 /// Per-label confidence threshold, ported from docling's
@@ -71,6 +77,7 @@ pub fn label_threshold(label: &str) -> f32 {
     }
 }
 
+#[cfg(feature = "ml")]
 pub struct LayoutModel {
     session: Session,
     /// Set when a multi-page inference fails — e.g. a locally built pre-#73
@@ -80,6 +87,7 @@ pub struct LayoutModel {
     batch_unsupported: bool,
 }
 
+#[cfg(feature = "ml")]
 impl LayoutModel {
     /// Load the ONNX model from `DOCLING_LAYOUT_ONNX`. Without the override,
     /// prefers `models/layout_heron_int8.onnx` when present (the quantized
@@ -253,6 +261,7 @@ impl LayoutModel {
     }
 }
 
+#[cfg(feature = "ml")]
 fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -9,30 +9,50 @@
 //! and the deterministic text/reading-order assembly ([`assemble`]). The layout,
 //! table-structure and OCR ONNX stages land behind [`Pipeline`] next.
 
+// Without `ml` only the text-layer path runs; the shared assembly/label
+// helpers it doesn't exercise stay compiled for API stability (the full
+// build still flags genuinely dead code).
+#![cfg_attr(not(feature = "ml"), allow(dead_code))]
+
 mod assemble;
 mod dp_lines;
+#[cfg(feature = "ml")]
 pub mod enrich;
+#[cfg(feature = "ml")]
 pub(crate) mod ep;
 pub mod layout;
+#[cfg(feature = "ml")]
 mod mets;
+#[cfg(feature = "ml")]
 mod ocr;
 pub mod pdfium_backend;
 mod reading_order;
+#[cfg(feature = "ml")]
 pub mod resample;
+#[cfg(feature = "ml")]
 pub mod tableformer;
 pub mod textparse;
+#[cfg(feature = "ml")]
 mod tf_match;
 pub mod timing;
 
+#[cfg(feature = "ml")]
 use std::collections::BTreeMap;
 use std::fmt;
+#[cfg(feature = "ml")]
 use std::sync::mpsc::{sync_channel, Receiver};
+#[cfg(feature = "ml")]
 use std::sync::{Arc, Mutex};
 
-use docling_core::{DoclingDocument, Node};
+use docling_core::DoclingDocument;
+#[cfg(feature = "ml")]
+use docling_core::Node;
 
+#[cfg(feature = "ml")]
 pub use mets::{convert_mets_gbs, convert_mets_gbs_with_options};
-pub use pdfium_backend::{PdfDocument, PdfPage, TextCell};
+#[cfg(feature = "ml")]
+pub use pdfium_backend::PdfDocument;
+pub use pdfium_backend::{PdfPage, TextCell};
 
 /// Errors from the PDF backend. Detailed and surfaced (never silently skipped).
 #[derive(Debug)]
@@ -57,14 +77,41 @@ impl fmt::Display for PdfError {
 
 impl std::error::Error for PdfError {}
 
+#[cfg(feature = "ml")]
 impl From<pdfium_render::prelude::PdfiumError> for PdfError {
     fn from(e: pdfium_render::prelude::PdfiumError) -> Self {
         PdfError::Pdfium(e.to_string())
     }
 }
 
+/// Convert a PDF's **embedded text layer only** — no pdfium, no ONNX, no
+/// threads: the pure-Rust content-stream parser ([`textparse`]) feeds the same
+/// orphan-region assembly the `no_ocr` pipeline flag uses, so text-layer PDFs
+/// come out identical to `--no-ocr` (flat, line-grouped paragraphs in reading
+/// order; no headings/lists/tables/pictures, and no hyperlink recovery).
+///
+/// This is the only conversion entry compiled without the `ml` feature (it is
+/// what a wasm32 build runs). A scanned/image-only PDF (no embedded text
+/// layer) yields an empty document rather than an error, same as `no_ocr` —
+/// callers can detect that and fall back to an OCR-capable build.
+pub fn convert_text_layer(bytes: &[u8], name: &str) -> Result<DoclingDocument, PdfError> {
+    let mut doc = DoclingDocument::new(name);
+    for page in textparse::pdf_text_pages(bytes) {
+        let mut regions = Vec::new();
+        assemble::add_orphan_regions(&mut regions, &page.cells);
+        let table_rows = vec![None; regions.len()];
+        let enrich_out = vec![None; regions.len()];
+        let (nodes, links) = assemble::assemble_page(&page, regions, &table_rows, &enrich_out);
+        doc.nodes.extend(nodes);
+        doc.links.extend(links);
+    }
+    assemble::merge_continuations(&mut doc.nodes);
+    Ok(doc)
+}
+
 /// Threads ONNX inference may use, capped by `DOCLING_RS_PDF_THREADS` if set.
 /// Defaults to the available parallelism (ort otherwise picks a low number).
+#[cfg(feature = "ml")]
 pub(crate) fn intra_threads() -> usize {
     if let Some(n) = std::env::var("DOCLING_RS_PDF_THREADS")
         .ok()
@@ -78,6 +125,7 @@ pub(crate) fn intra_threads() -> usize {
         .unwrap_or(1)
 }
 
+#[cfg(feature = "ml")]
 /// True when `DOCLING_RS_FP32` (any value but `0`) forces the full-precision
 /// models even where an INT8 variant sits next to the fp32 default.
 pub(crate) fn fp32_forced() -> bool {
@@ -86,6 +134,7 @@ pub(crate) fn fp32_forced() -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(feature = "ml")]
 /// Should the int8 model defaults be skipped in favor of fp32? Either the
 /// user said so (`DOCLING_RS_FP32`), or a GPU execution provider is selected
 /// (#74) — the int8 exports are QDQ graphs calibrated for CPU kernels and
@@ -95,6 +144,7 @@ pub(crate) fn prefer_fp32() -> bool {
     fp32_forced() || ep::prefers_fp32()
 }
 
+#[cfg(feature = "ml")]
 /// Resolve a default (CWD-relative) asset path. If it doesn't exist relative
 /// to the current directory, try next to the executable and one level above
 /// it (following symlinks — the layout `scripts/install/install.sh` produces:
@@ -122,6 +172,7 @@ pub(crate) fn resolve_asset(rel: &str) -> String {
     rel.to_string()
 }
 
+#[cfg(feature = "ml")]
 /// Resolve a model path: an explicit env override always wins; otherwise the
 /// INT8 variant of the default path when it exists on disk (the quantized
 /// models are conformance-validated — see docs/PDF_CONFORMANCE.md — and load/run
@@ -140,10 +191,12 @@ pub(crate) fn model_path(env: &str, fp32_default: &str, int8_default: &str) -> S
     resolve_asset(fp32_default)
 }
 
+#[cfg(feature = "ml")]
 /// One page's assembled output: typed nodes plus the page's hyperlinks, kept
 /// separate so pages processed out of order can be stitched back in page order.
 type PageOut = (Vec<Node>, Vec<(String, String)>);
 
+#[cfg(feature = "ml")]
 /// The pool-wide TableFormer slot: one instance shared by every worker, loaded
 /// lazily on the first table region any worker sees. Tables appear on a
 /// minority of pages, so per-worker copies mostly multiplied ~0.4 GB of
@@ -161,8 +214,10 @@ enum TfSlot {
     Ready(tableformer::TableFormer),
 }
 
+#[cfg(feature = "ml")]
 type SharedTables = Arc<Mutex<TfSlot>>;
 
+#[cfg(feature = "ml")]
 /// The same lazy shared-slot pattern for the (rarer still) enrichment models:
 /// one instance per pipeline, loaded on the first region that needs it.
 enum EnrichSlot<T> {
@@ -172,9 +227,12 @@ enum EnrichSlot<T> {
     Ready(T),
 }
 
+#[cfg(feature = "ml")]
 type SharedClassifier = Arc<Mutex<EnrichSlot<enrich::PictureClassifier>>>;
+#[cfg(feature = "ml")]
 type SharedCodeFormula = Arc<Mutex<EnrichSlot<enrich::CodeFormula>>>;
 
+#[cfg(feature = "ml")]
 /// The opt-in enrichment passes, mirroring docling's `PdfPipelineOptions`
 /// flags (`do_picture_classification`, `do_code_enrichment`,
 /// `do_formula_enrichment`). All off by default.
@@ -188,12 +246,14 @@ pub struct EnrichmentOptions {
     pub formula: bool,
 }
 
+#[cfg(feature = "ml")]
 impl EnrichmentOptions {
     fn any(&self) -> bool {
         self.picture_classification || self.code || self.formula
     }
 }
 
+#[cfg(feature = "ml")]
 /// A self-contained set of the per-page models (layout, OCR). Each parallel
 /// page-worker owns its own `Worker` so inference runs concurrently without
 /// sharing an ONNX session (`ort`'s `Session::run` is `&mut self`); only the
@@ -213,6 +273,7 @@ struct Worker {
     no_ocr: bool,
 }
 
+#[cfg(feature = "ml")]
 impl Worker {
     fn load(
         intra: usize,
@@ -479,6 +540,7 @@ impl Worker {
     }
 }
 
+#[cfg(feature = "ml")]
 /// Per-worker ONNX intra-op threads. The layout model is memory-bandwidth bound,
 /// so on a typical machine two threads per worker (sharing one in-cache copy of
 /// the weights) extracts more throughput than one fat model or many single-thread
@@ -498,6 +560,7 @@ fn pdf_intra() -> usize {
     }
 }
 
+#[cfg(feature = "ml")]
 /// How many page-workers to spin up for a multi-page PDF. `DOCLING_RS_PDF_WORKERS`
 /// overrides; otherwise size the pool so `workers × intra ≈ cores`, capped at 4 so
 /// a worst-case pool holds a bounded amount of model memory (~0.4 GB per worker)
@@ -513,6 +576,7 @@ fn pdf_worker_count() -> usize {
     (intra_threads() / pdf_intra()).clamp(1, 4)
 }
 
+#[cfg(feature = "ml")]
 /// Max pages a worker layout-detects with one batched inference call (issue
 /// #73). Workers drain the work channel opportunistically up to this size —
 /// whatever is already rendered gets batched, so batching never *waits* for
@@ -533,6 +597,7 @@ fn pdf_layout_batch() -> usize {
         .unwrap_or_else(|| if intra_threads() >= 8 { 4 } else { 1 })
 }
 
+#[cfg(feature = "ml")]
 /// Minimum page count before a PDF is worth the parallel worker pool. Below this,
 /// the serial primary (running its model on every core) is faster than fanning out
 /// — the helper pool's one-time model-load cost only pays off once enough pages
@@ -545,6 +610,7 @@ fn pdf_parallel_min() -> usize {
         .unwrap_or(6)
 }
 
+#[cfg(feature = "ml")]
 /// A reusable PDF pipeline. The **primary** worker runs its models on every core,
 /// so a single-page / small / image / METS input is converted at full intra-op
 /// speed with no pool to load. A document with enough pages instead fans out
@@ -574,6 +640,7 @@ pub struct Pipeline {
     enrich: EnrichmentOptions,
 }
 
+#[cfg(feature = "ml")]
 impl Pipeline {
     /// Construct the pipeline. Models load lazily on first use (full-intra primary
     /// for serial inputs, the helper pool for multi-page PDFs), so nothing is
@@ -1065,6 +1132,7 @@ impl Pipeline {
     }
 }
 
+#[cfg(feature = "ml")]
 /// Convenience one-shot conversion (loads the pipeline per call). Errors are
 /// detailed and surfaced (never silently skipped).
 pub fn convert(
@@ -1082,6 +1150,7 @@ pub fn convert(
     )
 }
 
+#[cfg(feature = "ml")]
 /// Like [`convert`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
 /// [`Pipeline::no_ocr`]), and/or enables the enrichment passes (see
@@ -1101,11 +1170,13 @@ pub fn convert_with_options(
         .convert(bytes, password, name)
 }
 
+#[cfg(feature = "ml")]
 /// Convenience one-shot image conversion (loads the pipeline per call).
 pub fn convert_image(bytes: &[u8], name: &str) -> Result<DoclingDocument, PdfError> {
     convert_image_with_options(bytes, name, false, false, EnrichmentOptions::default())
 }
 
+#[cfg(feature = "ml")]
 /// Like [`convert_image`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
 /// [`Pipeline::no_ocr`]), and/or enables the enrichment passes.
@@ -1123,12 +1194,14 @@ pub fn convert_image_with_options(
         .convert_image(bytes, name)
 }
 
+#[cfg(feature = "ml")]
 /// Convert pre-segmented pages (image + already-known text cells, e.g. METS/hOCR
 /// scans) through the shared layout + assembly pipeline.
 pub fn convert_pages(pages: Vec<PdfPage>, name: &str) -> Result<DoclingDocument, PdfError> {
     convert_pages_with_options(pages, name, false, false, EnrichmentOptions::default())
 }
 
+#[cfg(feature = "ml")]
 /// Like [`convert_pages`], but optionally skips loading/running TableFormer (see
 /// [`Pipeline::no_table_former`]) and/or layout+OCR+TableFormer entirely (see
 /// [`Pipeline::no_ocr`]), and/or enables the enrichment passes.
@@ -1146,6 +1219,7 @@ pub fn convert_pages_with_options(
         .process_pages(pages, name)
 }
 
+#[cfg(feature = "ml")]
 #[cfg(test)]
 mod send_check {
     /// The Node bindings (`docling-node`) run a shared [`super::Pipeline`] on

--- a/crates/docling-pdf/src/pdfium_backend.rs
+++ b/crates/docling-pdf/src/pdfium_backend.rs
@@ -9,7 +9,9 @@
 //! loop is driven through the raw `PdfiumLibraryBindings` FFI on a second handle
 //! to the same bytes (no fork; stays publishable).
 
+#[cfg(feature = "ml")]
 use image::RgbImage;
+#[cfg(feature = "ml")]
 use pdfium_render::prelude::*;
 
 /// A run of text with its bounding box, in PDF points with a **top-left** origin
@@ -44,6 +46,7 @@ pub struct PdfPage {
     /// Per-word cells (one per word, not joined into lines) for TableFormer cell
     /// matching.
     pub word_cells: Vec<TextCell>,
+    #[cfg(feature = "ml")]
     pub image: RgbImage,
     /// Hyperlink annotations on the page (rect in top-left page coords + target
     /// URI), restricted to web/mail/tel schemes. Used only by strict Markdown.
@@ -61,6 +64,7 @@ pub struct LinkAnnot {
     pub uri: String,
 }
 
+#[cfg(feature = "ml")]
 /// A parsed PDF: per-page text cells and page images.
 pub struct PdfDocument {
     pub pages: Vec<PdfPage>,
@@ -94,6 +98,7 @@ pub(crate) fn use_parser_code() -> bool {
     std::env::var("DOCLING_PDFIUM_WORDS").is_err() && std::env::var("DOCLING_PDFIUM_TEXT").is_err()
 }
 
+#[cfg(feature = "ml")]
 /// Try binding pdfium from a directory (or a literal library file path):
 /// `<dir>/<platform library name>` first, else `<dir>` itself as the file.
 fn try_bind_dir(path: &str) -> Option<Box<dyn pdfium_render::prelude::PdfiumLibraryBindings>> {
@@ -104,6 +109,7 @@ fn try_bind_dir(path: &str) -> Option<Box<dyn pdfium_render::prelude::PdfiumLibr
     Pdfium::bind_to_library(path).ok()
 }
 
+#[cfg(feature = "ml")]
 /// Bind to the pdfium dynamic library. Honors `PDFIUM_DYNAMIC_LIB_PATH` (a
 /// directory or file) first; else falls back to `.pdfium/lib` relative to the
 /// current directory (the layout `scripts/install/download_dependencies.sh` and
@@ -125,6 +131,7 @@ fn bind() -> Result<Pdfium, PdfiumError> {
     Pdfium::bind_to_system_library().map(Pdfium::new)
 }
 
+#[cfg(feature = "ml")]
 impl PdfDocument {
     /// Parse a PDF from bytes, optionally decrypting with `password`.
     ///
@@ -144,6 +151,7 @@ impl PdfDocument {
     }
 }
 
+#[cfg(feature = "ml")]
 /// Per-page prose line cells from the pure-Rust text parser. This is the
 /// **default** text layer (it matches docling-parse's char geometry and is a
 /// strict improvement on byte-conformance — e.g. it recovers the Arabic
@@ -160,6 +168,7 @@ fn rust_parser_cells(bytes: &[u8]) -> Option<Vec<crate::textparse::PageParserCel
     }))
 }
 
+#[cfg(feature = "ml")]
 /// Number of pages in a PDF, without rendering any of them — used to decide
 /// whether a document is worth spinning up the parallel worker pool.
 pub fn page_count(bytes: &[u8], password: Option<&str>) -> Result<usize, PdfiumError> {
@@ -168,6 +177,7 @@ pub fn page_count(bytes: &[u8], password: Option<&str>) -> Result<usize, PdfiumE
     Ok(doc.pages().len() as usize)
 }
 
+#[cfg(feature = "ml")]
 /// Render + extract pages one at a time, handing each (owned) [`PdfPage`] to `f`.
 /// Only one page bitmap is resident at a time — a rendered page is ~5 MB, so a
 /// large PDF would otherwise hold gigabytes of bitmaps at once. `f` receives the
@@ -205,6 +215,7 @@ where
     Ok(())
 }
 
+#[cfg(feature = "ml")]
 fn extract_page(
     page: &pdfium_render::prelude::PdfPage<'_>,
     ffi: &FfiText<'_>,
@@ -284,6 +295,7 @@ fn extract_page(
     })
 }
 
+#[cfg(feature = "ml")]
 /// The supersample→target downscale via `fast_image_resize` (SIMD convolution;
 /// the same a=-0.5 Catmull-Rom kernel as `image::imageops::resize(...,
 /// CatmullRom)` and PIL BICUBIC — see the render comment above). Set
@@ -324,6 +336,7 @@ fn fast_downscale(big: &RgbImage, dw: u32, dh: u32) -> RgbImage {
     image::imageops::resize(big, dw, dh, image::imageops::FilterType::CatmullRom)
 }
 
+#[cfg(feature = "ml")]
 /// Collect web/mail/tel hyperlink annotations on a page, mapping each link's
 /// rectangle into top-left page coordinates (like [`TextCell`]). `file://` and
 /// in-document destinations are skipped — only externally meaningful targets are
@@ -357,6 +370,7 @@ fn extract_links(page: &pdfium_render::prelude::PdfPage<'_>, page_h: f32) -> Vec
     out
 }
 
+#[cfg(feature = "ml")]
 /// Fallback line cells from pdfium-render's style segments (one cell per
 /// segment). Used only when the raw-FFI text page can't be loaded.
 fn segment_cells(text: &PdfPageText, page_h: f32) -> Vec<TextCell> {
@@ -379,6 +393,7 @@ fn segment_cells(text: &PdfPageText, page_h: f32) -> Vec<TextCell> {
         .collect()
 }
 
+#[cfg(feature = "ml")]
 /// A second, raw-FFI handle on the same PDF used to drive the character loop
 /// (`FPDFText_GetUnicode`/`GetCharBox`) that pdfium-render's safe API doesn't
 /// expose. Closes the document on drop.
@@ -407,6 +422,7 @@ pub(crate) struct Glyph {
     pub(crate) font: u64,
 }
 
+#[cfg(feature = "ml")]
 impl<'a> FfiText<'a> {
     fn load(bindings: &'a dyn PdfiumLibraryBindings, bytes: &[u8], password: Option<&str>) -> Self {
         let doc = bindings.FPDF_LoadMemDocument(bytes, password);
@@ -452,6 +468,7 @@ impl<'a> FfiText<'a> {
     }
 }
 
+#[cfg(feature = "ml")]
 impl Drop for FfiText<'_> {
     fn drop(&mut self) {
         if !self.doc.is_null() {
@@ -460,6 +477,7 @@ impl Drop for FfiText<'_> {
     }
 }
 
+#[cfg(feature = "ml")]
 /// Read every glyph (codepoint + native box) from the text page, in document
 /// order. A space glyph is kept as a word-boundary marker (NaN box, char `' '`);
 /// pdfium emits these on most lines and they pin word splits exactly. Hard line
@@ -493,6 +511,7 @@ pub fn debug_glyphs(bytes: &[u8], index: i32) -> Vec<(char, f32, f32)> {
     out
 }
 
+#[cfg(feature = "ml")]
 /// One text object on a page, for the hidden-layer diagnostic.
 #[derive(Debug, Clone)]
 pub struct DebugTextObject {
@@ -508,6 +527,7 @@ pub struct DebugTextObject {
     pub text: String,
 }
 
+#[cfg(feature = "ml")]
 /// Diagnostic: every text object on page `index`, each tagged visible/invisible
 /// (via the object-level [`FPDFTextObj_GetTextRenderMode`], which — unlike the
 /// per-character render-mode API — is available on the default pdfium binding).
@@ -574,6 +594,7 @@ pub fn debug_text_objects(bytes: &[u8], index: i32) -> Vec<DebugTextObject> {
     out
 }
 
+#[cfg(feature = "ml")]
 /// Hash a glyph's PDF font name + flags, for `enforce_same_font`. 0 if unavailable.
 fn font_hash(b: &dyn PdfiumLibraryBindings, tp: FPDF_TEXTPAGE, i: i32) -> u64 {
     use std::hash::{Hash, Hasher};
@@ -596,12 +617,14 @@ fn font_hash(b: &dyn PdfiumLibraryBindings, tp: FPDF_TEXTPAGE, i: i32) -> u64 {
     h.finish()
 }
 
+#[cfg(feature = "ml")]
 /// pdfium text render mode 3: the glyph is drawn with neither fill nor stroke —
 /// an invisible glyph. Web-to-PDF exporters put a hidden plain-text copy of
 /// syntax-highlighted code (and other "copy"/accessibility layers) in this mode,
 /// which the char-level text API then extracts as a duplicate of the visible text.
 const INVISIBLE_RENDER_MODE: i32 = 3;
 
+#[cfg(feature = "ml")]
 fn glyphs(b: &dyn PdfiumLibraryBindings, tp: FPDF_TEXTPAGE, fetch_font: bool) -> Vec<Glyph> {
     let n = b.FPDFText_CountChars(tp);
     let mut out = Vec::with_capacity(n.max(0) as usize);

--- a/crates/docling-pdf/src/textparse.rs
+++ b/crates/docling-pdf/src/textparse.rs
@@ -730,6 +730,41 @@ pub fn pdf_all_cells(bytes: &[u8]) -> Vec<PageParserCells> {
         .collect()
 }
 
+/// Whole pages for the text-layer-only conversion ([`crate::convert_text_layer`]):
+/// the parser's prose/word/code cells plus page geometry, assembled into
+/// [`PdfPage`]s with no rendered image and no link annotations. Everything here
+/// is pure Rust (lopdf), so it compiles without the `ml` feature — including on
+/// wasm32. A page the parser can't read (no text layer) comes back with empty
+/// cells; there is no pdfium fallback on this path.
+pub fn pdf_text_pages(bytes: &[u8]) -> Vec<crate::pdfium_backend::PdfPage> {
+    let Ok(doc) = Document::load_mem(bytes) else {
+        return Vec::new();
+    };
+    let mut caches = DocCaches::default();
+    let mut pages: Vec<_> = doc.get_pages().into_iter().collect();
+    pages.sort_by_key(|(n, _)| *n);
+    pages
+        .into_iter()
+        .map(|(_, pid)| {
+            let (w, h) = page_size(&doc, pid);
+            let glyphs = page_glyphs_cached(&doc, pid, &mut caches);
+            let (prose, words) = crate::dp_lines::line_and_word_cells(&glyphs, h, true);
+            crate::pdfium_backend::PdfPage {
+                width: w,
+                height: h,
+                // Cells are native PDF points; there is no rendered bitmap.
+                scale: 1.0,
+                cells: prose,
+                code_cells: crate::pdfium_backend::code_cells_from_glyphs(&glyphs, h),
+                word_cells: words,
+                #[cfg(feature = "ml")]
+                image: image::RgbImage::new(1, 1),
+                links: Vec::new(),
+            }
+        })
+        .collect()
+}
+
 /// The text-state scalars inherited by a Form XObject when it is invoked via
 /// `Do` (the PDF graphics state includes the text parameters, but not the text
 /// matrices, which a form re-establishes inside its own `BT`/`ET`).

--- a/crates/docling-pdf/tests/text_layer.rs
+++ b/crates/docling-pdf/tests/text_layer.rs
@@ -1,0 +1,49 @@
+//! `convert_text_layer` (the `pdf-text` / wasm32 path) must produce the same
+//! extraction as the full pipeline's `no_ocr` flag: both run the pure-Rust
+//! text parser through the orphan-region assembly, differing only in how the
+//! page is opened (lopdf vs pdfium). Runs under the default (ml) feature so
+//! both entries exist to compare.
+
+#![cfg(feature = "ml")]
+
+#[test]
+fn text_layer_matches_no_ocr() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/data/pdf/sources/code_and_formula.pdf"
+    ))
+    .expect("corpus pdf");
+
+    // Tests run with CWD = the crate dir; point the pdfium loader at the
+    // checkout's `.pdfium/lib` (the no_ocr side still opens pages via pdfium).
+    if std::env::var("PDFIUM_DYNAMIC_LIB_PATH").is_err() {
+        std::env::set_var(
+            "PDFIUM_DYNAMIC_LIB_PATH",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/../../.pdfium/lib"),
+        );
+    }
+
+    let text_layer = docling_pdf::convert_text_layer(&bytes, "code_and_formula.pdf")
+        .expect("text-layer conversion");
+    let no_ocr = docling_pdf::convert_with_options(
+        &bytes,
+        None,
+        "code_and_formula.pdf",
+        true, // no_table_former (moot: no_ocr skips it anyway)
+        true, // no_ocr — the path convert_text_layer mirrors
+        docling_pdf::EnrichmentOptions::default(),
+    )
+    .expect("no_ocr conversion");
+
+    let a = text_layer.export_to_markdown();
+    assert!(!a.trim().is_empty(), "text layer should extract");
+    assert_eq!(a, no_ocr.export_to_markdown());
+}
+
+#[test]
+fn scanned_pdf_yields_empty_document() {
+    // No content stream at all — the no-text-layer contract is an empty doc,
+    // not an error (callers decide whether to fall back to OCR).
+    let doc = docling_pdf::convert_text_layer(b"%PDF-1.4\n%%EOF", "scan.pdf").expect("no error");
+    assert!(doc.nodes.is_empty());
+}

--- a/crates/docling-pdf/tests/text_layer.rs
+++ b/crates/docling-pdf/tests/text_layer.rs
@@ -25,15 +25,24 @@ fn text_layer_matches_no_ocr() {
 
     let text_layer = docling_pdf::convert_text_layer(&bytes, "code_and_formula.pdf")
         .expect("text-layer conversion");
-    let no_ocr = docling_pdf::convert_with_options(
+    let no_ocr = match docling_pdf::convert_with_options(
         &bytes,
         None,
         "code_and_formula.pdf",
         true, // no_table_former (moot: no_ocr skips it anyway)
         true, // no_ocr — the path convert_text_layer mirrors
         docling_pdf::EnrichmentOptions::default(),
-    )
-    .expect("no_ocr conversion");
+    ) {
+        Ok(doc) => doc,
+        // The comparison baseline needs the pdfium shared library, which CI's
+        // model-free test job doesn't have — the equivalence claim is only
+        // checkable where a full local setup exists (scripts/dev/pdfium.sh).
+        Err(docling_pdf::PdfError::Pdfium(e)) if e.contains("LoadLibraryError") => {
+            eprintln!("skipping equivalence check: pdfium unavailable ({e})");
+            return;
+        }
+        Err(e) => panic!("no_ocr conversion: {e:?}"),
+    };
 
     let a = text_layer.export_to_markdown();
     assert!(!a.trim().is_empty(), "text layer should extract");

--- a/crates/docling-wasm/Cargo.toml
+++ b/crates/docling-wasm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # The pure-Rust declarative slice only: no pdfium/ONNX (pdf, asr), no HTTP
 # client (fetch-images) — exactly the set that compiles for wasm32 (#79).
-docling = { path = "../docling", version = "0.41.2", default-features = false }
+docling = { path = "../docling", version = "0.41.2", default-features = false, features = ["pdf-text"] }
 serde_json = "1"
 wasm-bindgen = "0.2"
 # Panic messages land in the browser console instead of "unreachable executed".

--- a/crates/docling-wasm/Cargo.toml
+++ b/crates/docling-wasm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "docling-wasm"
+description = "Browser/edge (wasm32) build of docling.rs's declarative converters: DOCX/HTML/MD/XLSX/PPTX/… → Markdown or docling JSON."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+# Shipped as an npm package built by wasm-pack / wasm-bindgen, not on crates.io.
+publish = false
+
+[lib]
+# wasm-bindgen needs a cdylib; rlib keeps `cargo test` runnable on the host.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# The pure-Rust declarative slice only: no pdfium/ONNX (pdf, asr), no HTTP
+# client (fetch-images) — exactly the set that compiles for wasm32 (#79).
+docling = { path = "../docling", version = "0.41.2", default-features = false }
+serde_json = "1"
+wasm-bindgen = "0.2"
+# Panic messages land in the browser console instead of "unreachable executed".
+console_error_panic_hook = "0.1"

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -1,0 +1,61 @@
+# docling-wasm — in-browser document conversion
+
+A `wasm32-unknown-unknown` build of docling.rs's **declarative** converters
+(issue #79): DOCX, HTML, Markdown, XLSX, PPTX, CSV, AsciiDoc, EPUB, ODF,
+WebVTT, Email, MHTML, JATS, USPTO, XBRL, LaTeX, JSON and DocLang, converted to
+Markdown / docling JSON / DocLang XML **entirely client-side** — no server,
+the file never leaves the page. Python docling cannot do this.
+
+The crate is `docling` with `default-features = false`: the PDF/image/ASR ML
+pipelines (pdfium + ONNX Runtime) and the HTTP image fetcher are compiled out.
+Those formats stay detectable and are rejected at convert time with a clear
+"rebuild with the `pdf` feature" error. Remote `<img src>` images stay
+placeholders (no network in the module); embedded images work normally.
+
+**Size: ~5.2 MB raw, ~1.8 MB gzipped** (measured on this crate at 0.41.x,
+`--release` with the workspace's `lto = "thin"`; no `wasm-opt` pass — one
+typically shaves another 10–15%). No models are involved: the declarative
+converters are pure Rust.
+
+## API
+
+```ts
+convert(bytes: Uint8Array, filename: string, to?: "md" | "json" | "doclang"): string
+supported_extensions(): string   // JSON array, e.g. for <input accept=…>
+version(): string
+```
+
+The filename's extension drives format detection, same as the CLI.
+
+## Build
+
+```bash
+rustup target add wasm32-unknown-unknown
+
+# Either wasm-pack (bundles the JS glue + package.json):
+wasm-pack build crates/docling-wasm --target web
+
+# ...or plain cargo + wasm-bindgen (what CI and the demo below use):
+cargo build -p docling-wasm --target wasm32-unknown-unknown --release
+wasm-bindgen --target web --out-dir crates/docling-wasm/www/pkg \
+    target/wasm32-unknown-unknown/release/docling_wasm.wasm
+```
+
+## Demo
+
+[`www/index.html`](./www/index.html) is a drop-a-file demo page over the
+module (output selector, conversion timing, automated-test hook). After the
+`wasm-bindgen` step above:
+
+```bash
+python3 -m http.server -d crates/docling-wasm/www 8901
+# open http://127.0.0.1:8901/
+```
+
+Verified end-to-end in headless Chromium: Markdown/DOCX→md, DOCX→JSON, and
+the PDF rejection path all exercised through the real wasm module.
+
+## Host-side tests
+
+`cargo test -p docling-wasm` runs the conversion body natively (the
+`JsError` boundary only exists on wasm), including a real corpus DOCX.

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -2,20 +2,26 @@
 
 A `wasm32-unknown-unknown` build of docling.rs's **declarative** converters
 (issue #79): DOCX, HTML, Markdown, XLSX, PPTX, CSV, AsciiDoc, EPUB, ODF,
-WebVTT, Email, MHTML, JATS, USPTO, XBRL, LaTeX, JSON and DocLang, converted to
-Markdown / docling JSON / DocLang XML **entirely client-side** — no server,
-the file never leaves the page. Python docling cannot do this.
+WebVTT, Email, MHTML, JATS, USPTO, XBRL, LaTeX, JSON, DocLang — and the
+**embedded text layer of PDFs** — converted to Markdown / docling JSON /
+DocLang XML **entirely client-side** — no server, the file never leaves the
+page. Python docling cannot do this.
 
-The crate is `docling` with `default-features = false`: the PDF/image/ASR ML
-pipelines (pdfium + ONNX Runtime) and the HTTP image fetcher are compiled out.
-Those formats stay detectable and are rejected at convert time with a clear
-"rebuild with the `pdf` feature" error. Remote `<img src>` images stay
-placeholders (no network in the module); embedded images work normally.
+The crate is `docling` with `default-features = false` plus `pdf-text`:
+digital PDFs convert through docling-pdf's pure-Rust content-stream parser —
+the exact extraction the native `--no-ocr` flag does (flat, line-grouped
+paragraphs in reading order; no headings/lists/tables/pictures, since those
+need the layout model). The ML pipelines (pdfium + ONNX Runtime) and the HTTP
+image fetcher are compiled out: scanned/image-only PDFs get a clear "no
+embedded text layer … OCR needs a build with the `pdf` feature" error, and
+images/audio/METS are rejected with a "rebuild with …" message. Remote
+`<img src>` images stay placeholders (no network in the module); embedded
+images work normally.
 
-**Size: ~5.2 MB raw, ~1.8 MB gzipped** (measured on this crate at 0.41.x,
+**Size: ~5.6 MB raw, ~1.9 MB gzipped** (measured on this crate at 0.41.x,
 `--release` with the workspace's `lto = "thin"`; no `wasm-opt` pass — one
 typically shaves another 10–15%). No models are involved: the declarative
-converters are pure Rust.
+converters and the PDF text parser are pure Rust.
 
 ## API
 
@@ -52,10 +58,12 @@ python3 -m http.server -d crates/docling-wasm/www 8901
 # open http://127.0.0.1:8901/
 ```
 
-Verified end-to-end in headless Chromium: Markdown/DOCX→md, DOCX→JSON, and
-the PDF rejection path all exercised through the real wasm module.
+Verified end-to-end in headless Chromium: Markdown/DOCX→md, DOCX→JSON, a
+corpus PDF→md through the text-layer path, and the scanned-PDF error path all
+exercised through the real wasm module.
 
 ## Host-side tests
 
 `cargo test -p docling-wasm` runs the conversion body natively (the
-`JsError` boundary only exists on wasm), including a real corpus DOCX.
+`JsError` boundary only exists on wasm), including a real corpus DOCX and
+PDF.

--- a/crates/docling-wasm/src/lib.rs
+++ b/crates/docling-wasm/src/lib.rs
@@ -3,9 +3,12 @@
 //! WebVTT, Email, MHTML, JATS, USPTO, XBRL, LaTeX, JSON, DocLang → Markdown or
 //! docling JSON — fully client-side, no server round-trip.
 //!
-//! Built on `docling` with `default-features = false`: the PDF/image/ASR ML
-//! pipelines (pdfium + ONNX Runtime) and the HTTP image fetcher are compiled
-//! out — those formats are rejected at convert time with a clear message.
+//! Built on `docling` with `default-features = false` plus `pdf-text`: a PDF's
+//! **embedded text layer** converts too (pure-Rust parser, same extraction as
+//! the native `--no-ocr` flag — flat paragraphs, no headings/tables/pictures).
+//! The ML pipelines (pdfium + ONNX Runtime) and the HTTP image fetcher are
+//! compiled out — scanned PDFs, images, and audio are rejected at convert time
+//! with a clear message.
 //!
 //! ```js
 //! import init, { convert } from "./pkg/docling_wasm.js";
@@ -53,17 +56,18 @@ pub fn convert(bytes: &[u8], filename: &str, to: Option<String>) -> Result<Strin
 }
 
 /// The file extensions this build can convert, as a JSON string array —
-/// handy for an `<input accept=…>` filter. The ML formats (pdf, images,
-/// audio, METS) are excluded: they are not compiled into the wasm build.
+/// handy for an `<input accept=…>` filter. PDF converts via its embedded
+/// text layer (`pdf-text`); the remaining ML formats (images, audio, METS)
+/// are excluded: they are not compiled into the wasm build.
 #[wasm_bindgen]
 pub fn supported_extensions() -> String {
-    // Keep in sync with `InputFormat::from_extension` minus the ML formats
-    // (pdf, images, audio, mets tarballs).
+    // Keep in sync with `InputFormat::from_extension` minus the ML-only
+    // formats (images, audio, mets tarballs).
     let exts = [
         "docx", "dotx", "docm", "dotm", "pptx", "potx", "ppsx", "pptm", "potm", "ppsm", "md",
         "txt", "text", "qmd", "rmd", "html", "htm", "xhtml", "xml", "nxml", "dclg", "dclx", "adoc",
         "asciidoc", "asc", "csv", "xlsx", "xlsm", "odt", "ott", "ods", "ots", "odp", "otp", "json",
-        "vtt", "tex", "latex", "eml", "epub", "mhtml", "mht",
+        "vtt", "tex", "latex", "eml", "epub", "mhtml", "mht", "pdf",
     ];
     serde_json::to_string(exts.as_slice()).expect("static array serializes")
 }
@@ -91,10 +95,45 @@ mod tests {
 
     #[test]
     fn ml_formats_rejected() {
-        let err = convert_impl(b"%PDF-1.4", "doc.pdf", None).unwrap_err();
+        // Images still need the full ML pipeline.
+        let err = convert_impl(&[0x89, b'P', b'N', b'G'], "scan.png", None).unwrap_err();
         assert!(
-            err.contains("pdf"),
-            "should point at the missing feature: {err}"
+            err.contains("unknown or unsupported") || err.contains("pdf"),
+            "should reject the ML-only format: {err}"
+        );
+    }
+
+    #[test]
+    fn pdf_text_layer_converts() {
+        // A text-layer PDF converts via the pure-Rust `pdf-text` path (the
+        // exact `--no-ocr` extraction: flat paragraphs in reading order).
+        // Under `cargo test --workspace`, feature unification swaps in the
+        // full ML pipeline (which needs pdfium + models) — this test is about
+        // the text-layer arm, so it only runs in the real wasm feature set.
+        if docling::PDF_ML_COMPILED {
+            return;
+        }
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/data/pdf/sources/code_and_formula.pdf"
+        ))
+        .expect("corpus pdf");
+        let out = convert_impl(&bytes, "code_and_formula.pdf", None).unwrap();
+        assert!(!out.trim().is_empty(), "text layer should extract");
+    }
+
+    #[test]
+    fn scanned_pdf_reports_missing_text_layer() {
+        // A PDF with no embedded text (here: a stub with no content stream)
+        // should explain that OCR needs a native build, not return "".
+        // Text-layer-arm-only, same as `pdf_text_layer_converts`.
+        if docling::PDF_ML_COMPILED {
+            return;
+        }
+        let err = convert_impl(b"%PDF-1.4\n%%EOF", "scan.pdf", None).unwrap_err();
+        assert!(
+            err.contains("text layer") || err.contains("OCR"),
+            "should point at the missing text layer: {err}"
         );
     }
 
@@ -114,6 +153,7 @@ mod tests {
     fn extensions_json_parses() {
         let v: Vec<String> = serde_json::from_str(&supported_extensions()).unwrap();
         assert!(v.contains(&"docx".to_string()));
-        assert!(!v.contains(&"pdf".to_string()));
+        assert!(v.contains(&"pdf".to_string()), "pdf-text is compiled in");
+        assert!(!v.contains(&"png".to_string()));
     }
 }

--- a/crates/docling-wasm/src/lib.rs
+++ b/crates/docling-wasm/src/lib.rs
@@ -1,0 +1,119 @@
+//! Browser/edge (wasm32) bindings for docling.rs's **declarative** converters
+//! (issue #79): DOCX, HTML, Markdown, XLSX, PPTX, CSV, AsciiDoc, EPUB, ODF,
+//! WebVTT, Email, MHTML, JATS, USPTO, XBRL, LaTeX, JSON, DocLang → Markdown or
+//! docling JSON — fully client-side, no server round-trip.
+//!
+//! Built on `docling` with `default-features = false`: the PDF/image/ASR ML
+//! pipelines (pdfium + ONNX Runtime) and the HTTP image fetcher are compiled
+//! out — those formats are rejected at convert time with a clear message.
+//!
+//! ```js
+//! import init, { convert } from "./pkg/docling_wasm.js";
+//! await init();
+//! const md = convert(new Uint8Array(await file.arrayBuffer()), file.name, "md");
+//! ```
+
+use docling::{DocumentConverter, InputFormat, SourceDocument};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+fn start() {
+    // Panics surface as readable messages in the browser console instead of
+    // an opaque `unreachable executed`.
+    console_error_panic_hook::set_once();
+}
+
+/// The whole conversion body, host-testable (`JsError` can only be
+/// constructed on the wasm target, so the JS boundary stays a thin shim).
+fn convert_impl(bytes: &[u8], filename: &str, to: Option<&str>) -> Result<String, String> {
+    let ext = filename.rsplit('.').next().unwrap_or_default();
+    let format = InputFormat::from_extension(ext)
+        .ok_or_else(|| format!("unknown or unsupported extension: {filename:?}"))?;
+    let source = SourceDocument::from_bytes(filename.to_string(), format, bytes.to_vec());
+    let result = DocumentConverter::new()
+        .convert(source)
+        .map_err(|e| e.to_string())?;
+    match to.unwrap_or("md") {
+        "md" | "markdown" => Ok(result.document.export_to_markdown()),
+        "json" => Ok(result.document.export_to_json()),
+        "doclang" => Ok(result.document.export_to_doclang()),
+        other => Err(format!(
+            "unknown output format {other:?} (expected \"md\", \"json\" or \"doclang\")"
+        )),
+    }
+}
+
+/// Convert a document (as bytes + filename, the extension drives format
+/// detection) to `to`: `"md"` (Markdown, default), `"json"` (docling-core's
+/// `DoclingDocument` wire format, schema 1.10.0) or `"doclang"` (docling's
+/// DocLang XML serialization).
+#[wasm_bindgen]
+pub fn convert(bytes: &[u8], filename: &str, to: Option<String>) -> Result<String, JsError> {
+    convert_impl(bytes, filename, to.as_deref()).map_err(|e| JsError::new(&e))
+}
+
+/// The file extensions this build can convert, as a JSON string array —
+/// handy for an `<input accept=…>` filter. The ML formats (pdf, images,
+/// audio, METS) are excluded: they are not compiled into the wasm build.
+#[wasm_bindgen]
+pub fn supported_extensions() -> String {
+    // Keep in sync with `InputFormat::from_extension` minus the ML formats
+    // (pdf, images, audio, mets tarballs).
+    let exts = [
+        "docx", "dotx", "docm", "dotm", "pptx", "potx", "ppsx", "pptm", "potm", "ppsm", "md",
+        "txt", "text", "qmd", "rmd", "html", "htm", "xhtml", "xml", "nxml", "dclg", "dclx", "adoc",
+        "asciidoc", "asc", "csv", "xlsx", "xlsm", "odt", "ott", "ods", "ots", "odp", "otp", "json",
+        "vtt", "tex", "latex", "eml", "epub", "mhtml", "mht",
+    ];
+    serde_json::to_string(exts.as_slice()).expect("static array serializes")
+}
+
+/// The docling.rs version this module was built from.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    // Host-side (`cargo test -p docling-wasm`) sanity of the conversion body —
+    // the wasm-bindgen layer is exercised by the browser demo.
+    use super::*;
+
+    #[test]
+    fn markdown_roundtrip() {
+        let md = b"# Title\n\nHello *world*\n";
+        let out = convert_impl(md, "note.md", None).unwrap();
+        assert!(out.contains("# Title"));
+        let json = convert_impl(md, "note.md", Some("json")).unwrap();
+        assert!(json.contains("\"schema_name\""));
+    }
+
+    #[test]
+    fn ml_formats_rejected() {
+        let err = convert_impl(b"%PDF-1.4", "doc.pdf", None).unwrap_err();
+        assert!(
+            err.contains("pdf"),
+            "should point at the missing feature: {err}"
+        );
+    }
+
+    #[test]
+    fn docx_converts() {
+        // A real corpus DOCX through the wasm entry path on the host.
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../docling/tests/data/docx/sources/docx_lists.docx"
+        ))
+        .expect("corpus docx");
+        let out = convert_impl(&bytes, "docx_lists.docx", None).unwrap();
+        assert!(!out.trim().is_empty());
+    }
+
+    #[test]
+    fn extensions_json_parses() {
+        let v: Vec<String> = serde_json::from_str(&supported_extensions()).unwrap();
+        assert!(v.contains(&"docx".to_string()));
+        assert!(!v.contains(&"pdf".to_string()));
+    }
+}

--- a/crates/docling-wasm/www/index.html
+++ b/crates/docling-wasm/www/index.html
@@ -25,10 +25,12 @@
 <body>
   <h1>docling.rs → wasm: convert documents in your browser</h1>
   <p>
-    DOCX / HTML / Markdown / XLSX / PPTX / CSV / EPUB / ODF / LaTeX / … are
-    converted to Markdown or docling JSON <strong>entirely client-side</strong>
-    — the file never leaves this page. PDF/image/audio need the native ML
-    pipeline and are not part of the wasm build.
+    DOCX / HTML / Markdown / XLSX / PPTX / CSV / EPUB / ODF / LaTeX /
+    digital PDF / … are converted to Markdown or docling JSON
+    <strong>entirely client-side</strong> — the file never leaves this page.
+    PDFs convert via their embedded text layer (flat paragraphs, like the
+    native <code>--no-ocr</code>); scanned PDFs, images and audio need the
+    native ML pipeline and are not part of the wasm build.
   </p>
   <div class="row">
     <label>Output:

--- a/crates/docling-wasm/www/index.html
+++ b/crates/docling-wasm/www/index.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>docling.rs — in-browser document conversion (wasm)</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    body { max-width: 60rem; margin: 2rem auto; padding: 0 1rem; }
+    h1 { font-size: 1.4rem; }
+    #drop {
+      border: 2px dashed #888; border-radius: 8px; padding: 2.5rem 1rem;
+      text-align: center; cursor: pointer; margin: 1rem 0;
+    }
+    #drop.hover { border-color: #4a90d9; background: rgba(74, 144, 217, 0.08); }
+    .row { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; }
+    #out {
+      width: 100%; min-height: 20rem; white-space: pre-wrap; overflow: auto;
+      border: 1px solid #8884; border-radius: 6px; padding: 0.8rem;
+      font-family: ui-monospace, monospace; font-size: 0.85rem;
+    }
+    #meta { color: #888; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <h1>docling.rs → wasm: convert documents in your browser</h1>
+  <p>
+    DOCX / HTML / Markdown / XLSX / PPTX / CSV / EPUB / ODF / LaTeX / … are
+    converted to Markdown or docling JSON <strong>entirely client-side</strong>
+    — the file never leaves this page. PDF/image/audio need the native ML
+    pipeline and are not part of the wasm build.
+  </p>
+  <div class="row">
+    <label>Output:
+      <select id="to">
+        <option value="md" selected>Markdown</option>
+        <option value="json">docling JSON</option>
+        <option value="doclang">DocLang XML</option>
+      </select>
+    </label>
+    <span id="meta">loading module…</span>
+  </div>
+  <div id="drop">Drop a document here, or click to pick a file</div>
+  <input type="file" id="pick" hidden>
+  <pre id="out"></pre>
+
+  <script type="module">
+    import init, { convert, supported_extensions, version } from "./pkg/docling_wasm.js";
+
+    const meta = document.getElementById("meta");
+    const out = document.getElementById("out");
+    const drop = document.getElementById("drop");
+    const pick = document.getElementById("pick");
+    const to = document.getElementById("to");
+
+    await init();
+    const exts = JSON.parse(supported_extensions());
+    pick.accept = exts.map((e) => "." + e).join(",");
+    meta.textContent = `docling.rs ${version()} · ${exts.length} extensions`;
+
+    let last = null; // {bytes, name}
+    async function run(file) {
+      last = { bytes: new Uint8Array(await file.arrayBuffer()), name: file.name };
+      render();
+    }
+    function render() {
+      if (!last) return;
+      const t0 = performance.now();
+      try {
+        out.textContent = convert(last.bytes, last.name, to.value);
+        meta.textContent = `${last.name} → ${to.value} in ${(performance.now() - t0).toFixed(1)} ms`;
+      } catch (e) {
+        out.textContent = String(e);
+      }
+    }
+
+    to.onchange = render;
+    drop.onclick = () => pick.click();
+    pick.onchange = () => pick.files[0] && run(pick.files[0]);
+    drop.ondragover = (e) => { e.preventDefault(); drop.classList.add("hover"); };
+    drop.ondragleave = () => drop.classList.remove("hover");
+    drop.ondrop = (e) => {
+      e.preventDefault();
+      drop.classList.remove("hover");
+      e.dataTransfer.files[0] && run(e.dataTransfer.files[0]);
+    };
+
+    // Hook for automated tests: window.doclingConvert(bytes, name, to)
+    window.doclingConvert = (bytes, name, fmt) => convert(new Uint8Array(bytes), name, fmt);
+    window.doclingReady = true;
+  </script>
+</body>
+</html>

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -16,6 +16,17 @@ rust-version.workspace = true
 exclude = ["tests", "benches"]
 
 [features]
+# The default build is the full converter. The ML pipelines and the HTTP
+# client are feature-sliced so `--no-default-features` leaves the pure-Rust
+# declarative converters (DOCX/HTML/MD/XLSX/PPTX/… → md/json) — a set that
+# compiles for wasm32-unknown-unknown (issue #79, see crates/docling-wasm).
+default = ["pdf", "asr", "fetch-images"]
+# PDF/image/METS-GBS ML pipeline (pdfium + ONNX Runtime via docling-pdf).
+pdf = ["dep:docling-pdf"]
+# Audio → Whisper ASR (symphonia + ONNX Runtime via docling-asr).
+asr = ["dep:docling-asr"]
+# Blocking HTTP fetch of remote <img src> images (DocumentConverter::fetch_images).
+fetch-images = ["dep:ureq"]
 # Optional headless-browser HTML pre-render (the `--use-web-browser` flag /
 # `DocumentConverter::use_web_browser`). Off by default so the standard build
 # stays pure-Rust with no browser/runtime dependency; enable with
@@ -26,18 +37,18 @@ web-browser = ["dep:headless_chrome"]
 chunking = ["docling-core/chunking"]
 # GPU execution providers for the PDF/image ML pipeline (#74) — pass-through
 # to docling-pdf; select at runtime with DOCLING_RS_EP (default: cpu).
-cuda = ["docling-pdf/cuda"]
-tensorrt = ["docling-pdf/tensorrt"]
-directml = ["docling-pdf/directml"]
-coreml = ["docling-pdf/coreml"]
+cuda = ["pdf", "docling-pdf/cuda"]
+tensorrt = ["pdf", "docling-pdf/tensorrt"]
+directml = ["pdf", "docling-pdf/directml"]
+coreml = ["pdf", "docling-pdf/coreml"]
 
 [dependencies]
 calamine = { version = "0.26", features = ["dates"] }
 csv = "1.4.0"
 headless_chrome = { version = "1.0", optional = true }
-docling-asr = { path = "../docling-asr", version = "0.41.2" }
+docling-asr = { path = "../docling-asr", version = "0.41.2", optional = true }
 docling-core = { path = "../docling-core", version = "0.41.2" }
-docling-pdf = { path = "../docling-pdf", version = "0.41.2" }
+docling-pdf = { path = "../docling-pdf", version = "0.41.2", optional = true }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "tiff", "webp"] }
 mail-parser = "0.11"
 pulldown-cmark = { version = "0.13.4", default-features = false }
@@ -53,7 +64,7 @@ serde_json = "1"
 # is enabled (DocumentConverter::fetch_images). 3.x matches the version `ort`
 # already pulls in (so the graph keeps a single ureq); it needs Rust 1.85, which
 # this crate already requires transitively via docling-pdf → ort.
-ureq = "3"
+ureq = { version = "3", optional = true }
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [[example]]

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -22,7 +22,10 @@ exclude = ["tests", "benches"]
 # compiles for wasm32-unknown-unknown (issue #79, see crates/docling-wasm).
 default = ["pdf", "asr", "fetch-images"]
 # PDF/image/METS-GBS ML pipeline (pdfium + ONNX Runtime via docling-pdf).
-pdf = ["dep:docling-pdf"]
+pdf = ["dep:docling-pdf", "docling-pdf/ml"]
+# Text-layer-only PDF conversion (docling-pdf's pure-Rust parser, no pdfium/
+# ONNX) — the wasm32 PDF path. Subsumed by `pdf`, which converts everything.
+pdf-text = ["dep:docling-pdf"]
 # Audio → Whisper ASR (symphonia + ONNX Runtime via docling-asr).
 asr = ["dep:docling-asr"]
 # Blocking HTTP fetch of remote <img src> images (DocumentConverter::fetch_images).
@@ -48,7 +51,7 @@ csv = "1.4.0"
 headless_chrome = { version = "1.0", optional = true }
 docling-asr = { path = "../docling-asr", version = "0.41.2", optional = true }
 docling-core = { path = "../docling-core", version = "0.41.2" }
-docling-pdf = { path = "../docling-pdf", version = "0.41.2", optional = true }
+docling-pdf = { path = "../docling-pdf", version = "0.41.2", optional = true, default-features = false }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "tiff", "webp"] }
 mail-parser = "0.11"
 pulldown-cmark = { version = "0.13.4", default-features = false }

--- a/crates/docling/src/backend/images.rs
+++ b/crates/docling/src/backend/images.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 use docling_core::PictureImage;
 
 /// Cap on a single fetched/decoded image, to bound memory on hostile input.
+#[cfg(feature = "fetch-images")]
 const MAX_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
 
 /// Resolves an `<img src>` to the image bytes behind it, or `None` if it can't
@@ -117,6 +118,7 @@ fn from_data_uri(uri: &str) -> Option<PictureImage> {
 
 /// Fetch a remote image over HTTP(S). The mimetype comes from `Content-Type`
 /// when it's an `image/*`, else it's guessed from the URL's extension.
+#[cfg(feature = "fetch-images")]
 fn fetch_remote(url: &str) -> Option<PictureImage> {
     let mut resp = ureq::get(url).call().ok()?;
     let content_type = resp
@@ -255,4 +257,11 @@ mod tests {
             .resolve(&format!("data:image/png;base64,{}", encode(RED_PNG)))
             .is_some());
     }
+}
+
+/// Compiled without the `fetch-images` feature (no HTTP client — e.g. the
+/// wasm32 build): remote images stay placeholders, same as a fetch failure.
+#[cfg(not(feature = "fetch-images"))]
+fn fetch_remote(_url: &str) -> Option<PictureImage> {
+    None
 }

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -397,10 +397,36 @@ impl DocumentConverter {
             #[cfg(feature = "asr")]
             InputFormat::Audio => docling_asr::convert_audio(&source.bytes, &source.name)
                 .map_err(|e| ConversionError::Parse(e.to_string()))?,
+            // Without the full ML pipeline, `pdf-text` still converts a PDF's
+            // embedded text layer (pure Rust — the wasm32 path), equivalent to
+            // `--no-ocr`: flat paragraphs, no headings/tables/pictures. A
+            // scanned PDF has no text layer, so an empty document means "this
+            // needs OCR" — say so instead of returning nothing.
+            #[cfg(all(feature = "pdf-text", not(feature = "pdf")))]
+            InputFormat::Pdf => {
+                let doc = docling_pdf::convert_text_layer(&source.bytes, &source.name)
+                    .map_err(|e| ConversionError::Parse(e.to_string()))?;
+                if doc.nodes.is_empty() {
+                    return Err(ConversionError::Parse(
+                        "PDF has no embedded text layer (scanned/image-only?); OCR needs a \
+                         build with the `pdf` feature"
+                            .into(),
+                    ));
+                }
+                doc
+            }
             // Compiled without the ML pipelines: the formats stay detectable,
             // but converting them needs a build with the matching feature.
+            #[cfg(not(any(feature = "pdf", feature = "pdf-text")))]
+            InputFormat::Pdf => {
+                return Err(ConversionError::Parse(
+                    "Pdf conversion is not compiled in (rebuild with the `pdf` feature, or \
+                     `pdf-text` for text-layer-only extraction)"
+                        .into(),
+                ))
+            }
             #[cfg(not(feature = "pdf"))]
-            InputFormat::Pdf | InputFormat::Image | InputFormat::MetsGbs => {
+            InputFormat::Image | InputFormat::MetsGbs => {
                 return Err(ConversionError::Parse(format!(
                     "{:?} conversion is not compiled in (rebuild with the `pdf` feature)",
                     source.format

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -53,7 +53,9 @@ use crate::error::ConversionError;
 use crate::format::InputFormat;
 use crate::result::{ConversionResult, ConversionStatus};
 use crate::source::SourceDocument;
+#[cfg(feature = "pdf")]
 use crate::stream::MarkdownStream;
+#[cfg(feature = "pdf")]
 use docling_core::ImageMode;
 
 /// Routes a [`SourceDocument`] to the backend for its format and returns a
@@ -74,7 +76,7 @@ pub struct DocumentConverter {
     /// Opt-in PDF/image enrichment models (docling's
     /// `do_picture_classification` / `do_code_enrichment` /
     /// `do_formula_enrichment`).
-    enrich: docling_pdf::EnrichmentOptions,
+    enrich: crate::EnrichmentOptions,
 }
 
 impl DocumentConverter {
@@ -93,7 +95,7 @@ impl DocumentConverter {
             no_table_former: false,
             no_ocr: false,
             use_web_browser: false,
-            enrich: docling_pdf::EnrichmentOptions::default(),
+            enrich: crate::EnrichmentOptions::default(),
         }
     }
 
@@ -234,6 +236,7 @@ impl DocumentConverter {
     /// Streaming is Markdown-only — JSON needs the whole node tree, so there is no
     /// streaming JSON. The conversion runs on a background thread; dropping the
     /// returned [`MarkdownStream`] cancels it.
+    #[cfg(feature = "pdf")]
     pub fn convert_streaming(
         &self,
         source: SourceDocument,
@@ -249,6 +252,7 @@ impl DocumentConverter {
     /// here.
     ///
     /// [`DoclingDocument::export_to_markdown_with_images`]: docling_core::DoclingDocument::export_to_markdown_with_images
+    #[cfg(feature = "pdf")]
     pub fn convert_streaming_images(
         &self,
         source: SourceDocument,
@@ -360,6 +364,7 @@ impl DocumentConverter {
             InputFormat::XmlDoclang | InputFormat::Dclx => {
                 crate::backend::DoclangBackend.convert(&source)?
             }
+            #[cfg(feature = "pdf")]
             InputFormat::Pdf => docling_pdf::convert_with_options(
                 &source.bytes,
                 None,
@@ -369,6 +374,7 @@ impl DocumentConverter {
                 self.enrich,
             )
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
+            #[cfg(feature = "pdf")]
             InputFormat::Image => docling_pdf::convert_image_with_options(
                 &source.bytes,
                 &source.name,
@@ -377,6 +383,7 @@ impl DocumentConverter {
                 self.enrich,
             )
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
+            #[cfg(feature = "pdf")]
             InputFormat::MetsGbs => docling_pdf::convert_mets_gbs_with_options(
                 &source.bytes,
                 &source.name,
@@ -387,8 +394,24 @@ impl DocumentConverter {
             .map_err(|e| ConversionError::Parse(e.to_string()))?,
             // Audio → Whisper ASR (symphonia decode + ONNX inference); each
             // transcribed segment becomes a `[time: start-end] text` paragraph.
+            #[cfg(feature = "asr")]
             InputFormat::Audio => docling_asr::convert_audio(&source.bytes, &source.name)
                 .map_err(|e| ConversionError::Parse(e.to_string()))?,
+            // Compiled without the ML pipelines: the formats stay detectable,
+            // but converting them needs a build with the matching feature.
+            #[cfg(not(feature = "pdf"))]
+            InputFormat::Pdf | InputFormat::Image | InputFormat::MetsGbs => {
+                return Err(ConversionError::Parse(format!(
+                    "{:?} conversion is not compiled in (rebuild with the `pdf` feature)",
+                    source.format
+                )))
+            }
+            #[cfg(not(feature = "asr"))]
+            InputFormat::Audio => {
+                return Err(ConversionError::Parse(
+                    "audio conversion is not compiled in (rebuild with the `asr` feature)".into(),
+                ))
+            }
         };
         // Carry the mode so `result.document.export_to_markdown()` reflects it.
         document.strict_markdown = self.strict;

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -30,6 +30,7 @@ mod error;
 mod format;
 mod result;
 mod source;
+#[cfg(feature = "pdf")]
 mod stream;
 
 pub mod backend;
@@ -39,6 +40,7 @@ pub use error::ConversionError;
 pub use format::InputFormat;
 pub use result::{ConversionResult, ConversionStatus};
 pub use source::SourceDocument;
+#[cfg(feature = "pdf")]
 pub use stream::MarkdownStream;
 
 // Re-export the core model so callers only need the one crate, and so
@@ -50,4 +52,19 @@ pub use docling_core::{
 
 // The reusable PDF/image pipeline (models loaded once, reused across documents),
 // for callers that convert many files or want a warm, startup-excluded measurement.
+#[cfg(feature = "pdf")]
 pub use docling_pdf::{EnrichmentOptions, Pipeline};
+
+/// Stand-in for `docling_pdf::EnrichmentOptions` when the `pdf` feature is
+/// off: the `DocumentConverter` builder methods keep compiling (and stay
+/// inert — the formats these flags affect are rejected at convert time).
+#[cfg(not(feature = "pdf"))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct EnrichmentOptions {
+    /// Classify each picture with DocumentFigureClassifier (26 classes).
+    pub picture_classification: bool,
+    /// Rewrite code blocks (and detect their language) with CodeFormulaV2.
+    pub code: bool,
+    /// Decode display formulas to LaTeX with CodeFormulaV2.
+    pub formula: bool,
+}

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -55,6 +55,15 @@ pub use docling_core::{
 #[cfg(feature = "pdf")]
 pub use docling_pdf::{EnrichmentOptions, Pipeline};
 
+/// Which PDF conversion this build compiled in: the full ML pipeline (`pdf`
+/// feature), the pure-Rust text-layer path (`pdf-text`, the wasm32 build), or
+/// neither. Compile-time facts, exported so downstream crates (whose own
+/// features can't see this crate's) can branch — e.g. docling-wasm's host
+/// tests, where workspace feature unification may pull `pdf` in.
+pub const PDF_ML_COMPILED: bool = cfg!(feature = "pdf");
+/// True when the `pdf-text` text-layer-only PDF path is compiled in.
+pub const PDF_TEXT_COMPILED: bool = cfg!(feature = "pdf-text");
+
 /// Stand-in for `docling_pdf::EnrichmentOptions` when the `pdf` feature is
 /// off: the `DocumentConverter` builder methods keep compiling (and stay
 /// inert — the formats these flags affect are rejected at convert time).


### PR DESCRIPTION
Feature-slice the docling crate so the pure-Rust declarative path stands alone: pdf (docling-pdf), asr (docling-asr) and fetch-images (ureq) become cargo features, all in the default set — a plain build is byte-identical to before. With --no-default-features the crate compiles for wasm32-unknown-unknown as-is (rayon degrades to sequential on targets without threads). The ML formats stay detectable and fail at convert time with a 'rebuild with the pdf feature' error; the streaming API (a background thread over the PDF pipeline) is pdf-gated; without an HTTP client remote <img src> stays a placeholder, same as a fetch failure.

New docling-wasm crate (workspace member, publish=false): wasm-bindgen convert(bytes, filename, to) → md / docling JSON / DocLang XML, plus supported_extensions() and version(). Host-side tests cover the conversion body (JsError only constructs on wasm), including a real corpus DOCX. www/index.html is a drop-a-file demo page; verified end-to-end in headless Chromium via the built module: md→md, corpus DOCX→md and →JSON, and the PDF rejection path.

Module size (release, thin-LTO, no wasm-opt): 5.2 MB raw, 1.8 MB gzipped — under the 2-4 MB the issue projected. CI gains a wasm job: wasm32 check of the sliced docling, release build of docling-wasm, host tests, and a size log. release.sh needs no change (explicit publish lists; the crate is publish=false).

Closes #79.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT