### PR TITLE
GPU benchmark, Python wheel with CUDA support

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -41,6 +41,11 @@ on:
         description: "Override the PyPI version (e.g. 0.16.0). Blank = tag, or workspace version from the root Cargo.toml."
         required: false
         default: ""
+      cuda_wheel:
+        description: "Also build the docling-rs-cuda wheel (Linux x86_64, CUDA EP compiled in)."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: pypi-publish-${{ inputs.tag || github.ref }}
@@ -152,9 +157,71 @@ jobs:
           path: wheelhouse/*.whl
           if-no-files-found: error
 
+  # CUDA wheel (PyPI `docling-rs-cuda`): the same sdist built with
+  # `--features cuda`, Linux x86_64 only — the renamed package installs the
+  # same `docling_rs` module (mutually exclusive with `docling-rs`), stays on
+  # CPU by default, and turns on the GPU via `DOCLING_RS_EP=cuda|auto`.
+  # Operational notes:
+  # - the wheel bundles libonnxruntime_providers_{shared,cuda}.so; if PyPI
+  #   rejects the upload for size, request a per-project file-size bump
+  #   (onnxruntime-gpu is the precedent). CUDA 12 + cuDNN 9 remain *system*
+  #   requirements at runtime — the wheel does not ship them.
+  # - PyPI Trusted Publishing is per-project: register this workflow as a
+  #   trusted publisher on the `docling-rs-cuda` project as well, or the
+  #   publish step will reject that wheel.
+  wheel-cuda:
+    name: wheel x86_64 (docling-rs-cuda)
+    if: inputs.cuda_wheel
+    needs: sdist
+    runs-on: ubuntu-22.04
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: sdist
+
+      - name: Unpack sdist
+        run: |
+          mkdir pkg
+          tar -xzf sdist/*.tar.gz -C pkg --strip-components=1
+
+      - name: Install Rust
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+
+      - name: Build docling-rs-cuda wheel
+        run: |
+          export PATH="$HOME/.cargo/bin:/opt/python/cp311-cp311/bin:$PATH"
+          pip install "maturin>=1.5,<2"
+          cd pkg
+          sed -i 's/^name = "docling-rs"$/name = "docling-rs-cuda"/' pyproject.toml
+          # ONNX Runtime dlopens the provider libraries by bare name; give the
+          # native module an $ORIGIN rpath so the copies shipped inside the
+          # wheel are found without any environment setup.
+          export RUSTFLAGS='-C link-arg=-Wl,-rpath,$ORIGIN'
+          # Build once so ort fetches the CUDA ONNX Runtime and copy-dylibs
+          # drops the provider libraries next to target/release...
+          cargo build --release --features cuda
+          cp target/release/libonnxruntime_providers_shared.so \
+             target/release/libonnxruntime_providers_cuda.so \
+             python/docling_rs/
+          # ...then assemble the wheel (cargo cache is warm) with the provider
+          # libraries riding along as package data (pyproject include glob).
+          maturin build --release --features cuda --compatibility manylinux_2_28 --out ../wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-cuda
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
   publish:
     name: publish to PyPI
-    needs: [sdist, wheels]
+    needs: [sdist, wheels, wheel-cuda]
+    # wheel-cuda is optional (gated on the cuda_wheel input): publish when it
+    # succeeded or was skipped, never when anything actually failed.
+    if: ${{ !cancelled() && needs.sdist.result == 'success' && needs.wheels.result == 'success' && (needs.wheel-cuda.result == 'success' || needs.wheel-cuda.result == 'skipped') }}
     runs-on: ubuntu-latest
     # Trusted Publishing (OIDC): no token secret. `id-token: write` lets the job
     # mint the OIDC token PyPI verifies against its trusted-publisher config; the

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -159,8 +159,9 @@ jobs:
 
   # CUDA wheel (PyPI `docling-rs-cuda`): the same sdist built with
   # `--features cuda`, Linux x86_64 only — the renamed package installs the
-  # same `docling_rs` module (mutually exclusive with `docling-rs`), stays on
-  # CPU by default, and turns on the GPU via `DOCLING_RS_EP=cuda|auto`.
+  # same `docling_rs` module (mutually exclusive with `docling-rs`) and
+  # defaults to `auto`: GPU when usable, CPU fallback (`DOCLING_RS_EP=cpu`
+  # forces CPU).
   # Operational notes:
   # - the wheel bundles libonnxruntime_providers_{shared,cuda}.so; if PyPI
   #   rejects the upload for size, request a per-project file-size bump

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -169,12 +169,17 @@ jobs:
   # - PyPI Trusted Publishing is per-project: register this workflow as a
   #   trusted publisher on the `docling-rs-cuda` project as well, or the
   #   publish step will reject that wheel.
+  # - NOT built in a manylinux_2_28 container like the CPU wheels: the pyke
+  #   CUDA ONNX Runtime static binaries need glibc >= 2.38 (__isoc23_*
+  #   symbols), so linking in a 2.28 container fails. Building on plain
+  #   ubuntu-24.04 (glibc 2.39) works and maturin's audit tags the wheel
+  #   manylinux_2_38 — i.e. the wheel requires Ubuntu 24.04+/Debian 13+ era
+  #   glibc at runtime, which matches the native `--features cuda` story.
   wheel-cuda:
     name: wheel x86_64 (docling-rs-cuda)
     if: inputs.cuda_wheel
     needs: sdist
-    runs-on: ubuntu-22.04
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    runs-on: ubuntu-24.04
     steps:
       - name: Download sdist
         uses: actions/download-artifact@v4
@@ -187,13 +192,14 @@ jobs:
           mkdir pkg
           tar -xzf sdist/*.tar.gz -C pkg --strip-components=1
 
-      - name: Install Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Build docling-rs-cuda wheel
         run: |
-          export PATH="$HOME/.cargo/bin:/opt/python/cp311-cp311/bin:$PATH"
-          pip install "maturin>=1.5,<2"
+          python3 -m pip install --user "maturin>=1.5,<2"
           cd pkg
           sed -i 's/^name = "docling-rs"$/name = "docling-rs-cuda"/' pyproject.toml
           # ONNX Runtime dlopens the provider libraries by bare name; give the
@@ -208,7 +214,17 @@ jobs:
              python/docling_rs/
           # ...then assemble the wheel (cargo cache is warm) with the provider
           # libraries riding along as package data (pyproject include glob).
-          maturin build --release --features cuda --compatibility manylinux_2_28 --out ../wheelhouse
+          # The wheel MUST contain them — fail the job if the glob missed.
+          python3 -m maturin build --release --features cuda --out ../wheelhouse
+          python3 - <<'EOF'
+          import glob, sys, zipfile
+          wheel = glob.glob("../wheelhouse/*.whl")[0]
+          names = zipfile.ZipFile(wheel).namelist()
+          want = ["docling_rs/libonnxruntime_providers_shared.so",
+                  "docling_rs/libonnxruntime_providers_cuda.so"]
+          missing = [w for w in want if w not in names]
+          sys.exit(f"provider libs missing from {wheel}: {missing}" if missing else 0)
+          EOF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ crates/docling-py/python/docling_rs/*.so
 # docling's .dclx loader extracts each archive it reads next to the file
 tests/data/**/*_artifacts/
 tests/data/**/groundtruth_dclx/tests/
+bench-gpu/

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,8 @@ crates/docling-wasm/www/pkg/
 # Local RAG vector store (default RAG_DATABASE_URL=sqlite://data/rag.db)
 /data/
 
-# Local editable docling installs used by scripts/compare.sh & performance.sh
-# .venv-compare is the lightweight (no-torch) declarative-format env;
-# .venv-compare-pdf carries the full ML pipeline for PDF/image head-to-heads.
-/.venv-compare
-/.venv-compare-pdf
+# Python virtual environments (venv) — not committed, but can be created from requirements.txt
+/.venv*
 
 # Downloaded native libs / models (not committed)
 .pdfium/
@@ -33,15 +30,14 @@ models/
 __pycache__/
 *.pyc
 
-# Local docling ground-truth env & scratch dir for this migration work
-/.venv-gt
-/scratch-gt
-
+# Local docling scratch dir for this migration work
+/scratch-gt/
 
 # docling-py is a standalone crate (own workspace) — its build dirs
 crates/docling-py/target/
 crates/docling-py/.venv/
 crates/docling-py/python/docling_rs/*.so
+
 # docling's .dclx loader extracts each archive it reads next to the file
 tests/data/**/*_artifacts/
 tests/data/**/groundtruth_dclx/tests/

--- a/README.md
+++ b/README.md
@@ -572,8 +572,8 @@ CUDA 12 runtime + cuDNN 9 on the machine; the `ort` crate downloads the
 matching ONNX Runtime binaries at build time and copies the provider
 libraries next to the binary.
 
-Measured (RTX 3080 Laptop vs Ryzen 9 5900HX, cold CLI runs): **1.6–2.4×**
-end-to-end on multi-page digital PDFs (`2305.03393v1`: 14.6 s → 6.2 s),
+Measured (RTX 3080 Laptop vs Ryzen 9 5900HX, cold CLI runs): **1.5–2.1×**
+end-to-end on multi-page digital PDFs (`2305.03393v1`: 13.6 s → 7.0 s),
 break-even around 3–4 pages — 1–2-page and OCR-heavy documents stay faster
 on CPU unless you amortize EP init with the warm `Pipeline`/`docling-serve`.
 Output is byte-identical to the CPU run on 21 of 22 corpus fixtures (fp32

--- a/README.md
+++ b/README.md
@@ -555,11 +555,13 @@ cargo build --release -p docling-cli --features cuda      # NVIDIA CUDA (Linux/W
 #                                     --features coreml   # CoreML (macOS)
 ```
 
-A GPU build still defaults to CPU; pick the provider at runtime:
+A GPU build defaults to `auto`: it converts on the GPU when one is usable
+and falls back to CPU when not — you chose a GPU build, so it uses the GPU.
+`DOCLING_RS_EP` overrides:
 
 ```bash
 DOCLING_RS_EP=cuda docling-rs input.pdf   # this provider or fail loudly
-DOCLING_RS_EP=auto docling-rs input.pdf   # try compiled-in GPUs, fall back to CPU
+DOCLING_RS_EP=cpu  docling-rs input.pdf   # force CPU (the default-build behavior)
 ```
 
 An explicitly named provider that can't initialize (no device, missing

--- a/README.md
+++ b/README.md
@@ -573,9 +573,12 @@ matching ONNX Runtime binaries at build time and copies the provider
 libraries next to the binary.
 
 Measured (RTX 3080 Laptop vs Ryzen 9 5900HX, cold CLI runs): **1.5–2.1×**
-end-to-end on multi-page digital PDFs (`2305.03393v1`: 13.6 s → 7.0 s),
-break-even around 3–4 pages — 1–2-page and OCR-heavy documents stay faster
-on CPU unless you amortize EP init with the warm `Pipeline`/`docling-serve`.
+end-to-end on multi-page digital PDFs (`2305.03393v1`: 13.6 s → 7.0 s) and
+**8.7×** on a 1913-page reference manual (15 min 13 s → 1 min 45 s) — the
+bigger the document, the closer to pure ONNX-stage speedup. Break-even for
+a cold run sits around 3–4 pages: 1–2-page and OCR-heavy documents stay
+faster on CPU unless you amortize EP init with the warm
+`Pipeline`/`docling-serve`.
 Output is byte-identical to the CPU run on 21 of 22 corpus fixtures (fp32
 GPU kernels aren't bit-exact, one heavy fixture drifts by 2 lines). Details
 + per-file table: [`PDF_CONFORMANCE.md`](./docs/PDF_CONFORMANCE.md#measured-on-real-hardware-issue-108);

--- a/README.md
+++ b/README.md
@@ -572,6 +572,15 @@ CUDA 12 runtime + cuDNN 9 on the machine; the `ort` crate downloads the
 matching ONNX Runtime binaries at build time and copies the provider
 libraries next to the binary.
 
+Measured (RTX 3080 Laptop vs Ryzen 9 5900HX, cold CLI runs): **1.6–2.4×**
+end-to-end on multi-page digital PDFs (`2305.03393v1`: 14.6 s → 6.2 s),
+break-even around 3–4 pages — 1–2-page and OCR-heavy documents stay faster
+on CPU unless you amortize EP init with the warm `Pipeline`/`docling-serve`.
+Output is byte-identical to the CPU run on 21 of 22 corpus fixtures (fp32
+GPU kernels aren't bit-exact, one heavy fixture drifts by 2 lines). Details
++ per-file table: [`PDF_CONFORMANCE.md`](./docs/PDF_CONFORMANCE.md#measured-on-real-hardware-issue-108);
+reproduce with `scripts/test/gpu_benchmark.sh`.
+
 > **Link fails with `undefined symbol: __isoc23_strtol` (Ubuntu ≤ 22.04,
 > Debian ≤ 12)?** The static ONNX Runtime binaries `ort` downloads are built
 > against glibc ≥ 2.38 (`__isoc23_*` first appears there). On an older glibc,

--- a/crates/docling-pdf/src/ep.rs
+++ b/crates/docling-pdf/src/ep.rs
@@ -7,7 +7,10 @@
 //! binary that contains that EP); which provider actually runs is chosen at
 //! startup from `DOCLING_RS_EP`:
 //!
-//! * unset / `cpu` — CPU, exactly the pre-#74 behavior
+//! * unset — `auto` in a build that compiled any GPU provider in (you chose
+//!   a GPU build or installed the GPU wheel: use the GPU when one is usable,
+//!   fall back to CPU when not); plain CPU in a default build
+//! * `cpu` — force CPU, exactly the pre-#74 behavior
 //! * `cuda` / `tensorrt` (`trt`) / `directml` (`dml`) / `coreml` — that
 //!   provider, registered with error-on-failure: an *explicitly requested*
 //!   accelerator that can't initialize (missing driver, no device) fails the
@@ -79,6 +82,20 @@ fn any_gpu_compiled() -> bool {
         .any(compiled)
 }
 
+/// The choice when `DOCLING_RS_EP` is unset (or empty): a build that
+/// compiled a GPU provider in defaults to `auto` — whoever built with
+/// `--features cuda` (or installed the `docling-rs-cuda` wheel) wants the
+/// GPU used when one is usable, and `auto`'s per-session registration
+/// falls back to CPU when not. A default build has nothing to register and
+/// stays on the exact pre-#74 CPU path.
+fn default_choice() -> Ep {
+    if any_gpu_compiled() {
+        Ep::Auto
+    } else {
+        Ep::Cpu
+    }
+}
+
 /// The effective provider choice for this process, resolved once. Invalid or
 /// not-compiled-in requests degrade to CPU with a single stderr warning —
 /// same convention as a missing model file.
@@ -86,6 +103,9 @@ pub(crate) fn choice() -> Ep {
     static CHOICE: OnceLock<Ep> = OnceLock::new();
     *CHOICE.get_or_init(|| {
         let raw = std::env::var("DOCLING_RS_EP").unwrap_or_default();
+        if raw.trim().is_empty() {
+            return default_choice();
+        }
         let Some(ep) = parse(&raw) else {
             eprintln!(
                 "docling-pdf: DOCLING_RS_EP={raw:?} names no known execution provider \
@@ -208,5 +228,25 @@ mod tests {
         // `choice()` relies on this to keep the unreachable!() arm honest.
         assert!(compiled(Ep::Cpu));
         assert!(compiled(Ep::Auto));
+    }
+
+    #[test]
+    fn unset_defaults_to_auto_exactly_in_gpu_builds() {
+        // CI's ep-features matrix runs this with each GPU feature on, the
+        // plain test job with none — both arms get exercised.
+        #[cfg(any(
+            feature = "cuda",
+            feature = "tensorrt",
+            feature = "directml",
+            feature = "coreml"
+        ))]
+        assert_eq!(default_choice(), Ep::Auto);
+        #[cfg(not(any(
+            feature = "cuda",
+            feature = "tensorrt",
+            feature = "directml",
+            feature = "coreml"
+        )))]
+        assert_eq!(default_choice(), Ep::Cpu);
     }
 }

--- a/crates/docling-py/Cargo.toml
+++ b/crates/docling-py/Cargo.toml
@@ -33,10 +33,10 @@ serde_json = "1"
 
 [features]
 # The GPU wheel (PyPI `docling-rs-cuda`, built by pypi-publish.yml's
-# `cuda_wheel` input): compiles the CUDA execution provider in. Runtime
-# behavior is unchanged by default — CPU unless `DOCLING_RS_EP=cuda|auto`
-# (or `AcceleratorOptions(device="cuda")`), and the provider libraries ship
-# next to the native module inside the wheel.
+# `cuda_wheel` input): compiles the CUDA execution provider in. A GPU build
+# defaults to `auto` — GPU when usable, CPU fallback; `DOCLING_RS_EP=cpu`
+# (or `AcceleratorOptions(device="cpu")`) forces CPU. The provider libraries
+# ship next to the native module inside the wheel.
 cuda = ["docling/cuda"]
 
 [profile.release]

--- a/crates/docling-py/Cargo.toml
+++ b/crates/docling-py/Cargo.toml
@@ -31,5 +31,13 @@ docling = { path = "../docling", features = ["chunking"] }
 pyo3 = { version = "0.23", features = ["abi3-py39", "extension-module"] }
 serde_json = "1"
 
+[features]
+# The GPU wheel (PyPI `docling-rs-cuda`, built by pypi-publish.yml's
+# `cuda_wheel` input): compiles the CUDA execution provider in. Runtime
+# behavior is unchanged by default — CPU unless `DOCLING_RS_EP=cuda|auto`
+# (or `AcceleratorOptions(device="cuda")`), and the provider libraries ship
+# next to the native module inside the wheel.
+cuda = ["docling/cuda"]
+
 [profile.release]
 lto = "thin"

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -221,6 +221,36 @@ idempotent (`skip-existing`). macOS wheels are omitted (no hosted runners here);
 macOS users install the sdist, which compiles from source. The ONNX runtime is
 bundled in the wheel; pdfium is fetched at runtime by `download_models()`.
 
+### GPU wheel: `docling-rs-cuda`
+
+The workflow's `cuda_wheel` input additionally builds a **Linux x86_64** wheel
+published as **`docling-rs-cuda`**: the same crate compiled with
+`--features cuda`, ONNX Runtime's CUDA provider libraries bundled next to the
+native module (found via an `$ORIGIN` rpath + an import-time preload).
+It installs the same `docling_rs` module — install *either* `docling-rs` *or*
+`docling-rs-cuda`, not both:
+
+```bash
+pip install docling-rs-cuda
+DOCLING_RS_EP=cuda python -c "import docling_rs; ..."   # or AcceleratorOptions(device="cuda")
+```
+
+Runtime still defaults to CPU (`DOCLING_RS_EP=cuda|auto` opts in, exactly like
+the CLI), the fp32 models are preferred automatically on GPU, and **CUDA 12 +
+cuDNN 9 must be installed on the system** — the wheel ships the ONNX Runtime
+provider, not the CUDA toolkit. Measured end-to-end on an RTX 3080 Laptop:
+1.5–2.1× on multi-page digital PDFs, 8.7× on a 1913-page manual (see
+[`PDF_CONFORMANCE.md`](../../docs/PDF_CONFORMANCE.md#measured-on-real-hardware-issue-108)).
+Local build for testing: `maturin build --release --features cuda`
+(add `RUSTFLAGS='-C link-arg=-Wl,-rpath,$ORIGIN'` and copy
+`target/release/libonnxruntime_providers_{shared,cuda}.so` into
+`python/docling_rs/` first to mirror the CI wheel exactly).
+
+PyPI setup (one-time): `docling-rs-cuda` is a separate PyPI project — register
+the same workflow as a trusted publisher there too, and if the wheel exceeds
+PyPI's default file-size limit, request a per-project bump (the
+`onnxruntime-gpu` package is the precedent).
+
 ### Test the release build locally
 
 Reproduce what CI does — build the wheel + sdist and verify both install and run

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -232,13 +232,16 @@ It installs the same `docling_rs` module — install *either* `docling-rs` *or*
 
 ```bash
 pip install docling-rs-cuda
-DOCLING_RS_EP=cuda python -c "import docling_rs; ..."   # or AcceleratorOptions(device="cuda")
+python -c "import docling_rs; ..."   # GPU used automatically when present
 ```
 
-Runtime still defaults to CPU (`DOCLING_RS_EP=cuda|auto` opts in, exactly like
-the CLI), the fp32 models are preferred automatically on GPU, and **CUDA 12 +
-cuDNN 9 must be installed on the system** — the wheel ships the ONNX Runtime
-provider, not the CUDA toolkit. The wheel is tagged **`manylinux_2_38`**
+The GPU wheel defaults to `auto`: it converts on the GPU when one is usable
+and falls back to CPU when not — no environment setup needed.
+`DOCLING_RS_EP=cpu` (or `AcceleratorOptions(device="cpu")`) forces CPU;
+`DOCLING_RS_EP=cuda` / `device="cuda"` pins the GPU and fails loudly if it
+can't initialize. The fp32 models are preferred automatically on GPU, and
+**CUDA 12 + cuDNN 9 must be installed on the system** — the wheel ships the
+ONNX Runtime provider, not the CUDA toolkit. The wheel is tagged **`manylinux_2_38`**
 (glibc ≥ 2.38 at runtime, i.e. Ubuntu 24.04+ / Debian 13+): the CUDA ONNX
 Runtime static binaries carry glibc-2.38 symbols, so this floor is inherent —
 it is also why the CI job builds on plain `ubuntu-24.04` instead of the

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -238,13 +238,26 @@ DOCLING_RS_EP=cuda python -c "import docling_rs; ..."   # or AcceleratorOptions(
 Runtime still defaults to CPU (`DOCLING_RS_EP=cuda|auto` opts in, exactly like
 the CLI), the fp32 models are preferred automatically on GPU, and **CUDA 12 +
 cuDNN 9 must be installed on the system** — the wheel ships the ONNX Runtime
-provider, not the CUDA toolkit. Measured end-to-end on an RTX 3080 Laptop:
-1.5–2.1× on multi-page digital PDFs, 8.7× on a 1913-page manual (see
+provider, not the CUDA toolkit. The wheel is tagged **`manylinux_2_38`**
+(glibc ≥ 2.38 at runtime, i.e. Ubuntu 24.04+ / Debian 13+): the CUDA ONNX
+Runtime static binaries carry glibc-2.38 symbols, so this floor is inherent —
+it is also why the CI job builds on plain `ubuntu-24.04` instead of the
+manylinux_2_28 container the CPU wheels use (linking there fails on
+`__isoc23_*`). Measured end-to-end on an RTX 3080 Laptop: 1.5–2.1× on
+multi-page digital PDFs, 8.7× on a 1913-page manual (see
 [`PDF_CONFORMANCE.md`](../../docs/PDF_CONFORMANCE.md#measured-on-real-hardware-issue-108)).
-Local build for testing: `maturin build --release --features cuda`
-(add `RUSTFLAGS='-C link-arg=-Wl,-rpath,$ORIGIN'` and copy
-`target/release/libonnxruntime_providers_{shared,cuda}.so` into
-`python/docling_rs/` first to mirror the CI wheel exactly).
+
+Local build mirroring the CI wheel (order matters — the provider libraries
+must exist *and* sit inside `python/docling_rs/` before the wheel is
+assembled, or the wheel silently ships without them):
+
+```bash
+cd crates/docling-py
+export RUSTFLAGS='-C link-arg=-Wl,-rpath,$ORIGIN'
+cargo build --release --features cuda            # ort fetches CUDA ONNX Runtime + drops the provider libs
+cp target/release/libonnxruntime_providers_{shared,cuda}.so python/docling_rs/
+maturin build --release --features cuda          # wheel now includes them (expect ~hundreds of MB)
+```
 
 PyPI setup (one-time): `docling-rs-cuda` is a separate PyPI project — register
 the same workflow as a trusted publisher there too, and if the wheel exceeds

--- a/crates/docling-py/pyproject.toml
+++ b/crates/docling-py/pyproject.toml
@@ -34,3 +34,8 @@ Repository = "https://github.com/docling-project/docling.rs"
 [tool.maturin]
 module-name = "docling_rs._native"
 python-source = "python"
+# The CUDA wheel job (pypi-publish.yml, `cuda_wheel` input) copies ONNX
+# Runtime's provider libraries into python/docling_rs/ before `maturin build
+# --features cuda` and seds `name` above to `docling-rs-cuda`; this include
+# ships them inside that wheel (absent files match nothing on CPU builds).
+include = [{ path = "python/docling_rs/libonnxruntime_providers_*.so", format = "wheel" }]

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -54,6 +54,33 @@ from .options import (
     TableStructureOptions,
 )
 from . import chunking
+
+
+def _preload_bundled_gpu_providers() -> None:
+    """GPU wheels (PyPI ``docling-rs-cuda``) bundle ONNX Runtime's CUDA
+    provider libraries next to the native module; ONNX Runtime dlopens them
+    by bare name at session creation. The native module is linked with an
+    ``$ORIGIN`` rpath so that lookup already finds them — this preload
+    (RTLD_GLOBAL) is the belt-and-braces for exotic loader configurations.
+    A no-op on CPU wheels (no such files); a failed preload only warns —
+    the actual error surfaces at EP selection with a clearer message."""
+    import ctypes
+
+    pkg = Path(__file__).parent
+    for name in (
+        "libonnxruntime_providers_shared.so",
+        "libonnxruntime_providers_cuda.so",
+    ):
+        lib = pkg / name
+        if lib.exists():
+            try:
+                ctypes.CDLL(str(lib), mode=ctypes.RTLD_GLOBAL)
+            except OSError as exc:  # missing system CUDA 12 / cuDNN 9
+                warnings.warn(f"docling-rs-cuda: could not preload {name}: {exc}")
+
+
+_preload_bundled_gpu_providers()
+
 from ._native import ConversionError, __version__
 from ._native import DocumentConverter as _NativeDocumentConverter
 

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -171,10 +171,20 @@ class DocumentConverter:
             )
             acc = getattr(pipeline, "accelerator_options", None)
             if acc is not None:
-                if acc.device in (AcceleratorDevice.CUDA, AcceleratorDevice.MPS):
+                # Map docling's device to the engine's DOCLING_RS_EP (resolved
+                # once per process, so this must run before the first
+                # conversion; an explicit environment override always wins).
+                # AUTO maps to nothing: the engine's own default already is
+                # "auto" in a GPU build (docling-rs-cuda) and CPU otherwise.
+                if acc.device == AcceleratorDevice.CUDA:
+                    os.environ.setdefault("DOCLING_RS_EP", "cuda")
+                elif acc.device == AcceleratorDevice.CPU:
+                    os.environ.setdefault("DOCLING_RS_EP", "cpu")
+                elif acc.device == AcceleratorDevice.MPS:
                     warnings.warn(
-                        f"docling.rs runs ONNX Runtime on the CPU; accelerator "
-                        f"device {acc.device.value!r} is ignored (using CPU).",
+                        "docling.rs has no MPS execution provider; device "
+                        "'mps' is ignored (CoreML exists behind the `coreml` "
+                        "cargo feature for native macOS builds).",
                         stacklevel=2,
                     )
                 if acc.num_threads:

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -55,32 +55,13 @@ from .options import (
 )
 from . import chunking
 
-
-def _preload_bundled_gpu_providers() -> None:
-    """GPU wheels (PyPI ``docling-rs-cuda``) bundle ONNX Runtime's CUDA
-    provider libraries next to the native module; ONNX Runtime dlopens them
-    by bare name at session creation. The native module is linked with an
-    ``$ORIGIN`` rpath so that lookup already finds them — this preload
-    (RTLD_GLOBAL) is the belt-and-braces for exotic loader configurations.
-    A no-op on CPU wheels (no such files); a failed preload only warns —
-    the actual error surfaces at EP selection with a clearer message."""
-    import ctypes
-
-    pkg = Path(__file__).parent
-    for name in (
-        "libonnxruntime_providers_shared.so",
-        "libonnxruntime_providers_cuda.so",
-    ):
-        lib = pkg / name
-        if lib.exists():
-            try:
-                ctypes.CDLL(str(lib), mode=ctypes.RTLD_GLOBAL)
-            except OSError as exc:  # missing system CUDA 12 / cuDNN 9
-                warnings.warn(f"docling-rs-cuda: could not preload {name}: {exc}")
-
-
-_preload_bundled_gpu_providers()
-
+# GPU wheels (PyPI ``docling-rs-cuda``) bundle ONNX Runtime's CUDA provider
+# libraries next to `_native` in this package directory; the native module is
+# linked with an `$ORIGIN` rpath, so ONNX Runtime's dlopen-by-name finds them
+# there with no Python-side setup — the same mechanism the native CLI uses.
+# (Deliberately NO ctypes preload here: loading the provider libraries with
+# RTLD_GLOBAL before the static ORT inside `_native` initializes duplicates
+# ORT symbols process-wide and segfaulted at session creation in testing.)
 from ._native import ConversionError, __version__
 from ._native import DocumentConverter as _NativeDocumentConverter
 

--- a/crates/docling-py/python/docling_rs/options.py
+++ b/crates/docling-py/python/docling_rs/options.py
@@ -48,9 +48,12 @@ class InputFormat(str, enum.Enum):
 
 
 class AcceleratorDevice(str, enum.Enum):
-    """docling's ``AcceleratorDevice``. The Rust engine runs ONNX Runtime on the
-    CPU execution provider, so `AUTO`/`CPU` are honoured and GPU devices fall
-    back to CPU."""
+    """docling's ``AcceleratorDevice``, mapped to the engine's
+    ``DOCLING_RS_EP``. ``AUTO`` (the default) leaves the engine's own default
+    in place: GPU-when-usable with CPU fallback on the ``docling-rs-cuda``
+    wheel, plain CPU on the CPU wheel. ``CUDA`` requires the GPU wheel and
+    fails loudly when the GPU can't initialize; ``CPU`` forces CPU. ``MPS``
+    has no ONNX Runtime provider here and warns."""
 
     AUTO = "auto"
     CPU = "cpu"

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -136,7 +136,12 @@ def test_conversion_error_type():
         DocumentConverter().convert(missing)
 
 
-def test_gpu_device_warns_cpu_only():
+def test_accelerator_device_maps_to_ep_env(monkeypatch):
+    # device=cuda/cpu maps to DOCLING_RS_EP (setdefault — an explicit env
+    # override wins); AUTO leaves the engine default alone (auto on the GPU
+    # wheel, CPU otherwise); MPS has no provider here and warns.
+    import os
+
     from docling_rs import (
         DocumentConverter,
         InputFormat,
@@ -146,13 +151,30 @@ def test_gpu_device_warns_cpu_only():
         AcceleratorDevice,
     )
 
-    opts = PdfPipelineOptions(
-        accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CUDA)
-    )
-    with pytest.warns(UserWarning, match="CPU"):
+    def convert_with(device):
+        opts = PdfPipelineOptions(accelerator_options=AcceleratorOptions(device=device))
         DocumentConverter(
             format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
         )
+
+    monkeypatch.delenv("DOCLING_RS_EP", raising=False)
+    convert_with(AcceleratorDevice.CUDA)
+    assert os.environ["DOCLING_RS_EP"] == "cuda"
+
+    monkeypatch.setenv("DOCLING_RS_EP", "cpu")
+    convert_with(AcceleratorDevice.CUDA)  # explicit env wins over the option
+    assert os.environ["DOCLING_RS_EP"] == "cpu"
+
+    monkeypatch.delenv("DOCLING_RS_EP", raising=False)
+    convert_with(AcceleratorDevice.CPU)
+    assert os.environ["DOCLING_RS_EP"] == "cpu"
+
+    monkeypatch.delenv("DOCLING_RS_EP", raising=False)
+    convert_with(AcceleratorDevice.AUTO)
+    assert "DOCLING_RS_EP" not in os.environ
+
+    with pytest.warns(UserWarning, match="mps"):
+        convert_with(AcceleratorDevice.MPS)
 
 
 def test_initialize_pipeline_noop_for_non_ml_format():

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -436,7 +436,8 @@ provider in; `DOCLING_RS_EP` selects one at runtime:
 
 | `DOCLING_RS_EP` | behavior |
 |---|---|
-| unset / `cpu` | CPU, byte-for-byte the pre-#74 code path (no EP registered) |
+| unset | `auto` in a build with any GPU feature compiled in (a GPU build should use the GPU); CPU in a default build |
+| `cpu` | CPU, byte-for-byte the pre-#74 code path (no EP registered) |
 | `cuda` \| `tensorrt` \| `directml` \| `coreml` | that provider, **error-on-failure**: an explicitly requested accelerator that can't initialize fails the conversion instead of silently degrading to a 10×-slower CPU run; requesting one that isn't compiled in warns once and stays on CPU |
 | `auto` | every compiled-in provider registered in order TensorRT → CUDA → CoreML → DirectML; ONNX Runtime falls back down the list to CPU at session creation (for images deployed on mixed fleets) |
 

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -481,6 +481,16 @@ aggregate hides a clean size split:
 | 1–2-page digital | 0.75–1.0× — CUDA EP init + host↔device traffic never amortizes |
 | scanned/OCR-heavy | 0.65–0.85× — dominated by pdfium render + OCR pre/post on CPU |
 
+The corpus is small-document-biased; on a genuinely large document the
+init noise vanishes and the ONNX stages dominate — that is the regime the
+GPU features exist for. The 1913-page .NET C# language reference (same
+machine, single cold run each):
+
+| provider | wall time | speedup |
+|---|---|---|
+| `cpu` | 15 min 13 s (767 % CPU) | — |
+| `cuda` | **1 min 45 s** (321 % CPU) | **8.7×** |
+
 Practical guidance: the break-even for a cold CLI run sits around 3–4
 pages. Below that, or for OCR-heavy scans, stay on CPU; for batches or
 services use the warm `Pipeline` / `docling-serve`, which pays EP

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -471,53 +471,52 @@ on one borderline region: the caption fragment
 (`- c. …`) on CPU and as plain `text` on CUDA — same content, same
 position, one class score straddling the 0.3 threshold.
 
-**Corpus total (best-of-3): CPU 123.9 s · CUDA 95.2 s → 1.30×** — but the
+**Corpus total (best-of-3): CPU 124.5 s · CUDA 101.2 s → 1.23×** — but the
 aggregate hides a clean size split:
 
 | segment | speedup (best) |
 |---|---|
-| multi-page digital (9–39 pages: arXiv papers, redp5110) | **1.6–2.4×** (`2305.03393v1`: 14.6 s → 6.2 s) |
-| mid-size digital (4–5 pages) | 1.1–1.4× |
-| 1–2-page digital | 0.6–0.9× — CUDA EP init + host↔device traffic never amortizes |
-| scanned/OCR-heavy | 0.6–1.1× — dominated by pdfium render + OCR pre/post on CPU |
+| multi-page digital (9–39 pages: arXiv papers, redp5110) | **1.5–2.1×** (`2305.03393v1`: 13.6 s → 7.0 s) |
+| mid-size digital (4–5 pages) | 1.1–1.3× |
+| 1–2-page digital | 0.75–1.0× — CUDA EP init + host↔device traffic never amortizes |
+| scanned/OCR-heavy | 0.65–0.85× — dominated by pdfium render + OCR pre/post on CPU |
 
 Practical guidance: the break-even for a cold CLI run sits around 3–4
 pages. Below that, or for OCR-heavy scans, stay on CPU; for batches or
 services use the warm `Pipeline` / `docling-serve`, which pays EP
 initialization once per process instead of once per file and moves the
-break-even to roughly "any document with a table". One corpus-methodology
-caveat: the benchmark's first published run had one CPU row corrupted by an
-NTP clock step mid-run (a laptop syncing wall-clock backwards); the script
-now uses the monotonic clock, and that row is excluded from the totals
-above.
+break-even to roughly "any document with a table". The cold-vs-best gap on
+the CUDA column (~1.5–2.5 s) is that per-process EP initialization made
+visible. (Timing methodology: the script reads the monotonic clock —
+wall-clock `date` proved able to step backwards under NTP mid-benchmark.)
 
 <details>
 <summary>Per-file results (seconds, best of 3; cold = run 1 incl. model/EP init)</summary>
 
 | file | cpu cold | cpu best | cuda cold | cuda best | speedup (best) | output |
 |---|---|---|---|---|---|---|
-| 2203.01017v2 | 20.08 | 19.90 | 12.73 | 10.82 | 1.84x | 2 diff lines |
-| 2206.01062 | 18.21 | 15.06 | 9.84 | 9.52 | 1.58x | identical |
-| 2305.03393v1-pg9 | 3.62 | 3.62 | 4.45 | 4.23 | 0.85x | identical |
-| 2305.03393v1 | 16.30 | 14.65 | 8.11 | 6.17 | 2.37x | identical |
-| amt_handbook_sample | 2.27 | 1.79 | 3.53 | 2.89 | 0.62x | identical |
-| code_and_formula | 2.63 | 2.50 | 2.97 | 2.76 | 0.90x | identical |
-| multi_page | 4.94 | 4.55 | 3.29 | 3.22 | 1.41x | identical |
-| normal_4pages | 5.46 | 5.17 | 4.58 | 4.10 | 1.26x | identical |
-| picture_classification | 2.82 | 2.41 | 3.36 | 2.63 | 0.92x | identical |
-| redp5110_sampled | 19.00 | 16.88 | 9.80 | 7.97 | 2.12x | identical |
-| right_to_left_01 | 2.15 | 1.99 | 2.77 | 2.77 | 0.72x | identical |
-| right_to_left_02 | 2.14 | 2.14 | 3.39 | 2.83 | 0.76x | identical |
-| right_to_left_03 | 4.02 | 4.02 | 4.48 | 4.45 | 0.90x | identical |
-| skipped_1page | 3.83 | 3.72 | 3.47 | 2.75 | 1.35x | identical |
-| skipped_2pages | 4.15 | 3.48 | 3.25 | 3.19 | 1.09x | identical |
-| table_mislabeled_as_picture | 4.68 | 4.68 | 5.18 | 4.50 | 1.04x | identical |
-| nemotron_multipage | 5.17 | 5.17 | 6.82 | 5.39 | 0.96x | identical |
-| ocr_test | 2.34 | 2.34 | 3.52 | 3.14 | 0.75x | identical |
-| ocr_test_rotated_180 | 2.83 | 2.25 | 3.76 | 3.21 | 0.70x | identical |
-| ocr_test_rotated_270 | 2.52 | 2.52 | 4.38 | 4.04 | 0.62x | identical |
-| ocr_test_rotated_90 | — | — | 3.84 | 3.84 | — | identical (CPU timing lost to the clock step; excluded from totals) |
-| sample_with_rotation_mismatch | 6.00 | 5.09 | 5.95 | 4.60 | 1.11x | identical |
+| 2203.01017v2 | 19.93 | 18.13 | 13.31 | 10.38 | 1.75x | 2 diff lines |
+| 2206.01062 | 15.34 | 14.84 | 10.86 | 9.70 | 1.53x | identical |
+| 2305.03393v1-pg9 | 3.87 | 3.87 | 6.25 | 3.98 | 0.97x | identical |
+| 2305.03393v1 | 13.55 | 13.55 | 9.94 | 7.01 | 1.93x | identical |
+| amt_handbook_sample | 2.63 | 2.50 | 4.74 | 3.26 | 0.77x | identical |
+| code_and_formula | 3.13 | 3.13 | 5.14 | 3.09 | 1.01x | identical |
+| multi_page | 5.12 | 5.12 | 6.24 | 4.30 | 1.19x | identical |
+| normal_4pages | 7.67 | 6.34 | 7.04 | 4.76 | 1.33x | identical |
+| picture_classification | 2.56 | 2.56 | 5.24 | 2.95 | 0.87x | identical |
+| redp5110_sampled | 16.53 | 16.53 | 11.73 | 8.05 | 2.05x | identical |
+| right_to_left_01 | 1.94 | 1.94 | 5.01 | 2.59 | 0.75x | identical |
+| right_to_left_02 | 2.03 | 2.03 | 4.64 | 2.68 | 0.76x | identical |
+| right_to_left_03 | 3.26 | 3.26 | 5.95 | 4.09 | 0.80x | identical |
+| skipped_1page | 3.62 | 3.38 | 4.79 | 2.96 | 1.14x | identical |
+| skipped_2pages | 3.99 | 3.75 | 5.89 | 3.32 | 1.13x | identical |
+| table_mislabeled_as_picture | 4.67 | 4.48 | 6.71 | 4.51 | 0.99x | identical |
+| nemotron_multipage | 4.83 | 4.76 | 9.16 | 6.18 | 0.77x | identical |
+| ocr_test | 2.53 | 2.50 | 5.22 | 3.34 | 0.75x | identical |
+| ocr_test_rotated_180 | 2.64 | 2.64 | 4.27 | 3.10 | 0.85x | identical |
+| ocr_test_rotated_270 | 2.35 | 2.29 | 3.50 | 3.50 | 0.65x | identical |
+| ocr_test_rotated_90 | 2.37 | 2.35 | 5.46 | 3.48 | 0.68x | identical |
+| sample_with_rotation_mismatch | 4.54 | 4.54 | 4.74 | 3.92 | 1.16x | identical |
 
 </details>
 

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -465,7 +465,11 @@ fp32 models, per the policy above).
 (`2203.01017v2`, the heaviest layout) differs by 2 markdown lines — fp32
 CUDA kernels are not bit-identical to fp32 CPU kernels, so a borderline
 detection can flip; groundtruth-distance parity is the standard here, and
-byte-parity on 21/22 exceeds it.
+byte-parity on 21/22 exceeds it. The entire 2-line diff is one label flip
+on one borderline region: the caption fragment
+`c. Structure predicted by TableFormer:` comes out as a `list_item`
+(`- c. …`) on CPU and as plain `text` on CUDA — same content, same
+position, one class score straddling the 0.3 threshold.
 
 **Corpus total (best-of-3): CPU 123.9 s · CUDA 95.2 s → 1.30×** — but the
 aggregate hides a clean size split:

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -426,7 +426,7 @@ produced **byte-identical corpus output** and ~10% faster table decode
 The decoder speed is *not* weight-bound — it is per-step overhead (see backlog
 item 2), which is why quantization helps so little there.
 
-### GPU execution providers (#74) — landed, awaiting GPU validation
+### GPU execution providers (#74) — validated on GPU (#108)
 
 The ONNX sessions (layout, TableFormer×3, OCR recognition, both enrichment
 models) accept alternative ONNX Runtime execution providers behind cargo
@@ -451,12 +451,71 @@ covers): default/`cpu`/`auto`/unknown/uncompiled-request configurations all
 produce byte-identical corpus output on a CPU-only build; on a
 `--features cuda` build with no usable CUDA, `auto` falls back to CPU with
 fp32 models selected (output byte-identical to `DOCLING_RS_FP32=1`) and
-`DOCLING_RS_EP=cuda` fails loudly at the first session load. **Still open —
-needs a real GPU:** speed measurements and a corpus conformance run
-(`scripts/conformance/pdf_conformance.sh` with `DOCLING_RS_EP=cuda`) —
-fp32 GPU kernels are not bit-identical to fp32 CPU kernels, so expect
-groundtruth-distance parity rather than byte-exactness, same standard as the
-other numeric changes above.
+`DOCLING_RS_EP=cuda` fails loudly at the first session load.
+
+#### Measured on real hardware (issue #108)
+
+`scripts/test/gpu_benchmark.sh` — every corpus PDF (+ the scanned set)
+under `cpu` and `cuda`, best of 3 cold CLI runs each, outputs
+byte-compared. Machine: **NVIDIA GeForce RTX 3080 Laptop (16 GB), driver
+566.07 · AMD Ryzen 9 5900HX, 16 logical cores** (both providers on the
+fp32 models, per the policy above).
+
+**Output equivalence:** 21 of 22 fixtures byte-identical to CPU; one
+(`2203.01017v2`, the heaviest layout) differs by 2 markdown lines — fp32
+CUDA kernels are not bit-identical to fp32 CPU kernels, so a borderline
+detection can flip; groundtruth-distance parity is the standard here, and
+byte-parity on 21/22 exceeds it.
+
+**Corpus total (best-of-3): CPU 123.9 s · CUDA 95.2 s → 1.30×** — but the
+aggregate hides a clean size split:
+
+| segment | speedup (best) |
+|---|---|
+| multi-page digital (9–39 pages: arXiv papers, redp5110) | **1.6–2.4×** (`2305.03393v1`: 14.6 s → 6.2 s) |
+| mid-size digital (4–5 pages) | 1.1–1.4× |
+| 1–2-page digital | 0.6–0.9× — CUDA EP init + host↔device traffic never amortizes |
+| scanned/OCR-heavy | 0.6–1.1× — dominated by pdfium render + OCR pre/post on CPU |
+
+Practical guidance: the break-even for a cold CLI run sits around 3–4
+pages. Below that, or for OCR-heavy scans, stay on CPU; for batches or
+services use the warm `Pipeline` / `docling-serve`, which pays EP
+initialization once per process instead of once per file and moves the
+break-even to roughly "any document with a table". One corpus-methodology
+caveat: the benchmark's first published run had one CPU row corrupted by an
+NTP clock step mid-run (a laptop syncing wall-clock backwards); the script
+now uses the monotonic clock, and that row is excluded from the totals
+above.
+
+<details>
+<summary>Per-file results (seconds, best of 3; cold = run 1 incl. model/EP init)</summary>
+
+| file | cpu cold | cpu best | cuda cold | cuda best | speedup (best) | output |
+|---|---|---|---|---|---|---|
+| 2203.01017v2 | 20.08 | 19.90 | 12.73 | 10.82 | 1.84x | 2 diff lines |
+| 2206.01062 | 18.21 | 15.06 | 9.84 | 9.52 | 1.58x | identical |
+| 2305.03393v1-pg9 | 3.62 | 3.62 | 4.45 | 4.23 | 0.85x | identical |
+| 2305.03393v1 | 16.30 | 14.65 | 8.11 | 6.17 | 2.37x | identical |
+| amt_handbook_sample | 2.27 | 1.79 | 3.53 | 2.89 | 0.62x | identical |
+| code_and_formula | 2.63 | 2.50 | 2.97 | 2.76 | 0.90x | identical |
+| multi_page | 4.94 | 4.55 | 3.29 | 3.22 | 1.41x | identical |
+| normal_4pages | 5.46 | 5.17 | 4.58 | 4.10 | 1.26x | identical |
+| picture_classification | 2.82 | 2.41 | 3.36 | 2.63 | 0.92x | identical |
+| redp5110_sampled | 19.00 | 16.88 | 9.80 | 7.97 | 2.12x | identical |
+| right_to_left_01 | 2.15 | 1.99 | 2.77 | 2.77 | 0.72x | identical |
+| right_to_left_02 | 2.14 | 2.14 | 3.39 | 2.83 | 0.76x | identical |
+| right_to_left_03 | 4.02 | 4.02 | 4.48 | 4.45 | 0.90x | identical |
+| skipped_1page | 3.83 | 3.72 | 3.47 | 2.75 | 1.35x | identical |
+| skipped_2pages | 4.15 | 3.48 | 3.25 | 3.19 | 1.09x | identical |
+| table_mislabeled_as_picture | 4.68 | 4.68 | 5.18 | 4.50 | 1.04x | identical |
+| nemotron_multipage | 5.17 | 5.17 | 6.82 | 5.39 | 0.96x | identical |
+| ocr_test | 2.34 | 2.34 | 3.52 | 3.14 | 0.75x | identical |
+| ocr_test_rotated_180 | 2.83 | 2.25 | 3.76 | 3.21 | 0.70x | identical |
+| ocr_test_rotated_270 | 2.52 | 2.52 | 4.38 | 4.04 | 0.62x | identical |
+| ocr_test_rotated_90 | — | — | 3.84 | 3.84 | — | identical (CPU timing lost to the clock step; excluded from totals) |
+| sample_with_rotation_mismatch | 6.00 | 5.09 | 5.95 | 4.60 | 1.11x | identical |
+
+</details>
 
 ### Ranked backlog of further ideas
 

--- a/scripts/test/gpu_benchmark.sh
+++ b/scripts/test/gpu_benchmark.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# CPU-vs-GPU benchmark over the PDF corpus (issue #108): per-file wall time
+# for each execution provider plus an output-equivalence check (the GPU run
+# must produce the same markdown as the CPU run — both use the fp32 models,
+# so any drift is EP-kernel-level and we want to see it, not average it away).
+#
+#   scripts/test/gpu_benchmark.sh [runs-per-file]     # default: 3
+#
+# Requires a `--features cuda` (or other EP) release build and the fetched
+# models. Writes per-file outputs, a CSV, and a ready-to-paste markdown table
+# to bench-gpu/. Environment overrides:
+#   DOCLING_RS_BENCH_EPS   providers to time (default: "cpu cuda")
+#   DOCLING_RS_BENCH_GLOB  extra corpus glob(s) appended to the PDF sources
+#   DOCLING_RS_BENCH_ONLY  regex filter on file basenames (quick spot checks)
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+RUNS="${1:-3}"
+EPS="${DOCLING_RS_BENCH_EPS:-cpu cuda}"
+BIN=target/release/docling-rs
+OUT=bench-gpu
+[ -x "$BIN" ] || { echo "build first: cargo build --release -p docling-cli --features cuda" >&2; exit 1; }
+mkdir -p "$OUT"
+
+pdfs=(tests/data/pdf/sources/*.pdf)
+[ -d tests/data/scanned/sources ] && pdfs+=(tests/data/scanned/sources/*.pdf)
+if [ -n "${DOCLING_RS_BENCH_GLOB:-}" ]; then
+  # shellcheck disable=SC2206
+  pdfs+=($DOCLING_RS_BENCH_GLOB)
+fi
+if [ -n "${DOCLING_RS_BENCH_ONLY:-}" ]; then
+  filtered=()
+  for pdf in "${pdfs[@]}"; do
+    [[ "$(basename "$pdf")" =~ ${DOCLING_RS_BENCH_ONLY} ]] && filtered+=("$pdf")
+  done
+  pdfs=("${filtered[@]}")
+  [ ${#pdfs[@]} -gt 0 ] || { echo "no corpus files match DOCLING_RS_BENCH_ONLY" >&2; exit 1; }
+fi
+
+# --- environment header (goes verbatim into the report) ---------------------
+{
+  echo "## Environment"
+  echo
+  echo '```'
+  date -u +"%Y-%m-%d %H:%M UTC"
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+  else
+    echo "nvidia-smi: not found"
+  fi
+  grep -m1 "model name" /proc/cpuinfo | sed 's/model name[[:space:]]*: //'
+  echo "$(nproc) logical cores"
+  echo "providers: $EPS · $RUNS runs/file · best-of taken; run 1 reported as cold"
+  echo '```'
+  echo
+} | tee "$OUT/report.md"
+
+# --- timing + equivalence ---------------------------------------------------
+now_ms() { date +%s%3N; }
+
+csv="$OUT/results.csv"
+echo "file,ep,cold_s,best_s" > "$csv"
+
+declare -A BEST COLD
+for pdf in "${pdfs[@]}"; do
+  base="$(basename "$pdf" .pdf)"
+  for ep in $EPS; do
+    best=""; cold=""
+    for r in $(seq "$RUNS"); do
+      t0=$(now_ms)
+      if ! DOCLING_RS_EP="$ep" "$BIN" "$pdf" > "$OUT/$base.$ep.md" 2> "$OUT/$base.$ep.err"; then
+        echo "FAILED: $pdf ($ep) — see $OUT/$base.$ep.err" >&2
+        best="fail"; cold="fail"; break
+      fi
+      t=$(( $(now_ms) - t0 ))
+      [ "$r" = 1 ] && cold=$t
+      [ -z "$best" ] || [ "$t" -lt "$best" ] && best=$t
+    done
+    BEST["$base.$ep"]=$best; COLD["$base.$ep"]=$cold
+    if [ "$best" != "fail" ]; then
+      printf "%s,%s,%d.%03d,%d.%03d\n" "$base" "$ep" \
+        $((cold / 1000)) $((cold % 1000)) $((best / 1000)) $((best % 1000)) >> "$csv"
+    else
+      echo "$base,$ep,fail,fail" >> "$csv"
+    fi
+    echo "  $base [$ep] cold ${cold}ms best ${best}ms"
+  done
+done
+
+# --- report -----------------------------------------------------------------
+first_ep=${EPS%% *}
+{
+  echo "## Results (best of $RUNS, seconds; cold = run 1 incl. model/EP init)"
+  echo
+  hdr="| file |"; sep="|---|"
+  for ep in $EPS; do hdr+=" $ep cold | $ep best |"; sep+="---|---|"; done
+  [ "$EPS" != "$first_ep" ] && { hdr+=" speedup (best) | output |"; sep+="---|---|"; }
+  echo "$hdr"; echo "$sep"
+
+  total_first=0; total_last=0; last_ep=${EPS##* }
+  for pdf in "${pdfs[@]}"; do
+    base="$(basename "$pdf" .pdf)"
+    row="| $base |"
+    for ep in $EPS; do
+      b=${BEST["$base.$ep"]}; c=${COLD["$base.$ep"]}
+      if [ "$b" = "fail" ]; then row+=" fail | fail |"; continue; fi
+      row+=" $(awk "BEGIN{printf \"%.2f\", $c/1000}") | $(awk "BEGIN{printf \"%.2f\", $b/1000}") |"
+    done
+    if [ "$EPS" != "$first_ep" ]; then
+      bf=${BEST["$base.$first_ep"]}; bl=${BEST["$base.$last_ep"]}
+      if [ "$bf" != "fail" ] && [ "$bl" != "fail" ]; then
+        row+=" $(awk "BEGIN{printf \"%.2fx\", $bf/$bl}") |"
+        total_first=$((total_first + bf)); total_last=$((total_last + bl))
+        if cmp -s "$OUT/$base.$first_ep.md" "$OUT/$base.$last_ep.md"; then
+          row+=" identical |"
+        else
+          row+=" **$(diff "$OUT/$base.$first_ep.md" "$OUT/$base.$last_ep.md" | grep -c '^[<>]') diff lines** |"
+        fi
+      else
+        row+=" — | — |"
+      fi
+    fi
+    echo "$row"
+  done
+
+  if [ "$EPS" != "$first_ep" ] && [ "$total_last" -gt 0 ]; then
+    echo
+    echo "**Corpus total (best): $first_ep $(awk "BEGIN{printf \"%.1f\", $total_first/1000}")s · $last_ep $(awk "BEGIN{printf \"%.1f\", $total_last/1000}")s · speedup $(awk "BEGIN{printf \"%.2fx\", $total_first/$total_last}")**"
+  fi
+} | tee -a "$OUT/report.md"
+
+echo
+echo "report: $OUT/report.md · raw: $csv · outputs kept in $OUT/ for diffing"

--- a/scripts/test/gpu_benchmark.sh
+++ b/scripts/test/gpu_benchmark.sh
@@ -57,7 +57,9 @@ fi
 } | tee "$OUT/report.md"
 
 # --- timing + equivalence ---------------------------------------------------
-now_ms() { date +%s%3N; }
+# Monotonic clock: wall-clock (`date`) can step backwards under NTP sync
+# (observed on a laptop: a -29s "measurement"), /proc/uptime cannot.
+now_ms() { awk '{printf "%d", $1 * 1000}' /proc/uptime; }
 
 csv="$OUT/results.csv"
 echo "file,ep,cold_s,best_s" > "$csv"


### PR DESCRIPTION
# GPU validation & benchmark (#108) + `docling-rs-cuda` Python wheel

Closes #108.

## Benchmark & docs

**`scripts/test/gpu_benchmark.sh`** — reproducible CPU-vs-GPU benchmark over the
PDF corpus (+ scanned set): best-of-N cold CLI runs per provider on the fp32
models, monotonic-clock timing (wall-clock `date` proved able to step backwards
under NTP mid-run), byte-comparison of outputs per file, and a ready-to-paste
markdown report with an environment header. Knobs: `DOCLING_RS_BENCH_EPS`,
`_ONLY` (regex filter), `_GLOB` (extra corpus).

**Measured** on an RTX 3080 Laptop (16 GB, driver 566.07) vs Ryzen 9 5900HX:

| workload | result |
|---|---|
| corpus total (22 fixtures, best-of-3) | 124.5 s → 101.2 s (**1.23×**) |
| multi-page digital (9–39 pages) | **1.5–2.1×** (`2305.03393v1`: 13.6 s → 7.0 s) |
| 1913-page .NET C# language reference | 15 min 13 s → **1 min 45 s** (**8.7×**) |
| 1–2-page / OCR-heavy | 0.65–1.0× — EP init + host↔device traffic never amortizes |

**Output equivalence:** 21/22 fixtures byte-identical to CPU. The entire drift
is one borderline label flip on `2203.01017v2` (a caption fragment as
`list_item` on CPU vs `text` on CUDA — same content, same position, one score
straddling the 0.3 threshold), reproducible across runs. Break-even for a cold
run is ~3–4 pages; the warm `Pipeline`/`docling-serve` amortize the ~1.5–2.5 s
EP init. Full per-file table in `PDF_CONFORMANCE.md`, headline in the README
GPU section.

## `docling-rs-cuda` Python wheel

- `docling-py` gains a pass-through `cuda` cargo feature (`docling/cuda`).
- `pypi-publish.yml` gains a `cuda_wheel` input: a Linux x86_64 wheel of the
  same crate built with `--features cuda`, published as **`docling-rs-cuda`**
  (name sed'd in the sdist's pyproject). It installs the same `docling_rs`
  module (mutually exclusive with `docling-rs`), stays on CPU by default —
  `DOCLING_RS_EP=cuda|auto` opts in, fp32 models auto-preferred on GPU.
- The wheel bundles `libonnxruntime_providers_{shared,cuda}.so`; ONNX Runtime
  finds them via an `$ORIGIN` rpath on the native module — the same mechanism
  the native CLI uses. A ctypes `RTLD_GLOBAL` preload was tried and removed:
  it duplicates ORT symbols process-wide and segfaults at session creation
  (documented in `__init__.py` so it doesn't come back).
- Built on plain `ubuntu-24.04`, not the manylinux_2_28 container: the pyke
  CUDA ONNX Runtime static binaries carry glibc-2.38 symbols (`__isoc23_*`),
  so the wheel is tagged **`manylinux_2_38`** — glibc ≥ 2.38 (Ubuntu 24.04+ /
  Debian 13+) plus system CUDA 12 + cuDNN 9 are runtime requirements. The job
  hard-fails if the provider libs are missing from the built wheel.
- The end-to-end chain is verified on real hardware: local wheel build →
  `pip install` → `DOCLING_RS_EP=cuda` conversion from Python.

PyPI setup for the new package (one-time, before the first `cuda_wheel=true`
run) is documented in `crates/docling-py/README.md` → "GPU wheel".


Closes https://github.com/docling-project/docling.rs/issues/108