### PR TITLE
fix(models): friendly validate-layout message when a model file is absent

### DIFF
--- a/scripts/install/quantize_models.py
+++ b/scripts/install/quantize_models.py
@@ -188,6 +188,20 @@ def validate_layout(src, dst):
     (download_dependencies.sh falls back gracefully — int8 is fetch_optional)."""
     import onnxruntime as ort
 
+    for path, kind in ((src, "fp32"), (dst, "int8")):
+        if not os.path.exists(path):
+            sys.exit(
+                f"layout gate: {path} not found — nothing to validate. "
+                + (
+                    "Fetch the models first (scripts/install/download_dependencies.sh)."
+                    if kind == "fp32"
+                    else "No int8 model on disk: the release ships fp32-only when a "
+                    "previous gate failed; build one with "
+                    "`python scripts/install/quantize_models.py layout` (it re-runs "
+                    "this gate on the result)."
+                )
+            )
+
     print("layout: validating int8 against fp32 (agreement gate)...", flush=True)
     opts = ort.SessionOptions()
     ref = ort.InferenceSession(src, opts, providers=["CPUExecutionProvider"])


### PR DESCRIPTION


Running the standalone gate against a release that ships fp32-only (post-gate-failure prune) died with an ONNXRuntime NoSuchFile traceback; say what happened and what to do instead.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT