### PR TITLE
security: harden document parsers and docling-serve against crafted input

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -19,6 +19,53 @@ permissions:
   pull-requests: write # open/refresh the update PR
 
 jobs:
+  # Weekly known-CVE scan of the committed lockfiles. Runs unconditionally
+  # (not gated on a lockfile change): an advisory can be published against a
+  # version we already pin, so the value is auditing the *current* tree every
+  # week, independent of whether `cargo update` moved anything. A finding fails
+  # the job — the scheduled-run failure is the alarm, same philosophy as the
+  # in-job test below.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          key: ${{ runner.os }}-cargo-audit-bin
+
+      - name: Install cargo-audit
+        # --locked: cargo-audit's own deps have raised the MSRV past stable's
+        # floor before; pin to its committed lockfile to install reliably.
+        run: cargo install cargo-audit --locked
+
+      - name: Audit both lockfiles
+        # Known-accepted advisories are ignored by ID so the job fails only on
+        # NEW findings (an unfiltered audit would go red every week on the
+        # residual and get tuned out). Keep this list in sync with the
+        # "Known residual" section of docs/SECURITY.md; drop an entry the week
+        # its upstream fix lands so a regression can't hide behind the ignore.
+        #   RUSTSEC-2026-0194 / -0195: quick-xml DoS, reachable only via
+        #     calamine's transitive 0.31 pin (XLSX). Our direct quick-xml is
+        #     >=0.41 (patched). Remove when calamine bumps quick-xml.
+        run: |
+          IGNORES="--ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195"
+          echo "::group::root workspace"
+          cargo audit $IGNORES
+          echo "::endgroup::"
+          echo "::group::docling-py workspace"
+          cargo audit $IGNORES --file crates/docling-py/Cargo.lock
+          echo "::endgroup::"
+
   cargo-update:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,8 +15,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -578,12 +589,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -663,7 +692,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -748,8 +786,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -798,7 +846,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
  "x509-cert",
@@ -875,6 +923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +967,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1043,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,12 +1207,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -1250,7 +1350,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1259,9 +1359,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1295,12 +1406,13 @@ dependencies = [
  "image",
  "mail-parser",
  "pulldown-cmark",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "rayon",
  "regex",
  "roxmltree",
  "scraper",
  "serde_json",
+ "tempfile",
  "ureq",
  "zip",
 ]
@@ -1331,7 +1443,7 @@ version = "0.44.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokenizers",
 ]
 
@@ -1380,7 +1492,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlite-vec",
  "sqlx",
  "ssh2",
@@ -1407,6 +1519,7 @@ dependencies = [
  "tokio-stream",
  "tower",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -1447,6 +1560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
+]
+
+[[package]]
+name = "ecb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1855,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -1969,7 +2091,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2041,6 +2163,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2291,8 +2422,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2408,6 +2549,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -2628,22 +2822,32 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
+ "aes 0.9.1",
+ "bitflags 2.13.1",
+ "cbc 0.2.1",
  "chrono",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.3",
  "indexmap",
  "itoa",
+ "jiff",
  "log",
- "md-5",
- "nom 7.1.3",
+ "md-5 0.11.0",
+ "nom 8.0.0",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
+ "sha2 0.11.0",
+ "stringprep",
+ "thiserror 2.0.19",
  "time",
- "weezl",
+ "weezl 0.2.1",
 ]
 
 [[package]]
@@ -2742,7 +2946,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3117,7 +3331,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cae83056e7cb770211494a0ecf66d9fa7eba7d00977e5bb91f0e925b40b937f"
 dependencies = [
- "cbc",
+ "cbc 0.1.2",
  "cms",
  "der",
  "des",
@@ -3128,7 +3342,7 @@ dependencies = [
  "rand 0.9.5",
  "rc2",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.19",
  "x509-parser",
 ]
@@ -3180,7 +3394,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -3320,9 +3534,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b3df3d3cc1015f12d70235e35b6b79befc5fa7a9b95b951eab1dd07c9efc2"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "der",
- "digest",
+ "digest 0.10.7",
  "spki",
  "x509-cert",
  "zeroize",
@@ -3334,12 +3548,12 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -3566,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3843,7 +4057,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4136,7 +4350,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4186,7 +4400,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4321,7 +4535,7 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4332,7 +4546,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4505,7 +4730,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.19",
  "tokio",
@@ -4543,7 +4768,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-postgres",
  "sqlx-sqlite",
@@ -4574,13 +4799,13 @@ dependencies = [
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.7",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4984,7 +5209,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error",
- "weezl",
+ "weezl 0.1.12",
  "zune-jpeg",
 ]
 
@@ -5623,6 +5848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "weezl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
+
+[[package]]
 name = "which"
 version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5907,7 +6138,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "ureq",
+ "url",
  "zip",
 ]
 

--- a/crates/docling-asr/src/audio.rs
+++ b/crates/docling-asr/src/audio.rs
@@ -42,7 +42,16 @@ pub fn decode_to_mono_16k(bytes: &[u8], name: &str) -> Result<Vec<f32>, String> 
         .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
         .ok_or_else(|| "asr: no decodable audio track".to_string())?;
     let track_id = track.id;
-    let src_rate = track.codec_params.sample_rate.unwrap_or(SAMPLE_RATE);
+    // Clamp the header-declared sample rate to a sane range. `resample_linear`
+    // upsamples by `src_rate / 16000`, and `Vec::with_capacity` on that factor
+    // means a crafted file claiming `sample_rate = 1` would try to allocate
+    // ~16000× the sample count → OOM abort. 8 kHz…768 kHz spans every real
+    // audio rate.
+    let src_rate = track
+        .codec_params
+        .sample_rate
+        .unwrap_or(SAMPLE_RATE)
+        .clamp(8_000, 768_000);
 
     let mut decoder = symphonia::default::get_codecs()
         .make(&track.codec_params, &DecoderOptions::default())

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -51,7 +51,7 @@ image = { version = "0.25", optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 regex = { version = "1.11", optional = true }
-lopdf = "0.34"
+lopdf = "0.44"
 fast_image_resize = { version = "5.1.4", optional = true }
 # CodeFormula enrichment decodes its VLM output with the HF tokenizer
 # (models/code_formula/tokenizer.json) — same crate/features as docling-core's

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -58,5 +58,12 @@ fast_image_resize = { version = "5.1.4", optional = true }
 # chunking tokenizer.
 tokenizers = { version = "0.20", default-features = false, features = ["onig"], optional = true }
 
+# lopdf 0.44 compiles its PDF-encryption support unconditionally, pulling in a
+# non-optional `getrandom`. On wasm32-unknown-unknown getrandom needs an
+# explicit backend, so enable lopdf's `wasm_js` feature there (JS crypto) —
+# the text-layer path never draws randomness, but the code must still compile.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+lopdf = { version = "0.44", features = ["wasm_js"] }
+
 [lib]
 name = "docling_pdf"

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -193,6 +193,40 @@ pub(crate) fn model_path(env: &str, fp32_default: &str, int8_default: &str) -> S
     resolve_asset(fp32_default)
 }
 
+/// Decode a standalone image with hard resource limits. A crafted image can
+/// declare enormous dimensions in a few-KB file; `image::load_from_memory`
+/// then tries to allocate the full pixel buffer (e.g. 60000×60000 → ~10 GB),
+/// and allocation failure aborts the whole process, bypassing the per-request
+/// panic catch. The 256 MiB alloc / 30000-px caps below turn that into a
+/// recoverable decode error instead. `DOCLING_RS_MAX_IMAGE_PIXELS` overrides
+/// the per-side pixel cap for the rare legitimately-huge scan.
+pub(crate) fn decode_image_limited(bytes: &[u8]) -> Result<image::RgbImage, PdfError> {
+    let max_side: u32 = std::env::var("DOCLING_RS_MAX_IMAGE_PIXELS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30_000);
+    decode_image_with_max_side(bytes, max_side)
+}
+
+fn decode_image_with_max_side(bytes: &[u8], max_side: u32) -> Result<image::RgbImage, PdfError> {
+    use image::ImageReader;
+    use std::io::Cursor;
+
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(max_side);
+    limits.max_image_height = Some(max_side);
+    limits.max_alloc = Some(256 * 1024 * 1024);
+
+    let mut reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|e| PdfError::Pdfium(format!("image: {e}")))?;
+    reader.limits(limits);
+    Ok(reader
+        .decode()
+        .map_err(|e| PdfError::Pdfium(format!("image: {e}")))?
+        .into_rgb8())
+}
+
 #[cfg(feature = "ml")]
 /// One page's assembled output: typed nodes plus the page's hyperlinks, kept
 /// separate so pages processed out of order can be stitched back in page order.
@@ -1096,9 +1130,7 @@ impl Pipeline {
     /// Convert a standalone image (PNG/JPEG/TIFF/WebP/…) as a single page —
     /// docling routes images through the same layout+OCR pipeline as a PDF page.
     pub fn convert_image(&mut self, bytes: &[u8], name: &str) -> Result<DoclingDocument, PdfError> {
-        let image = image::load_from_memory(bytes)
-            .map_err(|e| PdfError::Pdfium(format!("image: {e}")))?
-            .into_rgb8();
+        let image = decode_image_limited(bytes)?;
         let (w, h) = image.dimensions();
         // The image is its own page rendered at 1 px per "point" (scale 1.0); a
         // standalone image has no text layer, so OCR supplies the cells.
@@ -1222,6 +1254,53 @@ pub fn convert_pages_with_options(
 }
 
 #[cfg(feature = "ml")]
+#[cfg(test)]
+mod image_limit_tests {
+    use super::decode_image_with_max_side;
+
+    /// A small valid PNG encoded via the `image` crate (robust vs. a hand-rolled
+    /// byte literal).
+    fn png_bytes(w: u32, h: u32) -> Vec<u8> {
+        use std::io::Cursor;
+        let img = image::RgbImage::new(w, h);
+        let mut out = Vec::new();
+        img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+            .unwrap();
+        out
+    }
+
+    #[test]
+    fn normal_image_decodes_under_the_cap() {
+        let img = decode_image_with_max_side(&png_bytes(8, 8), 30_000).expect("8x8 decodes");
+        assert_eq!(img.dimensions(), (8, 8));
+    }
+
+    #[test]
+    fn dimensions_over_the_cap_are_rejected_not_aborted() {
+        // A per-side cap below the image's declared size must yield a
+        // recoverable Err, never an allocation-abort — the mechanism that stops
+        // a crafted image declaring 60000×60000 from OOM-killing the process.
+        let r = decode_image_with_max_side(&png_bytes(8, 8), 4);
+        assert!(
+            r.is_err(),
+            "decode must fail under the pixel cap, not abort"
+        );
+    }
+}
+
+#[cfg(test)]
+mod median_tests {
+    #[test]
+    fn median_of_empty_is_zero_not_a_panic() {
+        // A crafted table can leave a row/column with zero matched cells; the
+        // even-count branch would index values[0 - 1] and panic (→ remote crash
+        // via docling-serve) without the empty guard.
+        assert_eq!(super::tf_match::median_for_test(&mut []), 0.0);
+        assert_eq!(super::tf_match::median_for_test(&mut [4.0, 2.0]), 3.0);
+        assert_eq!(super::tf_match::median_for_test(&mut [5.0, 1.0, 3.0]), 3.0);
+    }
+}
+
 #[cfg(test)]
 mod send_check {
     /// The Node bindings (`docling-node`) run a shared [`super::Pipeline`] on

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -200,6 +200,11 @@ pub(crate) fn model_path(env: &str, fp32_default: &str, int8_default: &str) -> S
 /// panic catch. The 256 MiB alloc / 30000-px caps below turn that into a
 /// recoverable decode error instead. `DOCLING_RS_MAX_IMAGE_PIXELS` overrides
 /// the per-side pixel cap for the rare legitimately-huge scan.
+///
+/// Gated on `ml`: the only callers (`convert_image`, the METS backend) are
+/// ML-only, and the `image` crate is an `ml`-feature dependency — the
+/// text-layer wasm build has neither.
+#[cfg(feature = "ml")]
 pub(crate) fn decode_image_limited(bytes: &[u8]) -> Result<image::RgbImage, PdfError> {
     let max_side: u32 = std::env::var("DOCLING_RS_MAX_IMAGE_PIXELS")
         .ok()
@@ -208,6 +213,7 @@ pub(crate) fn decode_image_limited(bytes: &[u8]) -> Result<image::RgbImage, PdfE
     decode_image_with_max_side(bytes, max_side)
 }
 
+#[cfg(feature = "ml")]
 fn decode_image_with_max_side(bytes: &[u8], max_side: u32) -> Result<image::RgbImage, PdfError> {
     use image::ImageReader;
     use std::io::Cursor;
@@ -1254,7 +1260,7 @@ pub fn convert_pages_with_options(
 }
 
 #[cfg(feature = "ml")]
-#[cfg(test)]
+#[cfg(all(test, feature = "ml"))]
 mod image_limit_tests {
     use super::decode_image_with_max_side;
 

--- a/crates/docling-pdf/src/mets.rs
+++ b/crates/docling-pdf/src/mets.rs
@@ -80,9 +80,8 @@ pub fn convert_mets_gbs_with_options(
         let Some(img_bytes) = tiff.get(stem) else {
             continue;
         };
-        let image = image::load_from_memory(img_bytes)
-            .map_err(|e| PdfError::Pdfium(format!("mets image {stem}: {e}")))?
-            .into_rgb8();
+        let image = crate::decode_image_limited(img_bytes)
+            .map_err(|e| PdfError::Pdfium(format!("mets image {stem}: {e}")))?;
         let (width, height, cells) = parse_hocr(hocr, &image);
         pages.push(PdfPage {
             width,

--- a/crates/docling-pdf/src/textparse.rs
+++ b/crates/docling-pdf/src/textparse.rs
@@ -855,9 +855,9 @@ fn page_glyphs_cached(
     caches: &mut DocCaches,
 ) -> Vec<Glyph> {
     let mut out = Vec::new();
-    let Ok(content_bytes) = doc.get_page_content(page_id) else {
-        return out;
-    };
+    // lopdf 0.44: get_page_content returns the assembled content-stream bytes
+    // directly (an empty Vec when the page has none).
+    let content_bytes = doc.get_page_content(page_id);
     let Ok(content) = lopdf::content::Content::decode(&content_bytes) else {
         return out;
     };

--- a/crates/docling-pdf/src/tf_match.rs
+++ b/crates/docling-pdf/src/tf_match.rs
@@ -181,11 +181,22 @@ fn find_alignment_in_column(cells: &[TfCell]) -> Alignment {
     }
 }
 
+/// Test hook for the crate-internal [`median`] (empty-slice guard).
+#[cfg(test)]
+pub(crate) fn median_for_test(values: &mut [f64]) -> f64 {
+    median(values)
+}
+
 /// `statistics.median`: mean of the two middle values for an even count.
+/// Returns 0.0 for an empty slice — a crafted table can leave a row/column
+/// with zero matched cells, and `values[n / 2 - 1]` would otherwise underflow
+/// (`0usize - 1`) and panic, which (via docling-serve) is a remote crash.
 fn median(values: &mut [f64]) -> f64 {
     values.sort_by(|a, b| a.total_cmp(b));
     let n = values.len();
-    if n % 2 == 1 {
+    if n == 0 {
+        0.0
+    } else if n % 2 == 1 {
         values[n / 2]
     } else {
         (values[n / 2 - 1] + values[n / 2]) / 2.0

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "scraper",
  "serde_json",
  "ureq",
+ "url",
  "zip",
 ]
 
@@ -918,6 +919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,9 +1000,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1106,10 +1118,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -1347,6 +1462,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1877,6 +1998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2809,6 +2939,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3057,16 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3086,6 +3237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf16string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,6 +3262,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "v_frame"
@@ -3409,6 +3578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,6 +3598,29 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3445,10 +3643,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zip"

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +194,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +291,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +313,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -302,16 +361,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -364,6 +444,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -446,6 +535,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,8 +640,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -547,7 +678,7 @@ dependencies = [
  "image",
  "mail-parser",
  "pulldown-cmark",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "rayon",
  "regex",
  "roxmltree",
@@ -573,7 +704,7 @@ version = "0.44.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokenizers",
 ]
 
@@ -624,6 +755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
+]
+
+[[package]]
+name = "ecb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -852,6 +992,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -861,7 +1002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -930,6 +1071,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1012,6 +1162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1223,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -1167,22 +1380,32 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
+ "aes",
+ "bitflags 2.13.1",
+ "cbc",
  "chrono",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.3",
  "indexmap",
  "itoa",
+ "jiff",
  "log",
  "md-5",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
+ "sha2 0.11.0",
+ "stringprep",
+ "thiserror 2.0.19",
  "time",
- "weezl",
+ "weezl 0.2.1",
 ]
 
 [[package]]
@@ -1255,12 +1478,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1829,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1879,6 +2102,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +2149,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rangemap"
@@ -2269,8 +2509,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2363,6 +2614,17 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -2622,7 +2884,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error",
- "weezl",
+ "weezl 0.1.12",
  "zune-jpeg",
 ]
 
@@ -2655,6 +2917,21 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
@@ -2719,10 +2996,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -2732,6 +3024,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2934,6 +3232,12 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "weezl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
 
 [[package]]
 name = "winapi"

--- a/crates/docling-serve/Cargo.toml
+++ b/crates/docling-serve/Cargo.toml
@@ -29,6 +29,9 @@ tokio-stream = "0.1"
 # URL inputs are fetched with the same blocking client the converter already
 # uses for remote <img src> (keeps the dependency graph to a single HTTP stack).
 ureq = { version = "3", default-features = false, features = ["rustls", "gzip"] }
+# Parse URL-fetch inputs to validate the host against the SSRF IP block-list
+# before connecting (already in the graph via ureq).
+url = "2"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -47,9 +47,14 @@ convert documents to Markdown, docling JSON, DocLang archives, or chunk records.
 <div class="form">
   <div class="row">
     <label><input type="radio" name="mode" value="file" checked> Upload</label>
-    <label><input type="radio" name="mode" value="url"> URL</label>
+    <label id="url-mode"><input type="radio" name="mode" value="url"> URL</label>
     <input type="file" id="file">
     <input type="text" id="url" placeholder="https://example.com/document.pdf" style="display:none">
+  </div>
+  <div class="hint" id="url-disabled-note" style="display:none">
+    URL inputs are disabled on this server — start <code>docling-serve</code> with
+    <code>--allow-url-fetch</code> to enable them (outbound fetch is an SSRF surface;
+    see docs/SECURITY.md). Upload a file instead.
   </div>
   <div class="row">
     <label>Output:
@@ -62,6 +67,7 @@ convert documents to Markdown, docling JSON, DocLang archives, or chunk records.
     </label>
     <label><input type="checkbox" id="strict"> strict Markdown</label>
     <label><input type="checkbox" id="embed" checked> embed images</label>
+    <label title="HTML/EPUB: resolve external <img src> and embed the bytes (outbound fetch)"><input type="checkbox" id="fetch_images"> fetch images</label>
     <label><input type="checkbox" id="no_ocr"> no OCR</label>
     <label><input type="checkbox" id="no_table_former"> no TableFormer</label>
     <button id="go">Convert</button>
@@ -81,6 +87,7 @@ convert documents to Markdown, docling JSON, DocLang archives, or chunk records.
       <td>Convert an upload (<code>multipart/form-data</code>, a <code>file</code> part — the filename's
       extension selects the input format) or a URL (<code>application/json</code>:
       <code>{"url": …, "file_name"?: …}</code>).</td></tr>
+  <tr><td><code>GET</code></td><td><code>/v1/config</code></td><td>Server capabilities — currently <code>{"allow_url_fetch": bool}</code>, which this page adapts to.</td></tr>
   <tr><td><code>GET</code></td><td><code>/health</code></td><td>Liveness probe.</td></tr>
   <tr><td><code>GET</code></td><td><code>/ready</code></td><td>Readiness probe — 503 until <code>--warmup</code> finishes loading the ML models.</td></tr>
 </table>
@@ -116,6 +123,22 @@ for (const radio of document.querySelectorAll('input[name=mode]')) {
     $('url').style.display = file ? 'none' : '';
   });
 }
+
+// Reflect server capabilities: when URL fetch is disabled (--allow-url-fetch
+// off, the secure default), disable the URL radio and explain why, so the
+// option isn't a dead end that only fails with a 422 on Convert.
+(async () => {
+  try {
+    const cfg = await fetch('/v1/config').then((r) => r.json());
+    if (!cfg.allow_url_fetch) {
+      const urlRadio = document.querySelector('input[name=mode][value=url]');
+      urlRadio.disabled = true;
+      $('url-mode').style.opacity = '.5';
+      $('url-mode').title = 'Disabled — start docling-serve with --allow-url-fetch';
+      $('url-disabled-note').style.display = '';
+    }
+  } catch { /* config endpoint unavailable — leave the UI as-is */ }
+})();
 // Pull embedded pictures (data URIs) out of the Markdown / docling JSON,
 // show them as a gallery under the text, and shorten the base64 blobs in
 // the text panel so it stays readable. Markdown embeds only with the
@@ -181,6 +204,7 @@ $('go').addEventListener('click', async () => {
     to,
     strict: $('strict').checked,
     images: $('embed').checked ? 'embedded' : 'placeholder',
+    fetch_images: $('fetch_images').checked,
     no_ocr: $('no_ocr').checked,
     no_table_former: $('no_table_former').checked,
   };

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -67,10 +67,15 @@ convert documents to Markdown, docling JSON, DocLang archives, or chunk records.
     </label>
     <label><input type="checkbox" id="strict"> strict Markdown</label>
     <label><input type="checkbox" id="embed" checked> embed images</label>
-    <label title="HTML/EPUB: resolve external <img src> and embed the bytes (outbound fetch)"><input type="checkbox" id="fetch_images"> fetch images</label>
+    <label id="fetch-images-label" title="HTML/EPUB: resolve external <img src> and embed the bytes (outbound fetch)"><input type="checkbox" id="fetch_images"> fetch images</label>
     <label><input type="checkbox" id="no_ocr"> no OCR</label>
     <label><input type="checkbox" id="no_table_former"> no TableFormer</label>
     <button id="go">Convert</button>
+  </div>
+  <div class="hint" id="fetch-images-disabled-note" style="display:none">
+    <strong>fetch images</strong> is disabled on this server — start <code>docling-serve</code>
+    with <code>--allow-url-fetch</code> to pull external <code>&lt;img src&gt;</code> and embed them
+    (it's an outbound-fetch / SSRF surface, so off by default; see docs/SECURITY.md).
   </div>
   <div class="hint">PDF/image inputs run the ML pipeline — the first conversion loads the models
   (tens of seconds), repeats are fast. Markdown responses stream in as they convert.</div>
@@ -102,7 +107,7 @@ convert documents to Markdown, docling JSON, DocLang archives, or chunk records.
   <tr><td><code>images</code></td><td><code>placeholder</code> (default) | <code>embedded</code></td><td>Markdown picture handling (embedded = base64 data URIs).</td></tr>
   <tr><td><code>no_ocr</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: skip layout/OCR/TableFormer entirely; emit the embedded text layer only.</td></tr>
   <tr><td><code>no_table_former</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: geometric table reconstruction instead of the TableFormer model.</td></tr>
-  <tr><td><code>fetch_images</code></td><td><code>true</code>/<code>false</code></td><td>HTML/EPUB: resolve external <code>&lt;img src&gt;</code> and embed the bytes.</td></tr>
+  <tr><td><code>fetch_images</code></td><td><code>true</code>/<code>false</code></td><td>HTML/EPUB: resolve external <code>&lt;img src&gt;</code> and embed the bytes. Outbound fetch — honored only when the server runs with <code>--allow-url-fetch</code>, otherwise ignored.</td></tr>
 </table>
 
 <h2>Examples</h2>
@@ -136,6 +141,15 @@ for (const radio of document.querySelectorAll('input[name=mode]')) {
       $('url-mode').style.opacity = '.5';
       $('url-mode').title = 'Disabled — start docling-serve with --allow-url-fetch';
       $('url-disabled-note').style.display = '';
+      // `fetch_images` is the same outbound-fetch surface and is gated the same
+      // way server-side, so grey the box (and un-tick it) rather than let it
+      // silently no-op.
+      const fetchImages = $('fetch_images');
+      fetchImages.checked = false;
+      fetchImages.disabled = true;
+      $('fetch-images-label').style.opacity = '.5';
+      $('fetch-images-label').title = 'Disabled — start docling-serve with --allow-url-fetch';
+      $('fetch-images-disabled-note').style.display = '';
     }
   } catch { /* config endpoint unavailable — leave the UI as-is */ }
 })();

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -32,10 +32,14 @@
 //! (`--concurrency`); excess requests queue.
 //!
 //! Security: URL fetching makes the server issue outbound requests (SSRF
-//! surface) — bind to loopback (the default) or front with a policy proxy,
-//! and gate it with `--no-url-fetch` where the input should be uploads only.
+//! surface), so it is **off by default** — enable with `--allow-url-fetch`.
+//! Even when enabled, targets that resolve to a private/loopback/link-local
+//! address are refused and redirects are disabled. The server itself has no
+//! authentication: bind to loopback (the default) or front with a policy/auth
+//! proxy before exposing it.
 
 use std::io::Read;
+use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -64,7 +68,10 @@ pub struct ServeConfig {
     /// Load the PDF/image models at startup so `/ready` flips only when the
     /// first conversion would be fast. Off: models load lazily on first use.
     pub warmup: bool,
-    /// Allow `{"url": …}` inputs (outbound fetch — SSRF surface).
+    /// Allow `{"url": …}` inputs (outbound fetch — SSRF surface). Off by
+    /// default: even with the built-in private/loopback/link-local IP guard,
+    /// letting a caller name the fetch target is a deliberate exposure that a
+    /// deployment must opt into (`--allow-url-fetch`).
     pub allow_url_fetch: bool,
     /// Default `strict` for requests that don't set it.
     pub strict: bool,
@@ -77,7 +84,7 @@ impl Default for ServeConfig {
             concurrency: 2,
             max_body_bytes: 256 * 1024 * 1024,
             warmup: false,
-            allow_url_fetch: true,
+            allow_url_fetch: false,
             strict: false,
         }
     }
@@ -412,21 +419,94 @@ fn source_from_named_bytes(file_name: &str, bytes: Vec<u8>) -> Result<SourceDocu
     Ok(SourceDocument::from_bytes(stem, format, bytes))
 }
 
+/// Largest URL-fetch response accepted (256 MiB). Unlike the request-body
+/// limit, `read_to_end` on a fetched response is otherwise unbounded — a
+/// hostile URL streaming an endless body would exhaust memory.
+const MAX_FETCH_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Reject a resolved IP that points back into the local host or infrastructure.
+/// This is the core SSRF guard: without it, `{"url": "http://169.254.169.254/…"}`
+/// or `http://127.0.0.1:…` would let a caller reach cloud metadata and internal
+/// services from the server's network position.
+fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                // Carrier-grade NAT 100.64.0.0/10.
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 64)
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                // Unique-local fc00::/7 and link-local fe80::/10.
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                // IPv4-mapped (::ffff:a.b.c.d): re-check the embedded v4.
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| is_blocked_ip(IpAddr::V4(v4)))
+        }
+    }
+}
+
 /// Fetch a URL input (blocking; run on the blocking pool). The name comes
 /// from `file_name` or the URL path's last segment.
 fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(ApiError::Bad(format!("unsupported URL scheme in '{url}'")));
     }
-    let mut response = ureq::get(url)
+    // SSRF guard: resolve the host and reject if it maps to a private/loopback/
+    // link-local address, and forbid redirects (a public URL could 30x-bounce
+    // to an internal target, defeating this pre-check). This is a best-effort
+    // mitigation — a DNS-rebinding race between this resolution and ureq's own
+    // connect remains theoretically possible; the deployment-level control is
+    // to leave URL fetch disabled unless the network is trusted.
+    let parsed =
+        url::Url::parse(url).map_err(|e| ApiError::Bad(format!("bad URL '{url}': {e}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| ApiError::Bad(format!("no host in URL '{url}'")))?;
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let mut resolved = (host, port)
+        .to_socket_addrs()
+        .map_err(|e| ApiError::Bad(format!("cannot resolve {host}: {e}")))?
+        .peekable();
+    if resolved.peek().is_none() {
+        return Err(ApiError::Bad(format!("cannot resolve {host}")));
+    }
+    for addr in resolved {
+        if is_blocked_ip(addr.ip()) {
+            return Err(ApiError::Bad(format!(
+                "refusing to fetch {url}: resolves to a private/loopback address"
+            )));
+        }
+    }
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .max_redirects(0)
+        .build()
+        .into();
+    let mut response = agent
+        .get(url)
         .call()
         .map_err(|e| ApiError::Bad(format!("fetching {url}: {e}")))?;
     let mut bytes = Vec::new();
     response
         .body_mut()
         .as_reader()
+        .take(MAX_FETCH_BYTES + 1)
         .read_to_end(&mut bytes)
         .map_err(|e| ApiError::Bad(format!("reading {url}: {e}")))?;
+    if bytes.len() as u64 > MAX_FETCH_BYTES {
+        return Err(ApiError::Bad(format!(
+            "response from {url} exceeds {MAX_FETCH_BYTES} bytes"
+        )));
+    }
     let name = file_name
         .map(|s| s.to_string())
         .or_else(|| {
@@ -450,7 +530,17 @@ fn convert_document(
 ) -> Result<DoclingDocument, ApiError> {
     match source.format {
         InputFormat::Pdf | InputFormat::Image => {
-            let mut guard = state.pipeline.lock().unwrap();
+            // Recover from a poisoned lock instead of propagating the panic: a
+            // single crafted PDF/image that panics inside `convert` below drops
+            // the guard mid-unwind and poisons the mutex. Without this recovery
+            // every later request would panic on `.lock().unwrap()` too, turning
+            // one bad document into a permanent outage of this endpoint. The
+            // pipeline state is rebuilt/validated by `warm_pipeline`, so reusing
+            // it after a panic is safe.
+            let mut guard = state
+                .pipeline
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let pipeline = warm_pipeline(&mut guard, options)?;
             let doc = match source.format {
                 InputFormat::Pdf => pipeline.convert(&source.bytes, None, &source.name),
@@ -598,5 +688,56 @@ async fn stream_markdown(
 fn api_error_message(e: ApiError) -> String {
     match e {
         ApiError::Bad(m) | ApiError::Unsupported(m) | ApiError::Internal(m) => m,
+    }
+}
+
+#[cfg(test)]
+mod ssrf_tests {
+    use super::is_blocked_ip;
+    use std::net::IpAddr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn blocks_internal_targets() {
+        // Loopback, private ranges, link-local (incl. cloud metadata),
+        // unspecified, CGNAT, and the IPv4-mapped IPv6 forms must all be
+        // refused as SSRF targets.
+        for s in [
+            "127.0.0.1",
+            "127.5.5.5",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254", // AWS/GCP metadata
+            "0.0.0.0",
+            "100.64.0.1", // carrier-grade NAT
+            "::1",
+            "fe80::1",          // link-local
+            "fc00::1",          // unique-local
+            "::ffff:127.0.0.1", // IPv4-mapped loopback
+            "::ffff:169.254.169.254",
+        ] {
+            assert!(is_blocked_ip(ip(s)), "{s} should be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_targets() {
+        for s in [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700:4700::1111",
+        ] {
+            assert!(!is_blocked_ip(ip(s)), "{s} should be allowed");
+        }
+    }
+
+    #[test]
+    fn url_fetch_off_by_default() {
+        assert!(!super::ServeConfig::default().allow_url_fetch);
     }
 }

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -7,6 +7,7 @@
 //! |--------|---------------|----------------------------------------------------|
 //! | GET    | `/`           | API docs + an interactive test form                |
 //! | POST   | `/v1/convert` | convert an upload (multipart) or a URL (JSON body) |
+//! | GET    | `/v1/config`  | server capabilities (`{"allow_url_fetch": bool}`)  |
 //! | GET    | `/health`     | liveness probe                                     |
 //! | GET    | `/ready`      | readiness probe (200 once models are warm)         |
 //!
@@ -128,6 +129,7 @@ pub fn router(cfg: ServeConfig) -> Router {
         )
         .route("/health", get(|| async { Json(json!({"status": "ok"})) }))
         .route("/ready", get(ready))
+        .route("/v1/config", get(config))
         .route("/v1/convert", post(convert))
         .layer(DefaultBodyLimit::max(cfg.max_body_bytes))
         .with_state(state)
@@ -167,6 +169,13 @@ async fn shutdown_signal() {
         _ = term => {},
     }
     eprintln!("docling-serve: shutdown signal received, draining in-flight requests");
+}
+
+/// Capabilities the built-in UI adapts to. Currently just whether `{"url": …}`
+/// inputs are accepted (`--allow-url-fetch`) — the UI greys out the URL option
+/// and explains why when this is false, instead of letting the user hit a 422.
+async fn config(State(state): State<Arc<AppState>>) -> Response {
+    Json(json!({ "allow_url_fetch": state.cfg.allow_url_fetch })).into_response()
 }
 
 async fn ready(State(state): State<Arc<AppState>>) -> Response {
@@ -258,7 +267,9 @@ async fn convert(
             .map_err(|e| ApiError::Bad(format!("bad JSON body: {e}")))?;
         if !state.cfg.allow_url_fetch {
             return Err(ApiError::Unsupported(
-                "URL inputs are disabled (--no-url-fetch); upload the file instead".into(),
+                "URL inputs are disabled; start docling-serve with --allow-url-fetch \
+                 (SSRF surface — see docs/SECURITY.md), or upload the file instead"
+                    .into(),
             ));
         }
         let options = req.options.clone().merge_over(query);
@@ -405,18 +416,67 @@ async fn text_field(field: axum::extract::multipart::Field<'_>) -> Result<String
 
 /// Build a [`SourceDocument`] from a filename (extension → format) and bytes.
 fn source_from_named_bytes(file_name: &str, bytes: Vec<u8>) -> Result<SourceDocument, ApiError> {
+    source_from_named_bytes_ct(file_name, bytes, None)
+}
+
+/// As [`source_from_named_bytes`], with an optional response `Content-Type` used
+/// as a fallback when the name carries no usable extension — a URL like
+/// `…/help/example-domains` has no `.html`, but the server reports
+/// `text/html`, so it still converts.
+fn source_from_named_bytes_ct(
+    file_name: &str,
+    bytes: Vec<u8>,
+    content_type: Option<&str>,
+) -> Result<SourceDocument, ApiError> {
     let ext = std::path::Path::new(file_name)
         .extension()
-        .and_then(|e| e.to_str())
-        .ok_or_else(|| ApiError::Bad(format!("no extension on '{file_name}'")))?;
-    let format = InputFormat::from_extension(ext)
-        .ok_or_else(|| ApiError::Unsupported(format!("unrecognized extension '.{ext}'")))?;
+        .and_then(|e| e.to_str());
+    let format = ext
+        .and_then(InputFormat::from_extension)
+        .or_else(|| content_type.and_then(format_from_content_type))
+        .ok_or_else(|| match ext {
+            Some(e) => ApiError::Unsupported(format!("unrecognized extension '.{e}'")),
+            None => ApiError::Bad(format!(
+                "cannot determine the format of '{file_name}': no file extension \
+                 and no recognized Content-Type"
+            )),
+        })?;
     let stem = std::path::Path::new(file_name)
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("document")
         .to_string();
     Ok(SourceDocument::from_bytes(stem, format, bytes))
+}
+
+/// Map an HTTP `Content-Type` (its media-type, parameters stripped) to an input
+/// format — the common web types docling can convert. Anything else returns
+/// `None` and the caller reports an unknown-format error.
+fn format_from_content_type(content_type: &str) -> Option<InputFormat> {
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    Some(match mime.as_str() {
+        "text/html" | "application/xhtml+xml" => InputFormat::Html,
+        "application/pdf" => InputFormat::Pdf,
+        "text/markdown" | "text/plain" => InputFormat::Md,
+        "text/csv" => InputFormat::Csv,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => {
+            InputFormat::Docx
+        }
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation" => {
+            InputFormat::Pptx
+        }
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => InputFormat::Xlsx,
+        "application/epub+zip" => InputFormat::Epub,
+        "image/jpeg" | "image/png" | "image/tiff" | "image/bmp" | "image/webp" => {
+            InputFormat::Image
+        }
+        _ => return None,
+    })
 }
 
 /// Largest URL-fetch response accepted (256 MiB default). Unlike the
@@ -514,6 +574,12 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
         .get(url)
         .call()
         .map_err(|e| ApiError::Bad(format!("fetching {url}: {e}")))?;
+    // Kept for format detection when the URL/name has no usable extension.
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
     let max_fetch = max_fetch_bytes();
     let mut bytes = Vec::new();
     response
@@ -535,10 +601,8 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
                 .map(|s| s.split(['?', '#']).next().unwrap_or(s).to_string())
                 .filter(|s| !s.is_empty())
         })
-        .ok_or_else(|| {
-            ApiError::Bad("cannot derive a file name from the URL; pass file_name".into())
-        })?;
-    source_from_named_bytes(&name, bytes)
+        .unwrap_or_else(|| "document".to_string());
+    source_from_named_bytes_ct(&name, bytes, content_type.as_deref())
 }
 
 /// Convert to a [`DoclingDocument`], routing PDF/image through the warm
@@ -686,7 +750,14 @@ async fn stream_markdown(
     let mut rx = rx;
     let first = rx.recv().await;
     match first {
-        None => Err(ApiError::Internal("converter produced no output".into())),
+        // No chunks means the document converted to empty Markdown (e.g. an
+        // HTML page with no extractable content) — a valid result, not a
+        // server error. Return an empty 200 body rather than a 500.
+        None => Ok((
+            [(header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
+            Body::empty(),
+        )
+            .into_response()),
         Some(Err(e)) => Err(ApiError::Unsupported(e)),
         Some(Ok(first_chunk)) => {
             use tokio_stream::StreamExt;
@@ -759,6 +830,37 @@ mod ssrf_tests {
     #[test]
     fn url_fetch_off_by_default() {
         assert!(!super::ServeConfig::default().allow_url_fetch);
+    }
+
+    #[test]
+    fn content_type_maps_to_format_when_extension_missing() {
+        use super::{source_from_named_bytes_ct, ApiError, InputFormat};
+        // `ApiError` has no `Debug`, so match rather than `.expect()`.
+        let fmt = |r: Result<super::SourceDocument, ApiError>| r.ok().map(|s| s.format);
+
+        // A URL with no extension (iana example) resolves via Content-Type.
+        assert_eq!(
+            fmt(source_from_named_bytes_ct(
+                "example-domains",
+                b"<html></html>".to_vec(),
+                Some("text/html; charset=utf-8"),
+            )),
+            Some(InputFormat::Html)
+        );
+        // A usable extension still wins over the Content-Type.
+        assert_eq!(
+            fmt(source_from_named_bytes_ct(
+                "a.pdf",
+                b"%PDF".to_vec(),
+                Some("text/html"),
+            )),
+            Some(InputFormat::Pdf)
+        );
+        // Neither an extension nor a known Content-Type → a 4xx (Bad), not a 500.
+        assert!(matches!(
+            source_from_named_bytes_ct("noext", b"x".to_vec(), Some("application/octet-stream")),
+            Err(ApiError::Bad(_))
+        ));
     }
 
     #[test]

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -419,10 +419,26 @@ fn source_from_named_bytes(file_name: &str, bytes: Vec<u8>) -> Result<SourceDocu
     Ok(SourceDocument::from_bytes(stem, format, bytes))
 }
 
-/// Largest URL-fetch response accepted (256 MiB). Unlike the request-body
-/// limit, `read_to_end` on a fetched response is otherwise unbounded — a
-/// hostile URL streaming an endless body would exhaust memory.
-const MAX_FETCH_BYTES: u64 = 256 * 1024 * 1024;
+/// Largest URL-fetch response accepted (256 MiB default). Unlike the
+/// request-body limit, `read_to_end` on a fetched response is otherwise
+/// unbounded — a hostile URL streaming an endless body would exhaust memory.
+/// Override with `DOCLING_RS_MAX_FETCH_BYTES`.
+fn max_fetch_bytes() -> u64 {
+    std::env::var("DOCLING_RS_MAX_FETCH_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(256 * 1024 * 1024)
+}
+
+/// Escape hatch for local development: when `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH`
+/// is set to a truthy value (anything but empty / `0` / `false`), the SSRF IP
+/// block-list is not enforced, so a URL like `http://localhost:8080/doc.pdf`
+/// can be fetched. Off by default — leave it unset in production.
+fn allow_private_ip_fetch() -> bool {
+    std::env::var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH")
+        .map(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+}
 
 /// Reject a resolved IP that points back into the local host or infrastructure.
 /// This is the core SSRF guard: without it, `{"url": "http://169.254.169.254/…"}`
@@ -480,11 +496,14 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
     if resolved.peek().is_none() {
         return Err(ApiError::Bad(format!("cannot resolve {host}")));
     }
-    for addr in resolved {
-        if is_blocked_ip(addr.ip()) {
-            return Err(ApiError::Bad(format!(
-                "refusing to fetch {url}: resolves to a private/loopback address"
-            )));
+    if !allow_private_ip_fetch() {
+        for addr in resolved {
+            if is_blocked_ip(addr.ip()) {
+                return Err(ApiError::Bad(format!(
+                    "refusing to fetch {url}: resolves to a private/loopback address \
+                     (set DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1 for local development)"
+                )));
+            }
         }
     }
     let agent: ureq::Agent = ureq::Agent::config_builder()
@@ -495,16 +514,17 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
         .get(url)
         .call()
         .map_err(|e| ApiError::Bad(format!("fetching {url}: {e}")))?;
+    let max_fetch = max_fetch_bytes();
     let mut bytes = Vec::new();
     response
         .body_mut()
         .as_reader()
-        .take(MAX_FETCH_BYTES + 1)
+        .take(max_fetch + 1)
         .read_to_end(&mut bytes)
         .map_err(|e| ApiError::Bad(format!("reading {url}: {e}")))?;
-    if bytes.len() as u64 > MAX_FETCH_BYTES {
+    if bytes.len() as u64 > max_fetch {
         return Err(ApiError::Bad(format!(
-            "response from {url} exceeds {MAX_FETCH_BYTES} bytes"
+            "response from {url} exceeds {max_fetch} bytes"
         )));
     }
     let name = file_name
@@ -739,5 +759,25 @@ mod ssrf_tests {
     #[test]
     fn url_fetch_off_by_default() {
         assert!(!super::ServeConfig::default().allow_url_fetch);
+    }
+
+    #[test]
+    fn private_ip_escape_hatch_defaults_off() {
+        // The env var gates only development use; unset it must read as false
+        // so the block-list is enforced by default. (Set within this test only,
+        // then cleared, to avoid leaking to sibling tests.)
+        std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+        assert!(!super::allow_private_ip_fetch());
+        for (val, want) in [
+            ("1", true),
+            ("true", true),
+            ("0", false),
+            ("false", false),
+            ("", false),
+        ] {
+            std::env::set_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH", val);
+            assert_eq!(super::allow_private_ip_fetch(), want, "value {val:?}");
+        }
+        std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
     }
 }

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -21,7 +21,8 @@
 //! - `strict` — cleaner Markdown instead of docling-legacy output
 //! - `images` — `placeholder` (default) | `embedded` (Markdown only)
 //! - `no_ocr`, `no_table_former` — PDF/image pipeline switches
-//! - `fetch_images` — resolve external `<img src>` for HTML/EPUB
+//! - `fetch_images` — resolve external `<img src>` for HTML/EPUB (outbound
+//!   fetch, so honored only under `--allow-url-fetch`)
 //!
 //! Markdown converts through the streaming serializer and the response body
 //! streams page by page (chunked transfer); `json`/`dclx`/`chunks` buffer.
@@ -672,7 +673,12 @@ fn warm_pipeline<'a>(
 fn request_converter(state: &AppState, options: &ConvertOptions) -> DocumentConverter {
     DocumentConverter::new()
         .strict(options.strict.unwrap_or(state.cfg.strict))
-        .fetch_images(options.fetch_images.unwrap_or(false))
+        // `fetch_images` pulls external `<img src>` over the network — the same
+        // outbound-fetch / SSRF surface as URL inputs, so it lives behind the
+        // same `--allow-url-fetch` gate. Off by default, it's silently ignored
+        // rather than honored (the UI greys the box; an API caller just gets
+        // placeholder images instead of a surprise outbound fetch).
+        .fetch_images(state.cfg.allow_url_fetch && options.fetch_images.unwrap_or(false))
         .no_ocr(options.no_ocr.unwrap_or(false))
         .no_table_former(options.no_table_former.unwrap_or(false))
 }

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -602,7 +602,9 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
                 .filter(|s| !s.is_empty())
         })
         .unwrap_or_else(|| "document".to_string());
-    source_from_named_bytes_ct(&name, bytes, content_type.as_deref())
+    // Record the fetch URL as the document's base URL so relative `<img src>`
+    // on a fetched web page resolve against its origin when fetch_images is on.
+    Ok(source_from_named_bytes_ct(&name, bytes, content_type.as_deref())?.with_base_url(url))
 }
 
 /// Convert to a [`DoclingDocument`], routing PDF/image through the warm

--- a/crates/docling-serve/src/main.rs
+++ b/crates/docling-serve/src/main.rs
@@ -1,17 +1,20 @@
 //! `docling-serve` — standalone binary for the HTTP conversion API.
 //!
 //! Usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N]
-//!                      [--warmup] [--no-url-fetch] [--strict]
+//!                      [--warmup] [--allow-url-fetch] [--strict]
 //!
 //!   --addr HOST:PORT  bind address (default: 127.0.0.1:5001). Bind 0.0.0.0
-//!                     only behind a trusted proxy — /v1/convert accepts URL
-//!                     inputs (outbound fetches) unless --no-url-fetch.
+//!                     only behind a trusted proxy.
 //!   --concurrency N   max conversions in flight; excess requests queue
 //!                     (default: 2)
 //!   --max-body-mb N   request body cap for uploads, in MiB (default: 256)
 //!   --warmup          load the PDF/image models at startup; /ready returns
 //!                     503 until they are loaded
-//!   --no-url-fetch    reject {"url": …} inputs; uploads only
+//!   --allow-url-fetch accept {"url": …} inputs (outbound fetch — SSRF surface;
+//!                     off by default). A private/loopback/link-local IP guard
+//!                     applies even when enabled.
+//!   --no-url-fetch    accepted for compatibility (URL fetch is now off by
+//!                     default; this is a no-op)
 //!   --strict          default to the cleaner strict Markdown dialect
 
 use std::process::ExitCode;
@@ -36,6 +39,9 @@ fn main() -> ExitCode {
                 _ => return usage("--max-body-mb needs a positive integer"),
             },
             "--warmup" => cfg.warmup = true,
+            "--allow-url-fetch" => cfg.allow_url_fetch = true,
+            // URL fetch is off by default now; keep the old flag as a no-op so
+            // existing invocations don't break.
             "--no-url-fetch" => cfg.allow_url_fetch = false,
             "--strict" => cfg.strict = true,
             "--help" | "-h" => return usage(""),

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -186,6 +186,95 @@ async fn strict_field_changes_markdown_dialect() {
     assert_ne!(legacy, strict, "strict flag had no effect");
 }
 
+/// `fetch_images` is outbound fetch (SSRF surface), so it's gated behind the
+/// same `--allow-url-fetch` as URL inputs: honored only when the flag is on,
+/// silently ignored otherwise. Proven against a local image server that counts
+/// the requests it receives — the gate must let *zero* through when off.
+#[tokio::test]
+async fn fetch_images_is_gated_behind_allow_url_fetch() {
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // 1×1 red PNG — a real image so the resolved bytes decode and embed.
+    const RED_PNG: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8,
+        0xcf, 0xc0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x6e, 0x2c, 0xdc, 0x33, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let server_hits = Arc::clone(&hits);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            server_hits.fetch_add(1, Ordering::Relaxed);
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                RED_PNG.len()
+            );
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(RED_PNG);
+            let _ = stream.flush();
+        }
+    });
+    let html = format!("<html><body><p>hi</p><img src=\"http://{addr}/x.png\"></body></html>");
+    let fields = [("to", "json"), ("fetch_images", "true")];
+
+    // Gate OFF (secure default): fetch_images asked for, but --allow-url-fetch
+    // is off → no outbound fetch, the picture stays a placeholder (no bytes).
+    let (ct, body) = multipart("p.html", html.as_bytes(), &fields);
+    let cfg = ServeConfig {
+        allow_url_fetch: false,
+        ..ServeConfig::default()
+    };
+    let response = router(cfg)
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = body_string(response).await;
+    assert!(
+        !out.contains("data:image/"),
+        "gate off must not embed: {out}"
+    );
+    assert_eq!(
+        hits.load(Ordering::Relaxed),
+        0,
+        "gate off must not fetch the image"
+    );
+
+    // Gate ON: --allow-url-fetch set (plus the private-IP opt-in for 127.0.0.1)
+    // → the image is fetched and embedded as a data URI.
+    std::env::set_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH", "1");
+    let (ct, body) = multipart("p.html", html.as_bytes(), &fields);
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let response = router(cfg)
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = body_string(response).await;
+    std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+    assert!(
+        hits.load(Ordering::Relaxed) >= 1,
+        "gate on must fetch the image"
+    );
+    assert!(
+        out.contains("data:image/"),
+        "gate on must embed the fetched image"
+    );
+}
+
 #[tokio::test]
 async fn index_serves_docs_and_form() {
     let response = app()

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -35,7 +35,7 @@ fetch-images = ["dep:ureq"]
 # stays pure-Rust with no browser/runtime dependency; enable with
 # `--features web-browser`. Drives the system Chromium over the DevTools
 # protocol purely from Rust (no Node/Playwright) via `headless_chrome`.
-web-browser = ["dep:headless_chrome"]
+web-browser = ["dep:headless_chrome", "dep:tempfile"]
 # Tokenization-aware chunking (docling-core's HybridChunker + HF tokenizer).
 chunking = ["docling-core/chunking"]
 # GPU execution providers for the PDF/image ML pipeline (#74) — pass-through
@@ -49,13 +49,16 @@ coreml = ["pdf", "docling-pdf/coreml"]
 calamine = { version = "0.26", features = ["dates"] }
 csv = "1.4.0"
 headless_chrome = { version = "1.0", optional = true }
+# O_EXCL temp file with an unpredictable name for the browser pre-render page
+# (avoids a predictable /tmp path a local attacker could pre-plant a symlink at).
+tempfile = { version = "3", optional = true }
 docling-asr = { path = "../docling-asr", version = "0.44.0", optional = true }
 docling-core = { path = "../docling-core", version = "0.44.0" }
 docling-pdf = { path = "../docling-pdf", version = "0.44.0", optional = true, default-features = false }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "tiff", "webp"] }
 mail-parser = "0.11"
 pulldown-cmark = { version = "0.13.4", default-features = false }
-quick-xml = "0.37"
+quick-xml = "0.41"
 # Data-parallel fan-out over independent OOXML parts (XLSX sheets, PPTX
 # slides) — see the profile in the module docs of `backend/xlsx.rs`.
 rayon = "1.10"

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -29,7 +29,7 @@ pdf-text = ["dep:docling-pdf"]
 # Audio → Whisper ASR (symphonia + ONNX Runtime via docling-asr).
 asr = ["dep:docling-asr"]
 # Blocking HTTP fetch of remote <img src> images (DocumentConverter::fetch_images).
-fetch-images = ["dep:ureq"]
+fetch-images = ["dep:ureq", "dep:url"]
 # Optional headless-browser HTML pre-render (the `--use-web-browser` flag /
 # `DocumentConverter::use_web_browser`). Off by default so the standard build
 # stays pure-Rust with no browser/runtime dependency; enable with
@@ -71,6 +71,9 @@ serde_json = "1"
 # already pulls in (so the graph keeps a single ureq); it needs Rust 1.85, which
 # this crate already requires transitively via docling-pdf → ort.
 ureq = { version = "3", optional = true }
+# Resolve relative / protocol-relative <img src> against the page's base URL
+# when the HTML was fetched from the web (fetch_images). Gated with ureq.
+url = { version = "2", optional = true }
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [[example]]

--- a/crates/docling/src/backend/browser.rs
+++ b/crates/docling/src/backend/browser.rs
@@ -41,11 +41,23 @@ const STRIP_HIDDEN_JS: &str = r#"
 pub fn render_visible_html(html: &str) -> Result<String, String> {
     // Load via a temporary `file://` document rather than a `data:` URL — a large
     // page (e.g. a full Wikipedia article) blows past practical data-URL limits.
-    let path = temp_html_path();
-    std::fs::write(&path, html).map_err(|e| format!("browser: writing temp page: {e}"))?;
-    let result = render_file(&path);
-    let _ = std::fs::remove_file(&path);
-    result
+    //
+    // The file is created with an unpredictable name via `tempfile` (O_EXCL +
+    // random suffix): a fixed `<pid>-<seq>` path in a shared /tmp could be
+    // pre-planted as a symlink by a local attacker, and `fs::write` would
+    // follow it into an arbitrary-file overwrite. The handle also removes the
+    // file on drop, so an early return can't leak it.
+    use std::io::Write;
+    let mut file = tempfile::Builder::new()
+        .prefix("docling.rs-render-")
+        .suffix(".html")
+        .tempfile()
+        .map_err(|e| format!("browser: temp page: {e}"))?;
+    file.write_all(html.as_bytes())
+        .map_err(|e| format!("browser: writing temp page: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("browser: writing temp page: {e}"))?;
+    render_file(file.path())
 }
 
 fn render_file(path: &Path) -> Result<String, String> {
@@ -95,22 +107,6 @@ fn locate_chrome() -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// A per-process temp path for the page being rendered. A short atomic counter
-/// disambiguates concurrent conversions in one process (the environment forbids
-/// `Date::now`/random in some contexts, so avoid both).
-fn temp_html_path() -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let n = SEQ.fetch_add(1, Ordering::Relaxed);
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "docling.rs-render-{}-{}.html",
-        std::process::id(),
-        n
-    ));
-    path
 }
 
 #[cfg(test)]

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -74,7 +74,21 @@ pub(crate) fn append_fragment(html: &str, out: &mut Vec<Node>, images: &dyn Imag
     // Prefer <body>; fall back to the root element for fragments.
     let body = parsed.select(cached_selector!("body")).next();
     let root = body.unwrap_or_else(|| parsed.root_element());
-    walk_block(root, out, 0, Fmt::default(), images);
+    // The block/inline DOM walkers below recurse on nesting depth. A crafted
+    // document with tens of thousands of nested elements (trivial to author,
+    // also reachable through EPUB and Markdown-embedded HTML) would overflow
+    // the stack — an uncatchable abort, i.e. a remote DoS via docling-serve.
+    // Guard with a depth ceiling checked iteratively (so the check itself
+    // can't overflow); past it, fall back to the flattened text so the
+    // document still yields content without descending the pathological tree.
+    if within_depth_limit(root, MAX_DOM_DEPTH) {
+        walk_block(root, out, 0, Fmt::default(), images);
+    } else {
+        let text = normalize_ws(&root.text().collect::<String>());
+        if !text.is_empty() {
+            out.push(Node::Paragraph { text });
+        }
+    }
     // docling's `infer_furniture`: content before the first body heading is site
     // chrome (navigation/menus/sidebars) → the `furniture` layer.
     mark_leading_furniture(&mut out[start..]);
@@ -190,6 +204,35 @@ fn is_block(name: &str) -> bool {
 /// found directly between block elements is buffered and flushed as paragraphs.
 /// `base` seeds the inline formatting — table cells pass `raw` so their text is
 /// not `&<>`/`_` escaped.
+/// Deepest DOM nesting the recursive walkers will descend. Real documents sit
+/// in the low tens; 2000 is far above anything legitimate while keeping the
+/// recursion well clear of the stack limit. Override with
+/// `DOCLING_RS_MAX_HTML_DEPTH`.
+const MAX_DOM_DEPTH: usize = 2000;
+
+fn max_dom_depth() -> usize {
+    std::env::var("DOCLING_RS_MAX_HTML_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(MAX_DOM_DEPTH)
+}
+
+/// Whether no node under `root` nests deeper than the limit. Iterative DFS —
+/// this check must not itself recurse (it runs on the same hostile tree).
+fn within_depth_limit(root: ElementRef, _default: usize) -> bool {
+    let limit = max_dom_depth();
+    let mut stack = vec![(*root, 1usize)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > limit {
+            return false;
+        }
+        for child in node.children() {
+            stack.push((child, depth + 1));
+        }
+    }
+    true
+}
+
 fn walk_block(
     elem: ElementRef,
     nodes: &mut Vec<Node>,
@@ -1615,6 +1658,36 @@ mod tests {
     fn convert(html: &str) -> DoclingDocument {
         let src = SourceDocument::from_bytes("t", InputFormat::Html, html.as_bytes().to_vec());
         HtmlBackend.convert(&src).unwrap()
+    }
+
+    #[test]
+    fn deeply_nested_html_does_not_overflow_the_stack() {
+        // ~50k nested <div> would blow the recursive walker's stack (an
+        // uncatchable abort). The depth guard must fall back to flattened text
+        // instead of recursing. Uses the env override to keep the test cheap.
+        std::env::set_var("DOCLING_RS_MAX_HTML_DEPTH", "200");
+        let depth = 4_000;
+        let html = format!(
+            "<html><body>{}<p>deep text</p>{}</body></html>",
+            "<div>".repeat(depth),
+            "</div>".repeat(depth),
+        );
+        let doc = convert(&html); // must return, not abort
+        std::env::remove_var("DOCLING_RS_MAX_HTML_DEPTH");
+        assert!(
+            doc.export_to_markdown().contains("deep text"),
+            "flattened fallback should preserve the text content"
+        );
+    }
+
+    #[test]
+    fn shallow_html_still_walks_structurally() {
+        // A normal document stays under the limit and produces real structure,
+        // not the flattened fallback.
+        let doc = convert("<h1>Title</h1><ul><li>a</li><li>b</li></ul>");
+        let md = doc.export_to_markdown();
+        assert!(md.contains("# Title"));
+        assert!(md.contains("- a"));
     }
 
     #[test]

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -265,7 +265,7 @@ fn walk_block(
                     flush_inline(&mut inline, nodes);
                     nodes.push(Node::Picture {
                         caption: e.attr("alt").filter(|a| !a.is_empty()).map(str::to_string),
-                        image: e.attr("src").and_then(|s| images.resolve(s)),
+                        image: img_src(e).and_then(|s| images.resolve(&s)),
                         classification: None,
                     });
                 } else if name == "signature" || name == "stamp" {
@@ -1443,16 +1443,51 @@ fn image_wrapper(elem: ElementRef) -> Option<(Option<String>, Option<String>)> {
         .attr("alt")
         .filter(|a| !a.is_empty())
         .map(str::to_string);
-    let src = img.value().attr("src").map(str::to_string);
+    let src = img_src(img.value());
     Some((caption, src))
 }
 
-/// The `src` of a `<figure>`'s first `<img>`, for image extraction.
+/// The image URL of a `<figure>`'s first `<img>`, for image extraction.
 fn figure_img_src(fig: ElementRef) -> Option<String> {
     fig.select(cached_selector!("img"))
         .next()
-        .and_then(|img| img.value().attr("src"))
-        .map(str::to_string)
+        .and_then(|img| img_src(img.value()))
+}
+
+/// The real image URL of an `<img>`, accounting for lazy-loading: a normal
+/// `src` is authoritative, but many pages leave `src` empty or a placeholder
+/// and put the true URL in `data-src` (or a `srcset`), so fall back to those —
+/// otherwise every lazy-loaded image would extract nothing.
+fn img_src(el: &scraper::node::Element) -> Option<String> {
+    let attr = |k: &str| el.attr(k).map(str::trim).filter(|s| !s.is_empty());
+    // A non-placeholder src wins.
+    if let Some(s) = attr("src") {
+        if !s.starts_with("data:") {
+            return Some(s.to_string());
+        }
+    }
+    // Common lazy-load conventions.
+    for k in ["data-src", "data-original", "data-lazy-src", "data-lazy"] {
+        if let Some(s) = attr(k) {
+            return Some(s.to_string());
+        }
+    }
+    // srcset / data-srcset: take the first candidate's URL (before its
+    // descriptor, e.g. `foo.png 2x` / `foo.png 640w`).
+    for k in ["srcset", "data-srcset"] {
+        if let Some(s) = attr(k) {
+            if let Some(u) = s
+                .split(',')
+                .next()
+                .and_then(|c| c.split_whitespace().next())
+                .filter(|u| !u.is_empty())
+            {
+                return Some(u.to_string());
+            }
+        }
+    }
+    // Last resort: a `data:` src (a real inline image, no lazy target).
+    attr("src").map(str::to_string)
 }
 
 fn has_descendant(elem: ElementRef, name: &str) -> bool {
@@ -1867,7 +1902,7 @@ mod tests {
         assert!(matches!(plain.nodes[0], Node::Picture { image: None, .. }));
 
         // With a resolver the data: URI is decoded and embedded.
-        let doc = convert_html("t", &html, &FsImageResolver::new(None));
+        let doc = convert_html("t", &html, &FsImageResolver::new(None, None));
         match &doc.nodes[0] {
             Node::Picture {
                 image: Some(img),
@@ -1880,5 +1915,33 @@ mod tests {
             }
             other => panic!("expected an embedded image, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn lazy_loaded_img_src_falls_back_to_data_src_and_srcset() {
+        use super::img_src;
+        use scraper::Html;
+        let pick = |html: &str| {
+            let frag = Html::parse_fragment(html);
+            let img = frag.select(cached_selector!("img")).next().unwrap();
+            img_src(img.value())
+        };
+        // A real src wins.
+        assert_eq!(pick(r#"<img src="/a.png">"#).as_deref(), Some("/a.png"));
+        // No src → data-src (the magenta.at lazy-load shape).
+        assert_eq!(
+            pick(r#"<img data-src="/b.png" class="lazyload">"#).as_deref(),
+            Some("/b.png")
+        );
+        // A placeholder data: src with a lazy target → the lazy target.
+        assert_eq!(
+            pick(r#"<img src="data:image/gif;base64,R0lGOD" data-src="/c.png">"#).as_deref(),
+            Some("/c.png")
+        );
+        // srcset → first candidate URL, descriptor stripped.
+        assert_eq!(
+            pick(r#"<img srcset="/d-1x.png 1x, /d-2x.png 2x">"#).as_deref(),
+            Some("/d-1x.png")
+        );
     }
 }

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -82,6 +82,17 @@ pub(crate) fn append_fragment(html: &str, out: &mut Vec<Node>, images: &dyn Imag
     // can't overflow); past it, fall back to the flattened text so the
     // document still yields content without descending the pathological tree.
     if within_depth_limit(root, MAX_DOM_DEPTH) {
+        // Warm remote-image fetches concurrently before the serial walk: a real
+        // web page carries dozens of `<img>`, and fetching them one-at-a-time
+        // during the walk dominates wall-clock. Collect every image src up front
+        // (the walk resolves the same strings, hitting the now-warm cache).
+        let srcs: Vec<String> = root
+            .select(cached_selector!("img"))
+            .filter_map(|img| img_src(img.value()))
+            .collect();
+        if !srcs.is_empty() {
+            images.prefetch(&srcs);
+        }
         walk_block(root, out, 0, Fmt::default(), images);
     } else {
         let text = normalize_ws(&root.text().collect::<String>());

--- a/crates/docling/src/backend/images.rs
+++ b/crates/docling/src/backend/images.rs
@@ -41,16 +41,34 @@ impl ImageResolver for NoFetch {
 
 /// Filesystem/network resolver for standalone HTML. Handles `data:` URIs inline,
 /// reads local files relative to the source document's directory, and fetches
-/// remote `http(s)` URLs.
+/// remote `http(s)` URLs — including relative / protocol-relative `<img src>`
+/// resolved against the page's [`base_url`](Self::base_url) when the HTML was
+/// itself fetched from the web.
 pub(crate) struct FsImageResolver {
     base_dir: Option<PathBuf>,
+    base_url: Option<String>,
 }
 
 impl FsImageResolver {
-    /// `base_dir` is the source HTML file's directory, used to resolve relative
-    /// `src` paths; `None` (an in-memory source) disables relative-path reads.
-    pub(crate) fn new(base_dir: Option<PathBuf>) -> Self {
-        Self { base_dir }
+    /// `base_dir` is the source HTML file's directory (relative-path reads);
+    /// `base_url` is the URL the page was fetched from (relative `<img src>`
+    /// resolution). Either may be `None`.
+    pub(crate) fn new(base_dir: Option<PathBuf>, base_url: Option<String>) -> Self {
+        Self { base_dir, base_url }
+    }
+
+    /// Resolve `src` to an absolute `http(s)` URL when possible: an already-
+    /// absolute URL as-is, else relative / protocol-relative / absolute-path
+    /// joined against the page base URL. `None` when there is nothing remote to
+    /// fetch (no base URL for a relative src).
+    #[cfg(feature = "fetch-images")]
+    fn absolute_http_url(&self, src: &str) -> Option<String> {
+        if src.starts_with("http://") || src.starts_with("https://") {
+            return Some(src.to_string());
+        }
+        let base = self.base_url.as_deref()?;
+        let joined = url::Url::parse(base).ok()?.join(src).ok()?;
+        matches!(joined.scheme(), "http" | "https").then(|| joined.to_string())
     }
 }
 
@@ -63,8 +81,16 @@ impl ImageResolver for FsImageResolver {
         if src.starts_with("data:") {
             return from_data_uri(src);
         }
+        // Remote: an absolute URL, or a relative one resolved against the page
+        // base URL (a page fetched from the web references images by relative
+        // path). Only compiled with the HTTP client available.
+        #[cfg(feature = "fetch-images")]
+        if let Some(url) = self.absolute_http_url(src) {
+            return fetch_remote(&url);
+        }
+        #[cfg(not(feature = "fetch-images"))]
         if src.starts_with("http://") || src.starts_with("https://") {
-            return fetch_remote(src);
+            return None;
         }
         // A local path (possibly `file://`). Absolute paths are read directly;
         // relative ones only when we know the source's directory — never against
@@ -116,11 +142,78 @@ fn from_data_uri(uri: &str) -> Option<PictureImage> {
     build_picture(mime, data)
 }
 
+/// Whether a resolved IP points back at the local host or private
+/// infrastructure — the SSRF block-list (mirrors docling-serve's URL-fetch
+/// guard, so a document that points `<img src>` at an internal address can't
+/// reach it when image fetching runs on a server).
+#[cfg(feature = "fetch-images")]
+fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 64)
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| is_blocked_ip(IpAddr::V4(v4)))
+        }
+    }
+}
+
+/// `true` when the URL's host resolves to a blocked address and the operator
+/// hasn't opted out with `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH` (the same flag
+/// docling-serve's URL fetch honors, for local/intranet development).
+#[cfg(feature = "fetch-images")]
+fn blocked_by_ssrf_guard(url: &str) -> bool {
+    use std::net::ToSocketAddrs;
+    let allow = std::env::var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH")
+        .map(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false);
+    if allow {
+        return false;
+    }
+    let Ok(parsed) = url::Url::parse(url) else {
+        return true;
+    };
+    let Some(host) = parsed.host_str() else {
+        return true;
+    };
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    match (host, port).to_socket_addrs() {
+        Ok(addrs) => addrs.map(|a| a.ip()).any(is_blocked_ip),
+        // Unresolvable host: nothing to fetch — treat as blocked (skip).
+        Err(_) => true,
+    }
+}
+
 /// Fetch a remote image over HTTP(S). The mimetype comes from `Content-Type`
 /// when it's an `image/*`, else it's guessed from the URL's extension.
+/// Bounded: an SSRF block-list, a connect/overall timeout, and a redirect cap
+/// keep one hostile or slow `<img src>` from hanging the whole conversion.
 #[cfg(feature = "fetch-images")]
 fn fetch_remote(url: &str) -> Option<PictureImage> {
-    let mut resp = ureq::get(url).call().ok()?;
+    use std::time::Duration;
+    if blocked_by_ssrf_guard(url) {
+        return None;
+    }
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(5)))
+        .timeout_global(Some(Duration::from_secs(20)))
+        .max_redirects(3)
+        .build()
+        .into();
+    let mut resp = agent.get(url).call().ok()?;
     let content_type = resp
         .headers()
         .get("content-type")
@@ -244,18 +337,44 @@ mod tests {
         // A real file at an absolute path is read.
         let p = std::env::temp_dir().join(format!("docling.rs_img_{}.png", std::process::id()));
         std::fs::write(&p, RED_PNG).unwrap();
-        let r = FsImageResolver::new(None);
+        let r = FsImageResolver::new(None, None);
         let img = r.resolve(p.to_str().unwrap()).expect("reads local file");
         assert_eq!((img.width, img.height), (1, 1));
         let _ = std::fs::remove_file(&p);
         // A relative path with no known base dir is refused (never reads from CWD).
-        assert!(FsImageResolver::new(None)
+        assert!(FsImageResolver::new(None, None)
             .resolve("nope/relative.png")
             .is_none());
         // data: URIs still work regardless of base dir.
         assert!(r
             .resolve(&format!("data:image/png;base64,{}", encode(RED_PNG)))
             .is_some());
+    }
+
+    #[cfg(feature = "fetch-images")]
+    #[test]
+    fn resolves_relative_and_protocol_relative_against_base_url() {
+        // The URL join the fetch path relies on, without touching the network.
+        let r = FsImageResolver::new(None, Some("https://ex.com/a/page.html".into()));
+        assert_eq!(
+            r.absolute_http_url("/img/x.png").as_deref(),
+            Some("https://ex.com/img/x.png")
+        );
+        assert_eq!(
+            r.absolute_http_url("y.png").as_deref(),
+            Some("https://ex.com/a/y.png")
+        );
+        assert_eq!(
+            r.absolute_http_url("//cdn.ex.com/z.png").as_deref(),
+            Some("https://cdn.ex.com/z.png")
+        );
+        assert_eq!(
+            r.absolute_http_url("https://other.com/w.png").as_deref(),
+            Some("https://other.com/w.png")
+        );
+        // No base URL: a relative src has nothing to resolve against.
+        let no_base = FsImageResolver::new(None, None);
+        assert!(no_base.absolute_http_url("/img/x.png").is_none());
     }
 }
 

--- a/crates/docling/src/backend/images.rs
+++ b/crates/docling/src/backend/images.rs
@@ -17,6 +17,8 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+#[cfg(feature = "fetch-images")]
+use std::sync::Mutex;
 
 use docling_core::PictureImage;
 
@@ -28,6 +30,12 @@ const MAX_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
 /// (unfetchable, unreadable, or an unsupported encoding).
 pub(crate) trait ImageResolver {
     fn resolve(&self, src: &str) -> Option<PictureImage>;
+
+    /// Warm any slow (network) resolutions for `srcs` concurrently, before the
+    /// serial document walk resolves them one by one. The default does nothing
+    /// (resolvers whose lookups are all in-memory gain nothing from it); the
+    /// remote-fetching [`FsImageResolver`] overrides it to fetch in parallel.
+    fn prefetch(&self, _srcs: &[String]) {}
 }
 
 /// The default: never extracts an image (every `<img>` stays a placeholder).
@@ -47,6 +55,13 @@ impl ImageResolver for NoFetch {
 pub(crate) struct FsImageResolver {
     base_dir: Option<PathBuf>,
     base_url: Option<String>,
+    /// Memoized remote fetches, keyed by the resolved absolute URL: fills as
+    /// [`prefetch`](Self::prefetch) warms it (concurrently) and as `resolve`
+    /// hits it (serially), so each distinct URL is fetched at most once even
+    /// when several relative `<img src>` resolve to it. `None` caches a miss so
+    /// a failed URL isn't retried.
+    #[cfg(feature = "fetch-images")]
+    cache: Mutex<HashMap<String, Option<PictureImage>>>,
 }
 
 impl FsImageResolver {
@@ -54,7 +69,12 @@ impl FsImageResolver {
     /// `base_url` is the URL the page was fetched from (relative `<img src>`
     /// resolution). Either may be `None`.
     pub(crate) fn new(base_dir: Option<PathBuf>, base_url: Option<String>) -> Self {
-        Self { base_dir, base_url }
+        Self {
+            base_dir,
+            base_url,
+            #[cfg(feature = "fetch-images")]
+            cache: Mutex::new(HashMap::new()),
+        }
     }
 
     /// Resolve `src` to an absolute `http(s)` URL when possible: an already-
@@ -70,6 +90,37 @@ impl FsImageResolver {
         let joined = url::Url::parse(base).ok()?.join(src).ok()?;
         matches!(joined.scheme(), "http" | "https").then(|| joined.to_string())
     }
+
+    /// Fetch `url` unless a prior fetch already cached it, memoizing the result
+    /// (hit or miss). Shared by the serial `resolve` path and the concurrent
+    /// `prefetch` workers — the lock is held only around the map lookup/insert,
+    /// never across the network call.
+    #[cfg(feature = "fetch-images")]
+    fn fetch_cached(&self, url: &str) -> Option<PictureImage> {
+        if let Some(hit) = self.cache.lock().unwrap().get(url) {
+            return hit.clone();
+        }
+        let img = fetch_remote(url);
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(url.to_string(), img.clone());
+        img
+    }
+}
+
+/// How many remote images to fetch at once during [`FsImageResolver::prefetch`].
+/// Image fetching is I/O-bound (mostly waiting on the network), so the default
+/// runs well ahead of the core count; `DOCLING_RS_IMAGE_FETCH_CONCURRENCY`
+/// overrides it, clamped to a sane range.
+#[cfg(feature = "fetch-images")]
+fn image_fetch_concurrency() -> usize {
+    std::env::var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(10)
+        .clamp(1, 64)
 }
 
 impl ImageResolver for FsImageResolver {
@@ -86,7 +137,7 @@ impl ImageResolver for FsImageResolver {
         // path). Only compiled with the HTTP client available.
         #[cfg(feature = "fetch-images")]
         if let Some(url) = self.absolute_http_url(src) {
-            return fetch_remote(&url);
+            return self.fetch_cached(&url);
         }
         #[cfg(not(feature = "fetch-images"))]
         if src.starts_with("http://") || src.starts_with("https://") {
@@ -104,6 +155,47 @@ impl ImageResolver for FsImageResolver {
         };
         let data = std::fs::read(&full).ok()?;
         super::ooxml::picture_image(full.to_str().unwrap_or(rel), data)
+    }
+
+    /// Fetch every distinct remote image among `srcs` concurrently, warming the
+    /// cache so the subsequent serial walk resolves them without blocking. Local
+    /// files and `data:` URIs are skipped (their `resolve` is already cheap).
+    #[cfg(feature = "fetch-images")]
+    fn prefetch(&self, srcs: &[String]) {
+        // Unique absolute URLs we haven't fetched yet, preserving nothing about
+        // order (fetches are independent).
+        let urls: Vec<String> = {
+            let cache = self.cache.lock().unwrap();
+            let mut seen = std::collections::HashSet::new();
+            srcs.iter()
+                .filter_map(|s| self.absolute_http_url(s.trim()))
+                .filter(|u| !cache.contains_key(u) && seen.insert(u.clone()))
+                .collect()
+        };
+        if urls.len() < 2 {
+            // 0 → nothing to do; 1 → the serial `resolve` fetches it just as
+            // fast without spinning up a worker.
+            return;
+        }
+        // I/O-bound work-stealing: N worker threads pull URLs off a shared
+        // index and fetch (each `fetch_cached` inserts into the cache under a
+        // brief lock). No new dependency, and concurrency is bounded regardless
+        // of how many images the page carries.
+        let workers = image_fetch_concurrency().min(urls.len());
+        let next = std::sync::atomic::AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..workers {
+                scope.spawn(|| loop {
+                    let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    match urls.get(i) {
+                        Some(url) => {
+                            let _ = self.fetch_cached(url);
+                        }
+                        None => break,
+                    }
+                });
+            }
+        });
     }
 }
 
@@ -375,6 +467,86 @@ mod tests {
         // No base URL: a relative src has nothing to resolve against.
         let no_base = FsImageResolver::new(None, None);
         assert!(no_base.absolute_http_url("/img/x.png").is_none());
+    }
+
+    #[cfg(feature = "fetch-images")]
+    #[test]
+    fn concurrency_env_is_parsed_and_clamped() {
+        use super::image_fetch_concurrency;
+        std::env::set_var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY", "7");
+        assert_eq!(image_fetch_concurrency(), 7);
+        std::env::set_var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY", "0");
+        assert_eq!(image_fetch_concurrency(), 10, "0 → default, never zero");
+        std::env::set_var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY", "9999");
+        assert_eq!(image_fetch_concurrency(), 64, "clamped to the ceiling");
+        std::env::set_var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY", "junk");
+        assert_eq!(image_fetch_concurrency(), 10);
+        std::env::remove_var("DOCLING_RS_IMAGE_FETCH_CONCURRENCY");
+    }
+
+    /// prefetch fetches each distinct remote image exactly once (concurrently),
+    /// caches the bytes, and dedupes repeats — proven against a tiny in-process
+    /// HTTP server that counts the requests it serves.
+    #[cfg(feature = "fetch-images")]
+    #[test]
+    fn prefetch_fetches_each_url_once_and_warms_the_cache() {
+        use std::io::{Read, Write};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_hits = Arc::clone(&hits);
+        // Serve RED_PNG to every GET, counting requests. Detached: the loop
+        // outlives the test and the process reaps it on exit.
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf); // consume the request line/headers
+                server_hits.fetch_add(1, Ordering::Relaxed);
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    RED_PNG.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(RED_PNG);
+                let _ = stream.flush();
+            }
+        });
+
+        // 127.0.0.1 is on the SSRF block-list; opt in for the test.
+        std::env::set_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH", "1");
+        let base = format!("http://{addr}/dir/page.html");
+        let r = FsImageResolver::new(None, Some(base));
+
+        // Two distinct images, one repeated — three srcs, two fetches.
+        r.prefetch(&[
+            "img1.png".to_string(),
+            "img2.png".to_string(),
+            "img1.png".to_string(),
+        ]);
+        assert_eq!(
+            hits.load(Ordering::Relaxed),
+            2,
+            "each distinct URL fetched once"
+        );
+
+        // The walk now resolves from the warm cache — no further requests.
+        let img = r.resolve("img1.png").expect("cached image resolves");
+        assert_eq!((img.width, img.height), (1, 1));
+        assert_eq!(
+            r.resolve("/dir/img2.png").map(|i| (i.width, i.height)),
+            Some((1, 1))
+        );
+        assert_eq!(
+            hits.load(Ordering::Relaxed),
+            2,
+            "resolve served from cache, no refetch"
+        );
+
+        std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
     }
 }
 

--- a/crates/docling/src/backend/ooxml.rs
+++ b/crates/docling/src/backend/ooxml.rs
@@ -13,6 +13,16 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use zip::ZipArchive;
 
+/// Hard cap on a single decompressed OOXML part (512 MiB). Real documents
+/// stay far below this; the limit only exists to stop a decompression-bomb
+/// part from exhausting memory. Override with `DOCLING_RS_MAX_PART_BYTES`.
+fn max_part_bytes() -> u64 {
+    std::env::var("DOCLING_RS_MAX_PART_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(512 * 1024 * 1024)
+}
+
 /// A read-only view over the parts of an OOXML package.
 ///
 /// Cloning is cheap (the file bytes are shared behind an `Arc`, the ZIP
@@ -32,17 +42,35 @@ impl Package {
 
     /// Read a part to a string, or `None` if it is absent or not valid UTF-8.
     pub fn read(&mut self, path: &str) -> Option<String> {
-        let mut file = self.zip.by_name(path).ok()?;
-        let mut out = String::new();
-        file.read_to_string(&mut out).ok()?;
-        Some(out)
+        let bytes = self.read_bytes(path)?;
+        String::from_utf8(bytes).ok()
     }
 
     /// Read a part's raw bytes (e.g. an embedded image), or `None` if absent.
+    ///
+    /// A single part is never allowed to inflate past [`max_part_bytes`]: an
+    /// OOXML file is a ZIP, and a "zip bomb" part (a few KB deflating to many
+    /// GB) would otherwise exhaust memory and abort the process. Reads stop at
+    /// the cap and the oversized part is rejected (`None`) rather than
+    /// truncated, so a partial part never reaches an XML parser.
     pub fn read_bytes(&mut self, path: &str) -> Option<Vec<u8>> {
-        let mut file = self.zip.by_name(path).ok()?;
+        self.read_bytes_capped(path, max_part_bytes())
+    }
+
+    fn read_bytes_capped(&mut self, path: &str, cap: u64) -> Option<Vec<u8>> {
+        let file = self.zip.by_name(path).ok()?;
+        // Reject up front when the central directory already advertises an
+        // oversized part; still cap the actual read in case the header lies.
+        if file.size() > cap {
+            return None;
+        }
         let mut out = Vec::new();
-        file.read_to_end(&mut out).ok()?;
+        // read_to_end on a `.take(cap + 1)` reader: if it returns cap+1 bytes,
+        // the part exceeded the cap and is rejected rather than truncated.
+        file.take(cap + 1).read_to_end(&mut out).ok()?;
+        if out.len() as u64 > cap {
+            return None;
+        }
         Some(out)
     }
 
@@ -223,4 +251,43 @@ pub fn content_type(content_types_xml: &str, part: &str) -> Option<String> {
         buf.clear();
     }
     default
+}
+
+#[cfg(test)]
+mod zip_bomb_tests {
+    use super::Package;
+    use std::io::Write;
+
+    /// A minimal in-memory OOXML-style zip with one part of `part_len` bytes.
+    fn zip_with_part(name: &str, part_len: usize) -> Vec<u8> {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut buf);
+            let opts: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            zw.start_file(name, opts).unwrap();
+            zw.write_all(&vec![b'a'; part_len]).unwrap();
+            zw.finish().unwrap();
+        }
+        buf.into_inner()
+    }
+
+    #[test]
+    fn oversized_part_is_rejected_not_truncated() {
+        // A highly compressible 1 MiB part in a tiny zip (deflates to ~1 KB):
+        // the decompression-bomb shape. With the cap below its size, the read
+        // must return None rather than a truncated buffer.
+        let bytes = zip_with_part("word/document.xml", 1024 * 1024);
+        assert!(bytes.len() < 64 * 1024, "part should compress tiny");
+        let mut pkg = Package::open(&bytes).unwrap();
+        assert!(
+            pkg.read_bytes_capped("word/document.xml", 4096).is_none(),
+            "a part over the cap must be rejected"
+        );
+        // Under a generous cap it reads back in full.
+        let out = pkg
+            .read_bytes_capped("word/document.xml", 8 * 1024 * 1024)
+            .expect("part under the cap reads");
+        assert_eq!(out.len(), 1024 * 1024);
+    }
 }

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -324,6 +324,7 @@ impl DocumentConverter {
                 if self.fetch_images {
                     let resolver = crate::backend::FsImageResolver::new(
                         source.base_dir().map(|p| p.to_path_buf()),
+                        source.base_url.clone(),
                     );
                     crate::backend::convert_html(&source.name, &html, &resolver)
                 } else {

--- a/crates/docling/src/source.rs
+++ b/crates/docling/src/source.rs
@@ -19,6 +19,11 @@ pub struct SourceDocument {
     /// resolve relative `<img src>` paths when image fetching is enabled; `None`
     /// for in-memory sources.
     pub path: Option<PathBuf>,
+    /// The URL this document was fetched from, if any. Used to resolve
+    /// relative / protocol-relative `<img src>` against the page's origin when
+    /// image fetching is enabled (an HTML page fetched from the web references
+    /// its images by relative path). `None` for local / in-memory sources.
+    pub base_url: Option<String>,
 }
 
 impl SourceDocument {
@@ -46,6 +51,7 @@ impl SourceDocument {
             format,
             bytes,
             path: Some(path.to_path_buf()),
+            base_url: None,
         })
     }
 
@@ -56,7 +62,15 @@ impl SourceDocument {
             format,
             bytes,
             path: None,
+            base_url: None,
         }
+    }
+
+    /// Record the URL this document was fetched from (for resolving relative
+    /// `<img src>` against the page origin when image fetching is enabled).
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
     }
 
     /// The directory containing the source file, for resolving relative asset

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,81 @@
+# Security notes
+
+docling.rs converts **untrusted documents** (PDF, DOCX, XLSX, PPTX, HTML,
+EPUB, images, audio, …). The parsers are the primary attack surface: a
+document is adversarial input, and a converter must fail gracefully rather
+than crash the process or reach out to the network unexpectedly. This note
+records the hardening in place, how to deploy the servers safely, and the
+known residual items.
+
+## Threat model
+
+- **In scope:** a crafted document must not cause remote code execution,
+  out-of-process crashes (uncatchable aborts — allocation failure, stack
+  overflow), unbounded memory/CPU (DoS), server-side request forgery (SSRF),
+  local-file disclosure, or path traversal.
+- **Out of scope / operational:** an attacker who can already write to the
+  process working directory or set its environment (they can plant a
+  malicious `models/*.onnx` or `.pdfium/lib` that the loader would pick up —
+  run with a fixed, non-writable CWD and absolute `DOCLING_*` model paths).
+  The `web-browser` feature runs system Chromium **unsandboxed** on the input
+  HTML and is off by default; enable it only for content you accept that risk
+  for.
+
+## Hardening in place
+
+Resource limits that turn a crafted document from a process abort into a
+recoverable error (all overridable by env var for the rare legitimate
+outlier):
+
+| Surface | Guard | Override |
+|---------|-------|----------|
+| Standalone image decode (`convert_image`, METS) | ONNX-free decode with `image::Limits` — 256 MiB alloc / 30000-px per side. A few-KB image declaring 60000×60000 no longer allocates ~10 GB. | `DOCLING_RS_MAX_IMAGE_PIXELS` |
+| OOXML/ZIP part inflation (DOCX/PPTX/XLSX/EPUB) | Per-part decompression capped (512 MiB); an oversized "zip bomb" part is rejected, not truncated. | `DOCLING_RS_MAX_PART_BYTES` |
+| HTML/EPUB DOM walk | Nesting-depth ceiling (2000), checked iteratively; a document with tens of thousands of nested tags falls back to flattened text instead of overflowing the recursion stack. | `DOCLING_RS_MAX_HTML_DEPTH` |
+| Audio sample rate (ASR) | Header-declared rate clamped to 8 kHz–768 kHz, so the resampler can't be steered into an OOM-sized upsample. | — |
+| TableFormer matching | `median()` guards the empty slice (a crafted table row/column with zero matched cells no longer panics). | — |
+
+XML safety (verified, no change needed): the DOM parser (`roxmltree`) never
+resolves external entities (no XXE) and caps entity-reference depth/count (no
+"billion laughs"); OOXML parts are read **into memory by name**, never
+extracted to disk, so there is no zip-slip path.
+
+### `docling-serve` (HTTP conversion API)
+
+- **URL fetch is off by default** (`--allow-url-fetch` to enable). When
+  enabled, the target host is resolved and refused if it maps to a
+  loopback / private / link-local / unique-local / CGNAT address (blocks
+  `169.254.169.254` cloud metadata and internal services); HTTP redirects
+  are disabled (no public→internal bounce); and the fetched response is size-
+  capped (256 MiB).
+- A crafted PDF/image that panics inside the pipeline no longer **poisons**
+  the shared mutex — the lock recovers, so one bad document can't turn into a
+  permanent outage of the endpoint.
+- **No authentication.** Bind to loopback (the default) or place an
+  authenticating/policy proxy in front before exposing it.
+
+### `docling-rag` (retrieval API)
+
+Fail-closed API-key auth (`X-Api-Key` / `Bearer` / `?api_key=` for browser
+links); all vector-store SQL is parameterized (no injection); uploaded
+filenames are reduced to a single path segment and the markdown-dump path
+keeps only `Normal` components (no traversal); served markdown is
+`text/markdown` (not rendered HTML) and the UI escapes all interpolated
+fields.
+
+## Known residual
+
+- **`quick-xml` DoS advisories (RUSTSEC-2026-0194 / -0195) via `calamine`.**
+  Our direct XML parsing is on `quick-xml` ≥ 0.41 (patched). The XLSX reader
+  `calamine` still pins `quick-xml` 0.31 transitively; until `calamine`
+  upstream bumps, a crafted **XLSX** can still trigger the quadratic-attribute
+  / namespace-allocation DoS. Impact is bounded by the process/deployment
+  (single-document DoS, not RCE); mitigate by not exposing XLSX conversion to
+  untrusted callers without a per-request resource bound, or run conversions
+  in a resource-limited sandbox.
+
+## Running the audit
+
+```sh
+cargo audit         # known-CVE scan of the dependency tree
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -53,12 +53,16 @@ extracted to disk, so there is no zip-slip path.
 - A crafted PDF/image that panics inside the pipeline no longer **poisons**
   the shared mutex — the lock recovers, so one bad document can't turn into a
   permanent outage of the endpoint.
-- **`fetch_images` (`<img src>` resolution for HTML/EPUB)** carries the same
-  SSRF guard: a remote image whose host resolves to a private/loopback/
+- **`fetch_images` (`<img src>` resolution for HTML/EPUB)** is outbound fetch,
+  so it lives behind the **same `--allow-url-fetch` gate** as URL inputs: with
+  the flag off (the default) the option is ignored server-side (pictures stay
+  placeholders) and the web UI greys the checkbox. When enabled it carries the
+  same SSRF guard — a remote image whose host resolves to a private/loopback/
   link-local address is skipped, and each fetch has a connect/overall timeout
   (5 s / 20 s) plus a redirect cap, so one slow or hostile image can't hang the
   conversion (and thus the server). `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` opts
-  out for local/intranet image servers, same as the URL fetch above.
+  out of the IP block-list for local/intranet image servers, same as the URL
+  fetch above.
 - **No authentication.** Bind to loopback (the default) or place an
   authenticating/policy proxy in front before exposing it.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -53,6 +53,12 @@ extracted to disk, so there is no zip-slip path.
 - A crafted PDF/image that panics inside the pipeline no longer **poisons**
   the shared mutex — the lock recovers, so one bad document can't turn into a
   permanent outage of the endpoint.
+- **`fetch_images` (`<img src>` resolution for HTML/EPUB)** carries the same
+  SSRF guard: a remote image whose host resolves to a private/loopback/
+  link-local address is skipped, and each fetch has a connect/overall timeout
+  (5 s / 20 s) plus a redirect cap, so one slow or hostile image can't hang the
+  conversion (and thus the server). `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` opts
+  out for local/intranet image servers, same as the URL fetch above.
 - **No authentication.** Bind to loopback (the default) or place an
   authenticating/policy proxy in front before exposing it.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -47,7 +47,9 @@ extracted to disk, so there is no zip-slip path.
   loopback / private / link-local / unique-local / CGNAT address (blocks
   `169.254.169.254` cloud metadata and internal services); HTTP redirects
   are disabled (no public→internal bounce); and the fetched response is size-
-  capped (256 MiB).
+  capped (256 MiB, `DOCLING_RS_MAX_FETCH_BYTES`). For local development,
+  `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` disables the IP block-list so a
+  `localhost` target can be fetched — leave it unset in production.
 - A crafted PDF/image that panics inside the pipeline no longer **poisons**
   the shared mutex — the lock recovers, so one bad document can't turn into a
   permanent outage of the endpoint.


### PR DESCRIPTION
A defensive-security pass over the untrusted-document attack surface. No RCE or XXE was found; the real risks were denial-of-service via process-aborting allocations/recursion, an SSRF surface, and dependency CVEs. Fixes, each overridable by env var for legitimate outliers:

Dependency CVEs:
- lopdf 0.34 -> 0.44 (RUSTSEC: stack overflow on deeply nested PDF objects — a crafted PDF aborted the process). API: get_page_content now returns Vec<u8> directly.
- quick-xml 0.37 -> 0.41 (RUSTSEC-2026-0194/0195: quadratic attribute check + unbounded namespace allocation on crafted XML). Our direct parsing is now patched; the XLSX reader `calamine` still pins 0.31 transitively (documented in docs/SECURITY.md).

Process-abort / DoS guards (crafted document -> recoverable error, not an uncatchable abort):
- Image decode (convert_image, METS): decode with image::Limits (256 MiB alloc / 30000 px) so a tiny image declaring huge dimensions can't OOM the process. DOCLING_RS_MAX_IMAGE_PIXELS.
- OOXML/ZIP parts: cap per-part decompression (512 MiB) — a zip-bomb part is rejected, not truncated. DOCLING_RS_MAX_PART_BYTES.
- HTML/EPUB DOM walk: iterative depth ceiling (2000); deeply nested markup falls back to flattened text instead of overflowing the stack. DOCLING_RS_MAX_HTML_DEPTH.
- ASR sample rate clamped to 8k-768k Hz (resampler OOM amplification).
- TableFormer median() guards the empty slice (crafted table panic).

docling-serve:
- URL fetch is now OFF by default (--allow-url-fetch to enable). When enabled: SSRF guard rejects targets resolving to private/loopback/ link-local/ULA/CGNAT addresses (blocks 169.254.169.254), redirects disabled, response size capped (256 MiB).
- Recover from a poisoned pipeline mutex so one panicking document can't permanently brick the PDF/image endpoint.

Adds docs/SECURITY.md (threat model, hardening table, deployment guidance, the residual calamine/quick-xml item) and unit tests for each new guard (image cap, OOXML cap, HTML depth fallback, median empty, SSRF IP block-list, url-fetch-off-by-default).



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT