### PR TITLE
feat(py): mirror docling's module layout — imports migrate by package rename alone

### DIFF
--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -50,25 +50,36 @@ pip install docling-rs-cuda       # converts on the GPU automatically, CPU fallb
 pip uninstall docling             # optional — only when you no longer import it
 ```
 
-**2. Rewrite the imports** — everything comes from `docling_rs` /
-`docling_rs.chunking`:
+**2. Rewrite the imports: replace `docling` with `docling_rs`** — the package
+mirrors docling's module layout one-to-one, so it's a mechanical rename
+(`sed -i 's/\bdocling\./docling_rs./g'` on the import lines does it):
 
 | Python docling import | docling.rs import |
 |---|---|
-| `from docling.document_converter import DocumentConverter, PdfFormatOption` | `from docling_rs import DocumentConverter, PdfFormatOption` |
-| `from docling.datamodel.base_models import InputFormat, DocumentStream` | `from docling_rs import InputFormat, DocumentStream` |
-| `from docling.datamodel.pipeline_options import PdfPipelineOptions, AcceleratorOptions, TableFormerMode` | `from docling_rs import PdfPipelineOptions, AcceleratorOptions, TableFormerMode` |
-| `from docling.exceptions import ConversionError` | `from docling_rs import ConversionError` |
-| `from docling.chunking import HybridChunker, HierarchicalChunker` | `from docling_rs.chunking import HybridChunker, HierarchicalChunker` |
+| `from docling.document_converter import DocumentConverter, PdfFormatOption` | `from docling_rs.document_converter import DocumentConverter, PdfFormatOption` |
+| `from docling.datamodel.base_models import InputFormat, DocumentStream` | `from docling_rs.datamodel.base_models import InputFormat, DocumentStream` |
+| `from docling.datamodel.pipeline_options import PdfPipelineOptions, AcceleratorOptions, TableFormerMode` | `from docling_rs.datamodel.pipeline_options import …` (same names) |
+| `from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions` | `from docling_rs.datamodel.accelerator_options import …` (same names) |
+| `from docling.datamodel.document import ConversionResult` | `from docling_rs.datamodel.document import ConversionResult` |
+| `from docling.exceptions import ConversionError` | `from docling_rs.exceptions import ConversionError` |
+| `from docling.chunking import HybridChunker, HierarchicalChunker, BaseChunk` | `from docling_rs.chunking import HybridChunker, HierarchicalChunker, BaseChunk` |
+| `from docling.utils.model_downloader import download_models` | `from docling_rs.utils.model_downloader import download_models` |
 | `from docling_core.types.doc import …` (types, `ImageRefMode`, serializers) | unchanged — `docling_core` stays a dependency and `result.document` is its `DoclingDocument` |
+
+Every name is *also* exported flat from the package root
+(`from docling_rs import DocumentConverter, PdfPipelineOptions, …`) — the
+submodules are aliases of the same objects, kept for drop-in parity. An import
+docling.rs has no equivalent for (e.g. `docling.backend.*`, VLM pipeline
+options) raises `ModuleNotFoundError` at the import line — the honest signal
+that the code touches a not-ported area (see step 4).
 
 A minimal script, before and after:
 
 ```python
 # before                                         # after
-from docling.document_converter import (         from docling_rs import DocumentConverter
-    DocumentConverter,
-)
+from docling.document_converter import (         from docling_rs.document_converter import (
+    DocumentConverter,                               DocumentConverter,
+)                                                )
 conv = DocumentConverter()                       conv = DocumentConverter()
 result = conv.convert("report.pdf")              result = conv.convert("report.pdf")
 md = result.document.export_to_markdown()        md = result.document.export_to_markdown()

--- a/crates/docling-py/python/docling_rs/chunking.py
+++ b/crates/docling-py/python/docling_rs/chunking.py
@@ -55,7 +55,15 @@ from pathlib import Path
 from . import models
 from ._native import chunk_document as _chunk_document
 
-__all__ = ["DocMeta", "DocChunk", "HierarchicalChunker", "HybridChunker", "WindowChunker"]
+__all__ = [
+    "DocMeta",
+    "DocChunk",
+    "BaseChunk",
+    "BaseChunker",
+    "HierarchicalChunker",
+    "HybridChunker",
+    "WindowChunker",
+]
 
 
 @dataclass
@@ -123,6 +131,14 @@ class _BaseChunker:
     def contextualize(self, chunk: DocChunk) -> str:
         """The text to embed: heading path + chunk body, newline-joined."""
         return chunk._contextualized
+
+
+# docling.chunking-parity aliases: docling exports its chunk type and chunker
+# base under these names too, so `from docling_rs.chunking import BaseChunk,
+# BaseChunker` works for isinstance checks and type hints after a
+# docling → docling_rs package swap.
+BaseChunk = DocChunk
+BaseChunker = _BaseChunker
 
 
 class HierarchicalChunker(_BaseChunker):

--- a/crates/docling-py/python/docling_rs/datamodel/__init__.py
+++ b/crates/docling-py/python/docling_rs/datamodel/__init__.py
@@ -1,0 +1,9 @@
+"""docling-parity alias of the ``docling.datamodel`` package: the same
+submodule layout (``base_models``, ``pipeline_options``,
+``accelerator_options``, ``document``) re-exporting docling_rs's objects, so
+docling imports migrate by swapping the package name only.
+"""
+
+from . import accelerator_options, base_models, document, pipeline_options
+
+__all__ = ["accelerator_options", "base_models", "document", "pipeline_options"]

--- a/crates/docling-py/python/docling_rs/datamodel/accelerator_options.py
+++ b/crates/docling-py/python/docling_rs/datamodel/accelerator_options.py
@@ -1,0 +1,10 @@
+"""docling-parity alias of ``docling.datamodel.accelerator_options`` (where
+docling ≥ 2.29 defines the accelerator config)::
+
+    # was: from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+    from docling_rs.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+"""
+
+from ..options import AcceleratorDevice, AcceleratorOptions
+
+__all__ = ["AcceleratorDevice", "AcceleratorOptions"]

--- a/crates/docling-py/python/docling_rs/datamodel/base_models.py
+++ b/crates/docling-py/python/docling_rs/datamodel/base_models.py
@@ -1,0 +1,10 @@
+"""docling-parity alias of ``docling.datamodel.base_models``::
+
+    # was: from docling.datamodel.base_models import InputFormat, DocumentStream
+    from docling_rs.datamodel.base_models import InputFormat, DocumentStream
+"""
+
+from .. import ConversionStatus
+from ..options import DocumentStream, InputFormat
+
+__all__ = ["InputFormat", "DocumentStream", "ConversionStatus"]

--- a/crates/docling-py/python/docling_rs/datamodel/document.py
+++ b/crates/docling-py/python/docling_rs/datamodel/document.py
@@ -1,0 +1,9 @@
+"""docling-parity alias of ``docling.datamodel.document``::
+
+    # was: from docling.datamodel.document import ConversionResult
+    from docling_rs.datamodel.document import ConversionResult
+"""
+
+from .. import ConversionResult, InputDocument
+
+__all__ = ["ConversionResult", "InputDocument"]

--- a/crates/docling-py/python/docling_rs/datamodel/pipeline_options.py
+++ b/crates/docling-py/python/docling_rs/datamodel/pipeline_options.py
@@ -1,0 +1,25 @@
+"""docling-parity alias of ``docling.datamodel.pipeline_options``::
+
+    # was: from docling.datamodel.pipeline_options import PdfPipelineOptions, TableFormerMode
+    from docling_rs.datamodel.pipeline_options import PdfPipelineOptions, TableFormerMode
+
+``AcceleratorDevice`` / ``AcceleratorOptions`` are importable both from here
+(docling's historical location) and from ``datamodel.accelerator_options``
+(their current one) — mirroring docling's own back-compat re-export.
+"""
+
+from ..options import (
+    AcceleratorDevice,
+    AcceleratorOptions,
+    PdfPipelineOptions,
+    TableFormerMode,
+    TableStructureOptions,
+)
+
+__all__ = [
+    "PdfPipelineOptions",
+    "TableStructureOptions",
+    "TableFormerMode",
+    "AcceleratorDevice",
+    "AcceleratorOptions",
+]

--- a/crates/docling-py/python/docling_rs/document_converter.py
+++ b/crates/docling-py/python/docling_rs/document_converter.py
@@ -1,0 +1,15 @@
+"""docling-parity alias of ``docling.document_converter``.
+
+Lets a docling codebase migrate by replacing ``docling`` with ``docling_rs``
+in the import path — same module, same names::
+
+    # was: from docling.document_converter import DocumentConverter, PdfFormatOption
+    from docling_rs.document_converter import DocumentConverter, PdfFormatOption
+
+Everything here is the exact object also exported flat from ``docling_rs``.
+"""
+
+from . import ConversionResult, DocumentConverter
+from .options import PdfFormatOption
+
+__all__ = ["DocumentConverter", "PdfFormatOption", "ConversionResult"]

--- a/crates/docling-py/python/docling_rs/exceptions.py
+++ b/crates/docling-py/python/docling_rs/exceptions.py
@@ -1,0 +1,9 @@
+"""docling-parity alias of ``docling.exceptions``::
+
+    # was: from docling.exceptions import ConversionError
+    from docling_rs.exceptions import ConversionError
+"""
+
+from ._native import ConversionError
+
+__all__ = ["ConversionError"]

--- a/crates/docling-py/python/docling_rs/utils/__init__.py
+++ b/crates/docling-py/python/docling_rs/utils/__init__.py
@@ -1,0 +1,6 @@
+"""docling-parity alias of the ``docling.utils`` package (only the pieces
+docling.rs has an equivalent for — currently ``model_downloader``)."""
+
+from . import model_downloader
+
+__all__ = ["model_downloader"]

--- a/crates/docling-py/python/docling_rs/utils/model_downloader.py
+++ b/crates/docling-py/python/docling_rs/utils/model_downloader.py
@@ -1,0 +1,13 @@
+"""docling-parity alias of ``docling.utils.model_downloader``::
+
+    # was: from docling.utils.model_downloader import download_models
+    from docling_rs.utils.model_downloader import download_models
+
+Note the signature is docling.rs's own (``force=…`` etc., returning the cache
+dir) — the *import path* matches docling, the download itself fetches this
+repo's ONNX models, not docling's torch artifacts.
+"""
+
+from ..models import download_models
+
+__all__ = ["download_models"]

--- a/crates/docling-py/tests/test_namespace_parity.py
+++ b/crates/docling-py/tests/test_namespace_parity.py
@@ -1,0 +1,118 @@
+"""The docling-parity namespaces: every common `from docling.X import Y`
+must work verbatim after swapping the package name to `docling_rs`, and the
+aliases must be the *same objects* as the flat `docling_rs` exports."""
+
+import docling_rs
+
+
+def test_document_converter_module():
+    from docling_rs.document_converter import (
+        ConversionResult,
+        DocumentConverter,
+        PdfFormatOption,
+    )
+
+    assert DocumentConverter is docling_rs.DocumentConverter
+    assert PdfFormatOption is docling_rs.PdfFormatOption
+    assert ConversionResult is docling_rs.ConversionResult
+
+
+def test_datamodel_base_models():
+    from docling_rs.datamodel.base_models import (
+        ConversionStatus,
+        DocumentStream,
+        InputFormat,
+    )
+
+    assert InputFormat is docling_rs.InputFormat
+    assert DocumentStream is docling_rs.DocumentStream
+    assert ConversionStatus is docling_rs.ConversionStatus
+
+
+def test_datamodel_pipeline_options():
+    from docling_rs.datamodel.pipeline_options import (
+        AcceleratorDevice,
+        AcceleratorOptions,
+        PdfPipelineOptions,
+        TableFormerMode,
+        TableStructureOptions,
+    )
+
+    assert PdfPipelineOptions is docling_rs.PdfPipelineOptions
+    assert TableStructureOptions is docling_rs.TableStructureOptions
+    assert TableFormerMode is docling_rs.TableFormerMode
+    assert AcceleratorOptions is docling_rs.AcceleratorOptions
+    assert AcceleratorDevice is docling_rs.AcceleratorDevice
+
+
+def test_datamodel_accelerator_options():
+    # docling >= 2.29 location; pipeline_options keeps the back-compat alias.
+    from docling_rs.datamodel.accelerator_options import (
+        AcceleratorDevice,
+        AcceleratorOptions,
+    )
+
+    assert AcceleratorOptions is docling_rs.AcceleratorOptions
+    assert AcceleratorDevice is docling_rs.AcceleratorDevice
+
+
+def test_datamodel_document():
+    from docling_rs.datamodel.document import ConversionResult, InputDocument
+
+    assert ConversionResult is docling_rs.ConversionResult
+    assert InputDocument is docling_rs.InputDocument
+
+
+def test_exceptions():
+    from docling_rs.exceptions import ConversionError
+
+    assert ConversionError is docling_rs.ConversionError
+
+
+def test_chunking_parity_names():
+    from docling_rs.chunking import (
+        BaseChunk,
+        BaseChunker,
+        DocChunk,
+        HierarchicalChunker,
+        HybridChunker,
+    )
+
+    assert BaseChunk is DocChunk
+    assert issubclass(HierarchicalChunker, BaseChunker)
+    assert issubclass(HybridChunker, BaseChunker)
+
+
+def test_utils_model_downloader():
+    from docling_rs.utils.model_downloader import download_models
+
+    assert download_models is docling_rs.download_models
+
+
+def test_datamodel_package_imports_whole():
+    # `import docling_rs.datamodel` alone must expose the submodules, like
+    # docling's package does.
+    import docling_rs.datamodel as dm
+
+    assert dm.base_models.InputFormat is docling_rs.InputFormat
+    assert dm.pipeline_options.PdfPipelineOptions is docling_rs.PdfPipelineOptions
+    assert dm.document.ConversionResult is docling_rs.ConversionResult
+
+
+def test_migrated_docling_snippet_end_to_end(tmp_path):
+    # A verbatim docling snippet after s/docling/docling_rs/ on the imports.
+    from docling_rs.datamodel.base_models import InputFormat
+    from docling_rs.datamodel.pipeline_options import PdfPipelineOptions
+    from docling_rs.document_converter import DocumentConverter, PdfFormatOption
+
+    src = tmp_path / "note.md"
+    src.write_text("# Title\n\nSome body text.\n")
+
+    conv = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(do_ocr=False))
+        }
+    )
+    result = conv.convert(src)
+    assert result.status == "success"
+    assert "Some body text." in result.document.export_to_markdown()


### PR DESCRIPTION
Adds docling-parity alias submodules so a docling codebase moves to docling-rs / docling-rs-cuda by replacing `docling` with `docling_rs` on the import lines, nothing else:

  docling_rs.document_converter          DocumentConverter, PdfFormatOption, ConversionResult
  docling_rs.datamodel.base_models       InputFormat, DocumentStream, ConversionStatus
  docling_rs.datamodel.pipeline_options  PdfPipelineOptions, TableStructureOptions,
                                         TableFormerMode, Accelerator{Options,Device}
  docling_rs.datamodel.accelerator_options  (docling >= 2.29 location)
  docling_rs.datamodel.document          ConversionResult, InputDocument
  docling_rs.exceptions                  ConversionError
  docling_rs.utils.model_downloader      download_models
  docling_rs.chunking                    + BaseChunk / BaseChunker aliases

Each alias re-exports the same object as the flat package-root export. Imports docling.rs has no equivalent for (docling.backend.*, VLM options) keep raising ModuleNotFoundError as the honest not-ported signal.

Covered by a new parity test module (identity of every alias + an end-to-end run of a verbatim docling snippet after the rename); full suite is 40 passing. README migration guide updated accordingly.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT