### PR TITLE
fix(ci): CUDA wheel build broke on the new maturin sdist layout + Python migration guide

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -203,15 +203,24 @@ jobs:
           python3 -m pip install --user "maturin>=1.5,<2"
           cd pkg
           sed -i 's/^name = "docling-rs"$/name = "docling-rs-cuda"/' pyproject.toml
+          # Where the crate manifest sits depends on the maturin that built the
+          # sdist: at the root (older layouts) or in a subdirectory pointed at
+          # by [tool.maturin] manifest-path (1.8+ vendors the path-dependency
+          # crates as siblings — e.g. docling-py/Cargo.toml). Resolve it from
+          # pyproject.toml instead of assuming, and let cargo report the
+          # matching target directory (the crate is its own workspace, so it
+          # is NOT ./target when the manifest moved).
+          MANIFEST="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["maturin"].get("manifest-path", "Cargo.toml"))')"
+          TARGET_DIR="$(cargo metadata --no-deps --format-version 1 --manifest-path "$MANIFEST" | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
           # ONNX Runtime dlopens the provider libraries by bare name; give the
           # native module an $ORIGIN rpath so the copies shipped inside the
           # wheel are found without any environment setup.
           export RUSTFLAGS='-C link-arg=-Wl,-rpath,$ORIGIN'
           # Build once so ort fetches the CUDA ONNX Runtime and copy-dylibs
-          # drops the provider libraries next to target/release...
-          cargo build --release --features cuda
-          cp target/release/libonnxruntime_providers_shared.so \
-             target/release/libonnxruntime_providers_cuda.so \
+          # drops the provider libraries next to <target>/release...
+          cargo build --release --features cuda --manifest-path "$MANIFEST"
+          cp "$TARGET_DIR/release/libonnxruntime_providers_shared.so" \
+             "$TARGET_DIR/release/libonnxruntime_providers_cuda.so" \
              python/docling_rs/
           # ...then assemble the wheel (cargo cache is warm) with the provider
           # libraries riding along as package data (pyproject include glob).

--- a/README.md
+++ b/README.md
@@ -429,9 +429,14 @@ data = result.document.export_to_dict()   # docling JSON wire format (schema 1.1
 
 Declarative formats (Markdown, HTML, DOCX, XLSX, …) work with no models; the
 PDF/image pipeline downloads pdfium + the ONNX models on first use via
-`docling_rs.download_models()`. See
-[`crates/docling-py/README.md`](./crates/docling-py/README.md) for the full API
-and local build steps.
+`docling_rs.download_models()`. On an NVIDIA machine install
+**`docling-rs-cuda`** instead (same `docling_rs` module compiled with the CUDA
+provider — GPU automatically, CPU fallback). See
+[`crates/docling-py/README.md`](./crates/docling-py/README.md) for the full
+API, local build steps, and a step-by-step
+[migration guide from Python docling](./crates/docling-py/README.md#migrating-from-python-docling)
+(swap the install, rewrite the imports, fetch the models — the code below the
+imports stays unchanged).
 
 ## Getting the ML models
 

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -30,6 +30,72 @@ docling is required for the declarative path.
 > Cargo workspace and its crates.io publish flow. For development, build and
 > install locally as shown next.
 
+## Migrating from Python docling
+
+The package is designed so that a typical docling script moves over by
+changing **the install and the imports** — the code below the imports stays
+as-is, because `result.document` is a genuine `docling_core` `DoclingDocument`
+and all config objects are re-exported docling-shaped.
+
+**1. Swap the package.** `docling-rs` and `docling` can coexist in one
+environment (different module names), so you can A/B them during the
+transition; drop `docling` once nothing imports it. For the GPU build install
+`docling-rs-cuda` **instead of** `docling-rs` (same `docling_rs` module —
+never both):
+
+```bash
+pip install docling-rs            # CPU wheels: Linux x86-64/arm64, Windows; sdist elsewhere
+# or, with an NVIDIA GPU (Linux x86_64, CUDA 12 + cuDNN 9, glibc ≥ 2.38):
+pip install docling-rs-cuda       # converts on the GPU automatically, CPU fallback
+pip uninstall docling             # optional — only when you no longer import it
+```
+
+**2. Rewrite the imports** — everything comes from `docling_rs` /
+`docling_rs.chunking`:
+
+| Python docling import | docling.rs import |
+|---|---|
+| `from docling.document_converter import DocumentConverter, PdfFormatOption` | `from docling_rs import DocumentConverter, PdfFormatOption` |
+| `from docling.datamodel.base_models import InputFormat, DocumentStream` | `from docling_rs import InputFormat, DocumentStream` |
+| `from docling.datamodel.pipeline_options import PdfPipelineOptions, AcceleratorOptions, TableFormerMode` | `from docling_rs import PdfPipelineOptions, AcceleratorOptions, TableFormerMode` |
+| `from docling.exceptions import ConversionError` | `from docling_rs import ConversionError` |
+| `from docling.chunking import HybridChunker, HierarchicalChunker` | `from docling_rs.chunking import HybridChunker, HierarchicalChunker` |
+| `from docling_core.types.doc import …` (types, `ImageRefMode`, serializers) | unchanged — `docling_core` stays a dependency and `result.document` is its `DoclingDocument` |
+
+A minimal script, before and after:
+
+```python
+# before                                         # after
+from docling.document_converter import (         from docling_rs import DocumentConverter
+    DocumentConverter,
+)
+conv = DocumentConverter()                       conv = DocumentConverter()
+result = conv.convert("report.pdf")              result = conv.convert("report.pdf")
+md = result.document.export_to_markdown()        md = result.document.export_to_markdown()
+```
+
+**3. Fetch the models once** (PDF/image path only — declarative formats need
+none): `python -c "import docling_rs; docling_rs.download_models()"`
+(~700 MB to `~/.cache/docling.rs`, idempotent). docling's own model cache is
+not reused; torch, transformers and CUDA-for-python are no longer needed —
+the engine bundles ONNX Runtime.
+
+**4. Check the divergences** if your code goes beyond the common path:
+the full-VLM pipeline (SmolDocling) and per-format backend selection are not
+ported; some `PdfPipelineOptions` fields are accepted for compatibility but
+inert (`images_scale`, `generate_page_images`, …); inline formatting is
+rendered into the text rather than structured `formatting` fields. The
+[API surface](#api-surface-docling-shaped) table below lists what acts, and
+[`docs/MIGRATION.md`](../../docs/MIGRATION.md) §4 the documented output
+divergences. `HybridChunker(tokenizer=…)` takes a `tokenizer.json` **path**
+(no `transformers`) instead of a HF model name.
+
+**5. GPU** (`docling-rs-cuda`): no code changes — the wheel defaults to
+`auto` (GPU when usable, CPU fallback). `DOCLING_RS_EP=cpu` or
+`AcceleratorOptions(device="cpu")` forces CPU; `DOCLING_RS_EP=cuda` /
+`device="cuda"` pins the GPU and fails loudly instead of falling back. See
+[GPU wheel](#gpu-wheel-docling-rs-cuda) for the runtime requirements.
+
 ## Try it locally
 
 Needs a Rust toolchain (1.88+, the workspace MSRV) and Python ≥ 3.9.
@@ -226,7 +292,7 @@ bundled in the wheel; pdfium is fetched at runtime by `download_models()`.
 The workflow's `cuda_wheel` input additionally builds a **Linux x86_64** wheel
 published as **`docling-rs-cuda`**: the same crate compiled with
 `--features cuda`, ONNX Runtime's CUDA provider libraries bundled next to the
-native module (found via an `$ORIGIN` rpath + an import-time preload).
+native module (found via an `$ORIGIN` rpath — no import-time preload).
 It installs the same `docling_rs` module — install *either* `docling-rs` *or*
 `docling-rs-cuda`, not both:
 


### PR DESCRIPTION


maturin 1.14 (pulled in by the ">=1.5,<2" range) vendors the sdist's path-dependency crates as sibling directories and points [tool.maturin] manifest-path at docling-py/Cargo.toml instead of keeping the crate manifest at the tarball root. The wheel-cuda job's raw `cargo build` assumed the old root layout and died with "could not find Cargo.toml in .../pkg". Resolve the manifest path from pyproject.toml (root fallback included, so older layouts keep working), pass it to cargo, and take the target directory from `cargo metadata` — the crate is its own workspace, so target/ moved along with the manifest. The `maturin build` invocation already handles both layouts.

Also documents how to migrate a Python docling codebase to docling-rs / docling-rs-cuda: install swap, an import-mapping table, before/after example, model download, divergences to check, and GPU notes — with a pointer from the root README. Drops the stale "import-time preload" mention (removed in #118).



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT