### PR TITLE
ASR: English-only and Distil-Whisper model presets (upstream #3741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ instead — same models plus `pdfium.dll` — and see
 | PP-OCRv3 rec + dictionary | `models/ocr_rec.onnx`, `models/ppocr_keys_v1.txt` |
 | TableFormer (optional) | `models/tableformer/{encoder,decoder,bbox}.onnx` (+ `.data` sidecars where the export needs them) |
 | Whisper tiny (audio/ASR; skip with `--no-asr`) | `models/asr/{encoder_model,decoder_model}.onnx`, `models/asr/vocab.json` (+ `added_tokens.json` for language selection) |
+| Whisper presets (optional; `--asr-model=<preset>`, repeatable) | `models/asr/<preset>/…` — English-only (`whisper_tiny_en`, `whisper_base_en`, `whisper_small_en`) and Distil-Whisper (`whisper_distil_small_en`) exports, fetched from Hugging Face |
 | INT8 CPU models (fetched by default; skip with `--no-int8`) | `models/layout_heron_int8.onnx`, `models/tableformer/decoder_int8.onnx` (+ `models/code_formula/decoder_kv_int8.onnx` with `--enrich`) |
 | DocumentFigureClassifier (picture classification) | `models/picture_classifier.onnx` |
 | CodeFormulaV2 (code/formula enrichment, ~1.3 GB; fetch with `--enrich`) | `models/code_formula/{vision,embed,decoder_kv}.onnx`, `models/code_formula/tokenizer.json` |
@@ -480,6 +481,35 @@ come from Hugging Face (`$DOCLING_RS_ASR_MODELS_URL` overrides, or point
 `DOCLING_ASR_{ENCODER,DECODER,VOCAB}` at explicit files). pdfium is Linux x64
 only for now — other platforms, or building the models from source, need
 [`scripts/install/pdf_setup.sh`](#testing) instead.
+
+#### Whisper models for audio/ASR
+
+The default run already fetches **Whisper tiny** (multilingual) into
+`models/asr/` — nothing extra is needed for audio inputs:
+
+```bash
+scripts/install/download_dependencies.sh          # includes Whisper tiny
+scripts/install/download_dependencies.sh --no-asr # …or skip the ~150 MB ASR models
+```
+
+Named **model presets** (docling's English-only / Distil-Whisper ASR specs,
+the variants with public ONNX exports) are fetched on top with a repeatable
+`--asr-model=` flag, each into its own `models/asr/<preset>/` directory:
+
+```bash
+scripts/install/download_dependencies.sh --asr-model=whisper_tiny_en
+scripts/install/download_dependencies.sh --asr-model=whisper_base_en --asr-model=whisper_distil_small_en
+```
+
+Available presets: `whisper_tiny_en`, `whisper_base_en`, `whisper_small_en`,
+`whisper_distil_small_en`. Select one at run time with the CLI's
+`--asr-model <preset>`, `DocumentConverter::asr_model(...)` in Rust, the
+`asr_model` option in docling-serve requests, or `asrModel` / `asr_model` in
+the Node/Python bindings:
+
+```bash
+docling-rs --asr-model whisper_tiny_en recording.mp3
+```
 
 ### Enrichment models (picture classification, code, formulas)
 
@@ -742,6 +772,8 @@ cargo run -p docling-cli -- document.pdf
 # transcribe audio (wav/mp3/flac/ogg/aac/m4a, or an mp4/mov audio track) — the
 # Whisper models come from the same download script
 cargo run -p docling-cli -- recording.mp3
+# …with a named preset (fetch it first: download_dependencies.sh --asr-model=whisper_tiny_en)
+cargo run -p docling-cli -- --asr-model whisper_tiny_en recording.mp3
 
 # extract pictures (PDF/image inputs): embed as data URIs, or write ./artifacts/*.png
 cargo run -p docling-cli -- --images embedded   document.pdf

--- a/crates/docling-asr/examples/preset_check.rs
+++ b/crates/docling-asr/examples/preset_check.rs
@@ -1,0 +1,9 @@
+//! Quick preset comparison: default vs a named preset on one audio file.
+fn main() {
+    let path = std::env::args().nth(1).expect("audio path");
+    let preset = std::env::args().nth(2);
+    let bytes = std::fs::read(&path).unwrap();
+    let doc =
+        docling_asr::convert_audio_with_model(&bytes, &path, preset.as_deref()).expect("converts");
+    println!("{}", doc.export_to_markdown());
+}

--- a/crates/docling-asr/src/lib.rs
+++ b/crates/docling-asr/src/lib.rs
@@ -27,7 +27,7 @@ use std::fmt;
 
 use docling_core::{DoclingDocument, Node};
 
-pub use whisper::{models_available, Segment, Transcriber};
+pub use whisper::{models_available, models_available_for, Segment, Transcriber, PRESETS};
 
 /// Errors from the ASR backend. Detailed and surfaced (never silently skipped).
 #[derive(Debug)]
@@ -48,16 +48,35 @@ impl std::error::Error for AsrError {}
 /// [`Transcriber`] directly to batch many files. Fails with a clear message
 /// when the model files are absent.
 pub fn convert_audio(bytes: &[u8], name: &str) -> Result<DoclingDocument, AsrError> {
-    if !models_available() {
-        return Err(AsrError(
-            "asr: Whisper model files not found under models/asr/ \
-             (run scripts/install/download_dependencies.sh, or set \
-             DOCLING_ASR_{ENCODER,DECODER,VOCAB})"
-                .into(),
-        ));
+    convert_audio_with_model(bytes, name, None)
+}
+
+/// [`convert_audio`] with a named Whisper model preset (see [`PRESETS`]):
+/// English-only and Distil-Whisper variants, each under its own
+/// `models/asr/<preset>/` directory (docling PR #3741's presets, limited to
+/// the variants with public ONNX exports).
+pub fn convert_audio_with_model(
+    bytes: &[u8],
+    name: &str,
+    model: Option<&str>,
+) -> Result<DoclingDocument, AsrError> {
+    if !models_available_for(model) {
+        let dir = match model {
+            None | Some("whisper_tiny") | Some("") => "models/asr/".to_string(),
+            Some(p) => format!("models/asr/{p}/"),
+        };
+        return Err(AsrError(format!(
+            "asr: Whisper model files not found under {dir} \
+             (run scripts/install/download_dependencies.sh{}, or set \
+             DOCLING_ASR_{{ENCODER,DECODER,VOCAB}})",
+            model
+                .filter(|m| !m.is_empty() && *m != "whisper_tiny")
+                .map(|m| format!(" --asr-model {m}"))
+                .unwrap_or_default()
+        )));
     }
     let samples = audio::decode_to_mono_16k(bytes, name).map_err(AsrError)?;
-    let mut transcriber = Transcriber::load().map_err(AsrError)?;
+    let mut transcriber = Transcriber::load_preset(model).map_err(AsrError)?;
     let segments = transcriber.transcribe(&samples).map_err(AsrError)?;
 
     let mut doc = DoclingDocument::new(name);

--- a/crates/docling-asr/src/whisper.rs
+++ b/crates/docling-asr/src/whisper.rs
@@ -14,13 +14,96 @@ use ort::value::{Tensor, TensorRef};
 use crate::mel::{log_mel_spectrogram, N_FRAMES, N_SAMPLES};
 use crate::tokenizer::Tokenizer;
 
-// Multilingual Whisper special tokens (vocab 51865).
+// Multilingual Whisper special tokens (vocab 51865) — the fallback when the
+// vocabulary can't be resolved. English-only exports shift every id down by
+// one (no language tokens), so the real ids come from the vocab at load time.
 const EOT: u32 = 50_257;
 const SOT: u32 = 50_258;
 const LANG_EN: u32 = 50_259;
 const TRANSCRIBE: u32 = 50_359;
 const NO_SPEECH: u32 = 50_362;
 const TS_BEGIN: u32 = 50_364;
+
+/// The model presets the loader accepts (docling PR #3741's English-only and
+/// Distil-Whisper additions, limited to the variants with public ONNX
+/// exports). Each maps to a `models/asr/<preset>/` directory; the unnamed
+/// default (Whisper tiny multilingual) stays at `models/asr/` itself.
+pub const PRESETS: &[&str] = &[
+    "whisper_tiny",
+    "whisper_tiny_en",
+    "whisper_base_en",
+    "whisper_small_en",
+    "whisper_distil_small_en",
+];
+
+/// The special-token ids of the loaded model, resolved from its vocabulary —
+/// English-only exports have no language tokens and every id past
+/// `<|endoftext|>` sits one lower than the multilingual layout.
+#[derive(Clone, Copy)]
+pub(crate) struct Specials {
+    pub eot: u32,
+    pub sot: u32,
+    /// `None` for English-only models (their prompt is just `<|startoftranscript|>`).
+    pub lang: Option<u32>,
+    pub transcribe: Option<u32>,
+    pub no_speech: u32,
+    pub ts_begin: u32,
+}
+
+impl Specials {
+    fn multilingual_default() -> Self {
+        Self {
+            eot: EOT,
+            sot: SOT,
+            lang: Some(language_token("models/asr/added_tokens.json")),
+            transcribe: Some(TRANSCRIBE),
+            no_speech: NO_SPEECH,
+            ts_begin: TS_BEGIN,
+        }
+    }
+
+    /// Resolve from the merged vocab + added-tokens map. Falls back to the
+    /// multilingual constants when the anchor tokens are missing.
+    ///
+    /// `english_only` comes from the preset name (`*_en`), not the vocabulary:
+    /// modern HF exports ship the full unified token set even for
+    /// English-only weights, so the presence of `<|en|>` proves nothing —
+    /// but prompting an English-only model with language/task tokens it was
+    /// never trained on yields empty transcripts. English-only models prompt
+    /// with `<|startoftranscript|>` alone (OpenAI's `sot_sequence`).
+    fn resolve(
+        map: &std::collections::HashMap<String, u32>,
+        added_tokens: &str,
+        english_only: bool,
+    ) -> Self {
+        let get = |name: &str| map.get(name).copied();
+        let (Some(eot), Some(sot), Some(ts_begin)) = (
+            get("<|endoftext|>"),
+            get("<|startoftranscript|>"),
+            get("<|0.00|>"),
+        ) else {
+            return Self::multilingual_default();
+        };
+        let (lang, transcribe) = if english_only {
+            (None, None)
+        } else {
+            (
+                get("<|en|>").map(|_| language_token(added_tokens)),
+                get("<|transcribe|>"),
+            )
+        };
+        Self {
+            eot,
+            sot,
+            lang,
+            transcribe,
+            no_speech: get("<|nospeech|>")
+                .or_else(|| get("<|nocaptions|>"))
+                .unwrap_or(ts_begin - 2),
+            ts_begin,
+        }
+    }
+}
 /// Space token (`Ġ`), suppressed as the first sampled token (`suppress_blank`).
 const SPACE: u32 = 220;
 /// Max new tokens per window (docling's `max_new_tokens=256` capped by
@@ -44,7 +127,7 @@ pub struct Transcriber {
     encoder: Session,
     decoder: Session,
     tokenizer: Tokenizer,
-    lang_token: u32,
+    specials: Specials,
     /// OpenAI's default `suppress_tokens="-1"` non-speech symbol set.
     suppress: Vec<u32>,
 }
@@ -73,12 +156,28 @@ fn model_path(var: &str, default: &str) -> std::path::PathBuf {
     default.to_string().into()
 }
 
+/// The model directory for a preset: the unnamed default lives at
+/// `models/asr/`, a named preset in its own `models/asr/<preset>/`
+/// subdirectory (matching `download_dependencies.sh --asr-model`).
+fn preset_dir(preset: Option<&str>) -> String {
+    match preset {
+        None | Some("whisper_tiny") | Some("") => "models/asr".to_string(),
+        Some(p) => format!("models/asr/{p}"),
+    }
+}
+
 /// Whether the Whisper model files are present (so callers can fail with a
 /// clear "models missing" message instead of an opaque load error).
 pub fn models_available() -> bool {
-    model_path("DOCLING_ASR_ENCODER", "models/asr/encoder_model.onnx").exists()
-        && model_path("DOCLING_ASR_DECODER", "models/asr/decoder_model.onnx").exists()
-        && model_path("DOCLING_ASR_VOCAB", "models/asr/vocab.json").exists()
+    models_available_for(None)
+}
+
+/// [`models_available`] for a specific preset directory.
+pub fn models_available_for(preset: Option<&str>) -> bool {
+    let dir = preset_dir(preset);
+    model_path("DOCLING_ASR_ENCODER", &format!("{dir}/encoder_model.onnx")).exists()
+        && model_path("DOCLING_ASR_DECODER", &format!("{dir}/decoder_model.onnx")).exists()
+        && model_path("DOCLING_ASR_VOCAB", &format!("{dir}/vocab.json")).exists()
 }
 
 impl Transcriber {
@@ -86,6 +185,24 @@ impl Transcriber {
     /// `DOCLING_ASR_{ENCODER,DECODER,VOCAB}`, defaulting to `models/asr/…`
     /// relative to the working directory (mirroring the PDF models).
     pub fn load() -> Result<Self, String> {
+        Self::load_preset(None)
+    }
+
+    /// [`load`](Self::load) for a named model preset (see [`PRESETS`]):
+    /// English-only and Distil-Whisper variants live in their own
+    /// `models/asr/<preset>/` directories, and their special-token ids are
+    /// resolved from the vocabulary (English-only exports carry no language
+    /// tokens and shift the id layout).
+    pub fn load_preset(preset: Option<&str>) -> Result<Self, String> {
+        if let Some(p) = preset {
+            if !p.is_empty() && !PRESETS.contains(&p) {
+                return Err(format!(
+                    "asr: unknown model preset '{p}' (available: {})",
+                    PRESETS.join(", ")
+                ));
+            }
+        }
+        let dir = preset_dir(preset);
         let session = |path: std::path::PathBuf| -> Result<Session, String> {
             Session::builder()
                 .map_err(|e| format!("asr: builder: {e}"))?
@@ -100,19 +217,38 @@ impl Transcriber {
         };
         let encoder = session(model_path(
             "DOCLING_ASR_ENCODER",
-            "models/asr/encoder_model.onnx",
+            &format!("{dir}/encoder_model.onnx"),
         ))?;
         let decoder = session(model_path(
             "DOCLING_ASR_DECODER",
-            "models/asr/decoder_model.onnx",
+            &format!("{dir}/decoder_model.onnx"),
         ))?;
-        let tokenizer = Tokenizer::load(&model_path("DOCLING_ASR_VOCAB", "models/asr/vocab.json"))?;
+        let vocab_path = model_path("DOCLING_ASR_VOCAB", &format!("{dir}/vocab.json"));
+        let tokenizer = Tokenizer::load(&vocab_path)?;
+        // Specials resolve from vocab.json merged with added_tokens.json
+        // (Whisper keeps the special tokens in the latter).
+        let added_path = format!("{dir}/added_tokens.json");
+        let mut merged: std::collections::HashMap<String, u32> =
+            std::fs::read_to_string(&vocab_path)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok())
+                .unwrap_or_default();
+        if let Ok(raw) =
+            std::fs::read_to_string(model_path("DOCLING_ASR_ADDED_TOKENS", &added_path))
+        {
+            if let Ok(extra) = serde_json::from_str::<std::collections::HashMap<String, u32>>(&raw)
+            {
+                merged.extend(extra);
+            }
+        }
+        let english_only = preset.is_some_and(|p| p.ends_with("_en"));
+        let specials = Specials::resolve(&merged, &added_path, english_only);
         let suppress = tokenizer.non_speech_tokens();
         Ok(Self {
             encoder,
             decoder,
             tokenizer,
-            lang_token: language_token(),
+            specials,
             suppress,
         })
     }
@@ -164,12 +300,14 @@ impl Transcriber {
         segment_duration: f64,
         segments: &mut Vec<Segment>,
     ) -> usize {
-        let is_ts = |t: u32| t >= TS_BEGIN;
-        let ts_sec = |t: u32| (t - TS_BEGIN) as f64 * TIME_PRECISION;
+        let ts_begin = self.specials.ts_begin;
+        let eot = self.specials.eot;
+        let is_ts = |t: u32| t >= ts_begin;
+        let ts_sec = |t: u32| (t - ts_begin) as f64 * TIME_PRECISION;
         let push = |segments: &mut Vec<Segment>, start: f64, end: f64, ids: &[u32]| {
             let text = self
                 .tokenizer
-                .decode(&ids.iter().cloned().filter(|&t| t < EOT).collect::<Vec<_>>());
+                .decode(&ids.iter().cloned().filter(|&t| t < eot).collect::<Vec<_>>());
             let text = text.trim();
             if !text.is_empty() {
                 segments.push(Segment {
@@ -214,7 +352,7 @@ impl Transcriber {
             // lone timestamp still bounds its duration.
             let ts_tokens: Vec<u32> = tokens.iter().cloned().filter(|&t| is_ts(t)).collect();
             let duration = match ts_tokens.last() {
-                Some(&t) if t > TS_BEGIN => ts_sec(t),
+                Some(&t) if t > ts_begin => ts_sec(t),
                 _ => segment_duration,
             };
             push(segments, time_offset, time_offset + duration, tokens);
@@ -237,7 +375,13 @@ impl Transcriber {
 
     /// Greedy decode of one 30-second window with OpenAI's timestamp rules.
     fn decode_window(&mut self, hidden: &(Vec<f32>, Vec<usize>)) -> Result<WindowOutput, String> {
-        let mut tokens: Vec<u32> = vec![SOT, self.lang_token, TRANSCRIBE];
+        // Multilingual prompt: <|sot|><|lang|><|transcribe|>. English-only
+        // exports have neither token — their prompt is just <|sot|>.
+        let mut tokens: Vec<u32> = vec![self.specials.sot];
+        if let (Some(lang), Some(task)) = (self.specials.lang, self.specials.transcribe) {
+            tokens.push(lang);
+            tokens.push(task);
+        }
         let prompt_len = tokens.len();
         let mut sampled: Vec<u32> = Vec::new();
         let mut sum_logprob = 0f64;
@@ -249,15 +393,15 @@ impl Transcriber {
             if step == 0 {
                 // p(no-speech) is read at the <|startoftranscript|> position.
                 let sot_row = &logits[..vocab];
-                no_speech_prob = softmax_prob(sot_row, NO_SPEECH as usize);
+                no_speech_prob = softmax_prob(sot_row, self.specials.no_speech as usize);
             }
             let mut row: Vec<f32> = logits[(tokens.len() - 1) * vocab..].to_vec();
-            apply_rules(&mut row, &sampled, step, &self.suppress);
+            apply_rules(&mut row, &sampled, step, &self.suppress, self.specials);
 
             // Greedy sample from the masked distribution; accumulate log-prob.
             let (next, logprob) = argmax_logprob(&row);
             sum_logprob += logprob;
-            if next == EOT {
+            if next == self.specials.eot {
                 break;
             }
             sampled.push(next);
@@ -316,14 +460,15 @@ fn window_mel(mel: &[f32], total_frames: usize, seek: usize) -> Vec<f32> {
 /// order: special-token + non-speech-symbol suppression, `suppress_blank`, the
 /// timestamp pairing/monotonicity rules, and the timestamp-probability-mass
 /// rule.
-fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32]) {
+fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32], sp: Specials) {
     let neg_inf = f32::NEG_INFINITY;
+    let (eot, ts_begin) = (sp.eot, sp.ts_begin);
     // Suppress every special token between EOT and the timestamps (SOT, task,
     // language, no-speech, no-timestamps, …) — none is ever valid output here.
     for v in row
         .iter_mut()
-        .take(TS_BEGIN as usize)
-        .skip(EOT as usize + 1)
+        .take(ts_begin as usize)
+        .skip(eot as usize + 1)
     {
         *v = neg_inf;
     }
@@ -336,21 +481,21 @@ fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32]) 
     if step == 0 {
         // suppress_blank: never start with a space or immediate end.
         row[SPACE as usize] = neg_inf;
-        row[EOT as usize] = neg_inf;
+        row[eot as usize] = neg_inf;
         // The first token must be a timestamp, capped at max_initial_timestamp.
-        for v in row.iter_mut().take(TS_BEGIN as usize) {
+        for v in row.iter_mut().take(ts_begin as usize) {
             *v = neg_inf;
         }
         for v in row
             .iter_mut()
-            .skip((TS_BEGIN + MAX_INITIAL_TS) as usize + 1)
+            .skip((ts_begin + MAX_INITIAL_TS) as usize + 1)
         {
             *v = neg_inf;
         }
         return;
     }
 
-    let is_ts = |t: u32| t >= TS_BEGIN;
+    let is_ts = |t: u32| t >= ts_begin;
     let last_was_ts = sampled.last().is_some_and(|&t| is_ts(t));
     let penultimate_was_ts = match sampled.len() {
         0 | 1 => true,
@@ -359,12 +504,12 @@ fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32]) 
     if last_was_ts {
         if penultimate_was_ts {
             // A completed pair: the next token has to be text (or EOT).
-            for v in row.iter_mut().skip(TS_BEGIN as usize) {
+            for v in row.iter_mut().skip(ts_begin as usize) {
                 *v = neg_inf;
             }
         } else {
             // An opening timestamp: only its closing timestamp (or EOT) may follow.
-            for v in row.iter_mut().take(EOT as usize) {
+            for v in row.iter_mut().take(eot as usize) {
                 *v = neg_inf;
             }
         }
@@ -376,7 +521,7 @@ fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32]) 
         } else {
             last_ts + 1
         };
-        for v in row.iter_mut().take(floor as usize).skip(TS_BEGIN as usize) {
+        for v in row.iter_mut().take(floor as usize).skip(ts_begin as usize) {
             *v = neg_inf;
         }
     }
@@ -384,13 +529,13 @@ fn apply_rules(row: &mut [f32], sampled: &[u32], step: usize, suppress: &[u32]) 
     // If the total probability mass on timestamps exceeds any single text
     // token, a timestamp must be sampled.
     let logprobs = log_softmax(row);
-    let ts_mass = logsumexp(&logprobs[TS_BEGIN as usize..]);
-    let max_text = logprobs[..TS_BEGIN as usize]
+    let ts_mass = logsumexp(&logprobs[ts_begin as usize..]);
+    let max_text = logprobs[..ts_begin as usize]
         .iter()
         .cloned()
         .fold(f64::NEG_INFINITY, f64::max);
     if ts_mass > max_text {
-        for v in row.iter_mut().take(TS_BEGIN as usize) {
+        for v in row.iter_mut().take(ts_begin as usize) {
             *v = neg_inf;
         }
     }
@@ -444,12 +589,12 @@ fn round2(v: f64) -> f64 {
 /// The `<|lang|>` prompt token. `DOCLING_RS_ASR_LANG` selects the language
 /// (default `en`); codes are resolved through `added_tokens.json` next to the
 /// vocabulary when present, so any Whisper language works without a table here.
-fn language_token() -> u32 {
+fn language_token(added_tokens_default: &str) -> u32 {
     let lang = std::env::var("DOCLING_RS_ASR_LANG").unwrap_or_else(|_| "en".into());
     if lang == "en" {
         return LANG_EN;
     }
-    let path = model_path("DOCLING_ASR_ADDED_TOKENS", "models/asr/added_tokens.json");
+    let path = model_path("DOCLING_ASR_ADDED_TOKENS", added_tokens_default);
     if let Ok(raw) = std::fs::read_to_string(&path) {
         if let Ok(map) = serde_json::from_str::<std::collections::HashMap<String, u32>>(&raw) {
             if let Some(&id) = map.get(&format!("<|{lang}|>")) {
@@ -467,9 +612,17 @@ mod tests {
     #[test]
     fn timestamp_rules_force_initial_timestamp_and_pairing() {
         let v = 51_865usize;
+        let sp = Specials {
+            eot: EOT,
+            sot: SOT,
+            lang: Some(LANG_EN),
+            transcribe: Some(TRANSCRIBE),
+            no_speech: NO_SPEECH,
+            ts_begin: TS_BEGIN,
+        };
         // Step 0: only timestamps within the first second survive.
         let mut row = vec![0f32; v];
-        apply_rules(&mut row, &[], 0, &[]);
+        apply_rules(&mut row, &[], 0, &[], sp);
         assert!(row[..TS_BEGIN as usize]
             .iter()
             .all(|&x| x == f32::NEG_INFINITY));
@@ -488,6 +641,7 @@ mod tests {
             &[TS_BEGIN, 1000, TS_BEGIN + 10, TS_BEGIN + 10],
             4,
             &[],
+            sp,
         );
         assert!(row[TS_BEGIN as usize..]
             .iter()
@@ -498,16 +652,74 @@ mod tests {
     #[test]
     fn lone_opening_timestamp_only_allows_closing_timestamp() {
         let v = 51_865usize;
+        let sp = Specials {
+            eot: EOT,
+            sot: SOT,
+            lang: Some(LANG_EN),
+            transcribe: Some(TRANSCRIBE),
+            no_speech: NO_SPEECH,
+            ts_begin: TS_BEGIN,
+        };
         let mut row = vec![0f32; v];
         // "<|5.00|> hello" then an opening ts <|7.00|>: text is masked, earlier
         // timestamps are masked (monotonicity), the closing timestamp — allowed
         // to repeat the opening one — survives. (On this uniform row the
         // timestamp-probability-mass rule also masks EOT, exactly as OpenAI's
         // `logits[:timestamp_begin] = -inf` does.)
-        apply_rules(&mut row, &[TS_BEGIN + 250, 1000, TS_BEGIN + 350], 3, &[]);
+        apply_rules(
+            &mut row,
+            &[TS_BEGIN + 250, 1000, TS_BEGIN + 350],
+            3,
+            &[],
+            sp,
+        );
         assert!(row[..EOT as usize].iter().all(|&x| x == f32::NEG_INFINITY));
         assert_eq!(row[(TS_BEGIN + 349) as usize], f32::NEG_INFINITY);
         assert!(row[(TS_BEGIN + 350) as usize].is_finite());
         assert!(row[(TS_BEGIN + 351) as usize].is_finite());
+    }
+
+    #[test]
+    fn unknown_preset_is_a_clear_error() {
+        let err = match Transcriber::load_preset(Some("whisper_mega")) {
+            Err(e) => e,
+            Ok(_) => panic!("unknown preset must fail"),
+        };
+        assert!(err.contains("unknown model preset"), "{err}");
+        assert!(err.contains("whisper_tiny_en"), "lists the options: {err}");
+    }
+
+    #[test]
+    fn preset_dirs_resolve() {
+        assert_eq!(preset_dir(None), "models/asr");
+        assert_eq!(preset_dir(Some("whisper_tiny")), "models/asr");
+        assert_eq!(
+            preset_dir(Some("whisper_tiny_en")),
+            "models/asr/whisper_tiny_en"
+        );
+    }
+
+    #[test]
+    fn specials_resolve_english_only_and_multilingual() {
+        // The modern HF export layout: unified token set at the English-only
+        // (shifted) ids — <|en|> exists either way, so the preset flag decides.
+        let mut map = std::collections::HashMap::new();
+        for (tok, id) in [
+            ("<|endoftext|>", 50_256u32),
+            ("<|startoftranscript|>", 50_257),
+            ("<|en|>", 50_258),
+            ("<|transcribe|>", 50_358),
+            ("<|nocaptions|>", 50_361),
+            ("<|0.00|>", 50_363),
+        ] {
+            map.insert(tok.to_string(), id);
+        }
+        let en = Specials::resolve(&map, "nonexistent.json", true);
+        assert_eq!((en.eot, en.sot, en.ts_begin), (50_256, 50_257, 50_363));
+        assert_eq!(en.lang, None, "English-only prompts with <|sot|> alone");
+        assert_eq!(en.no_speech, 50_361);
+        let multi = Specials::resolve(&map, "nonexistent.json", false);
+        assert_eq!(multi.lang, Some(LANG_EN));
+        assert_eq!(multi.transcribe, Some(50_358));
     }
 }

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -3,7 +3,7 @@
 //! The docling.rs counterpart of `docling.cli.main`; `docling-rs serve`
 //! (with `--features serve`) starts the HTTP conversion API.
 //!
-//! Usage: docling-rs [--strict] [--to md|json] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--asr-model PRESET] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --to md|json       output format (default: md). `json` emits docling-core's
 //!                      native DoclingDocument JSON (export_to_dict).
 //!   --images MODE      picture handling for Markdown (mirrors docling's
@@ -24,6 +24,10 @@
 //!                      geometric reconstruction from cell positions. Faster
 //!                      (no model load, no per-table inference) at the cost of
 //!                      table fidelity — helps most in streaming mode.
+//!   --asr-model NAME   Whisper preset for audio inputs: whisper_tiny_en,
+//!                      whisper_base_en, whisper_small_en, whisper_distil_small_en
+//!                      (models under models/asr/<preset>/; fetch them with
+//!                      download_dependencies.sh --asr-model=<preset>)
 //!   --no-ocr           skip layout detection, OCR, and TableFormer entirely for
 //!                      PDF/image input — no model load or inference at all.
 //!                      Emits the embedded text layer as flat paragraphs in
@@ -74,6 +78,7 @@ fn main() -> ExitCode {
     let mut no_table_former = false;
     let mut no_ocr = false;
     let mut use_web_browser = false;
+    let mut asr_model: Option<String> = None;
     let mut enrich_picture_classes = false;
     let mut enrich_code = false;
     let mut enrich_formula = false;
@@ -94,6 +99,10 @@ fn main() -> ExitCode {
             "--enrich-code" => enrich_code = true,
             "--enrich-formula" => enrich_formula = true,
             "--to" => to = args.next().unwrap_or_default(),
+            // Named Whisper preset for audio inputs (English-only /
+            // Distil-Whisper variants under models/asr/<preset>/; fetch with
+            // download_dependencies.sh --asr-model=<preset>).
+            "--asr-model" => asr_model = args.next(),
             "--images" => images = args.next().unwrap_or_default(),
             // Hidden benchmarking aid: load the PDF/image pipeline once, then time
             // N warm conversions (models already loaded), printing the avg seconds
@@ -165,6 +174,7 @@ fn main() -> ExitCode {
 
     let converter = DocumentConverter::new()
         .strict(strict)
+        .asr_model(asr_model.clone())
         .fetch_images(fetch_images)
         .no_table_former(no_table_former)
         .no_ocr(no_ocr)

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -31,6 +31,9 @@ use docling::{
 #[napi(object)]
 #[derive(Clone, Default)]
 pub struct ConverterOptions {
+    /// Named Whisper model preset for audio sources (English-only /
+    /// Distil-Whisper variants under `models/asr/<preset>/`).
+    pub asr_model: Option<String>,
     /// Emit cleaner, more conformant Markdown (code-fence languages preserved,
     /// no inline-run spacing artifacts) instead of docling's byte-for-byte
     /// legacy output. Markdown only. Default `false`.
@@ -65,6 +68,8 @@ pub struct OutputOptions {
 pub struct ConvertOptions {
     pub strict: Option<bool>,
     pub fetch_images: Option<bool>,
+    /// Named Whisper model preset for audio sources.
+    pub asr_model: Option<String>,
     pub allowed_formats: Option<Vec<String>>,
     pub to: Option<String>,
     pub image_mode: Option<String>,
@@ -117,6 +122,7 @@ pub struct ConvertResult {
 struct ConvertConfig {
     strict: bool,
     fetch_images: bool,
+    asr_model: Option<String>,
     allowed_formats: Option<Vec<InputFormat>>,
     to: OutputKind,
     image_mode: ImageMode,
@@ -163,6 +169,7 @@ impl RawResult {
 fn build_config(
     strict: Option<bool>,
     fetch_images: Option<bool>,
+    asr_model: Option<String>,
     allowed_formats: Option<Vec<String>>,
     to: Option<String>,
     image_mode: Option<String>,
@@ -179,6 +186,7 @@ fn build_config(
     Ok(ConvertConfig {
         strict: strict.unwrap_or(false),
         fetch_images: fetch_images.unwrap_or(false),
+        asr_model,
         allowed_formats: allowed,
         to: parse_output_kind(to.as_deref())?,
         image_mode: parse_image_mode(image_mode.as_deref())?,
@@ -191,7 +199,9 @@ fn build_converter(cfg: &ConvertConfig) -> RsConverter {
         Some(list) => RsConverter::with_allowed_formats(list.iter().copied()),
         None => RsConverter::new(),
     };
-    base.strict(cfg.strict).fetch_images(cfg.fetch_images)
+    base.strict(cfg.strict)
+        .fetch_images(cfg.fetch_images)
+        .asr_model(cfg.asr_model.clone())
 }
 
 /// Render an already-converted document to Markdown/JSON per the config. The
@@ -269,6 +279,7 @@ pub fn convert_file(path: String, options: Option<ConvertOptions>) -> Result<Con
     let cfg = build_config(
         o.strict,
         o.fetch_images,
+        o.asr_model,
         o.allowed_formats,
         o.to,
         o.image_mode,
@@ -285,6 +296,7 @@ pub fn convert(input: ConvertInput, options: Option<ConvertOptions>) -> Result<C
     let cfg = build_config(
         o.strict,
         o.fetch_images,
+        o.asr_model,
         o.allowed_formats,
         o.to,
         o.image_mode,
@@ -305,6 +317,7 @@ pub fn convert_file_async(
     let cfg = build_config(
         o.strict,
         o.fetch_images,
+        o.asr_model,
         o.allowed_formats,
         o.to,
         o.image_mode,
@@ -323,6 +336,7 @@ pub fn convert_async(
     let cfg = build_config(
         o.strict,
         o.fetch_images,
+        o.asr_model,
         o.allowed_formats,
         o.to,
         o.image_mode,
@@ -388,6 +402,7 @@ impl Task for ConvertBytesTask {
 pub struct DocumentConverter {
     strict: bool,
     fetch_images: bool,
+    asr_model: Option<String>,
     allowed_formats: Option<Vec<InputFormat>>,
 }
 
@@ -407,6 +422,7 @@ impl DocumentConverter {
         Ok(Self {
             strict: o.strict.unwrap_or(false),
             fetch_images: o.fetch_images.unwrap_or(false),
+            asr_model: o.asr_model.clone(),
             allowed_formats: allowed,
         })
     }
@@ -416,6 +432,7 @@ impl DocumentConverter {
         Ok(ConvertConfig {
             strict: self.strict,
             fetch_images: self.fetch_images,
+            asr_model: self.asr_model.clone(),
             allowed_formats: self.allowed_formats.clone(),
             to: parse_output_kind(out.to.as_deref())?,
             image_mode: parse_image_mode(out.image_mode.as_deref())?,
@@ -826,6 +843,7 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
     Ok(ConvertConfig {
         strict,
         fetch_images: false,
+        asr_model: None,
         allowed_formats: None,
         to: parse_output_kind(out.to.as_deref())?,
         image_mode: parse_image_mode(out.image_mode.as_deref())?,

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "0.44.0"
+version = "0.47.3"
 dependencies = [
  "calamine",
  "csv",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "0.44.0"
+version = "0.47.3"
 dependencies = [
  "docling-core",
  "ort",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "0.44.0"
+version = "0.47.3"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "0.44.0"
+version = "0.47.3"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -112,6 +112,7 @@ impl PyDocumentConverter {
         do_picture_classification = false,
         do_code_enrichment = false,
         do_formula_enrichment = false,
+        asr_model = None,
         allowed_formats = None,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -123,6 +124,7 @@ impl PyDocumentConverter {
         do_picture_classification: bool,
         do_code_enrichment: bool,
         do_formula_enrichment: bool,
+        asr_model: Option<String>,
         allowed_formats: Option<Vec<String>>,
     ) -> PyResult<Self> {
         // `allowed_formats` (docling's converter arg) restricts which input
@@ -147,6 +149,7 @@ impl PyDocumentConverter {
         Ok(Self {
             inner: base
                 .fetch_images(fetch_images)
+                .asr_model(asr_model)
                 .no_ocr(!do_ocr)
                 .no_table_former(!do_table_structure)
                 .use_web_browser(use_web_browser)

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -200,6 +200,7 @@ struct ConvertOptions {
     no_ocr: Option<bool>,
     no_table_former: Option<bool>,
     fetch_images: Option<bool>,
+    asr_model: Option<String>,
 }
 
 impl ConvertOptions {
@@ -211,6 +212,7 @@ impl ConvertOptions {
             no_ocr: self.no_ocr.or(base.no_ocr),
             no_table_former: self.no_table_former.or(base.no_table_former),
             fetch_images: self.fetch_images.or(base.fetch_images),
+            asr_model: self.asr_model.or(base.asr_model),
         }
     }
 }
@@ -390,6 +392,7 @@ async fn read_multipart(
                     _ => body_opts.images = Some(v),
                 }
             }
+            "asr_model" => body_opts.asr_model = Some(text_field(field).await?),
             "strict" | "no_ocr" | "no_table_former" | "fetch_images" => {
                 let v = text_field(field).await?;
                 let b = matches!(v.as_str(), "1" | "true" | "yes" | "on");
@@ -679,6 +682,7 @@ fn request_converter(state: &AppState, options: &ConvertOptions) -> DocumentConv
         // rather than honored (the UI greys the box; an API caller just gets
         // placeholder images instead of a surprise outbound fetch).
         .fetch_images(state.cfg.allow_url_fetch && options.fetch_images.unwrap_or(false))
+        .asr_model(options.asr_model.clone())
         .no_ocr(options.no_ocr.unwrap_or(false))
         .no_table_former(options.no_table_former.unwrap_or(false))
 }

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -76,6 +76,10 @@ pub struct DocumentConverter {
     no_table_former: bool,
     no_ocr: bool,
     use_web_browser: bool,
+    /// Named Whisper model preset for audio sources (docling's ASR model
+    /// specs, PR #3741): English-only / Distil-Whisper variants under
+    /// `models/asr/<preset>/`. `None` = the default Whisper tiny.
+    asr_model: Option<String>,
     /// Opt-in PDF/image enrichment models (docling's
     /// `do_picture_classification` / `do_code_enrichment` /
     /// `do_formula_enrichment`).
@@ -98,8 +102,20 @@ impl DocumentConverter {
             no_table_former: false,
             no_ocr: false,
             use_web_browser: false,
+            asr_model: None,
             enrich: crate::EnrichmentOptions::default(),
         }
+    }
+
+    /// Select a named Whisper model preset for audio sources — the
+    /// English-only (`whisper_tiny_en`, `whisper_base_en`, `whisper_small_en`)
+    /// and Distil-Whisper (`whisper_distil_small_en`) variants of docling's
+    /// ASR model specs. `None` (default) uses Whisper tiny (multilingual)
+    /// from `models/asr/`; presets load from `models/asr/<preset>/` (fetch
+    /// them with `download_dependencies.sh --asr-model <preset>`).
+    pub fn asr_model(mut self, model: Option<String>) -> Self {
+        self.asr_model = model;
+        self
     }
 
     /// Select the Markdown export mode for documents this converter produces.
@@ -404,8 +420,12 @@ impl DocumentConverter {
             // Audio → Whisper ASR (symphonia decode + ONNX inference); each
             // transcribed segment becomes a `[time: start-end] text` paragraph.
             #[cfg(feature = "asr")]
-            InputFormat::Audio => docling_asr::convert_audio(&source.bytes, &source.name)
-                .map_err(|e| ConversionError::Parse(e.to_string()))?,
+            InputFormat::Audio => docling_asr::convert_audio_with_model(
+                &source.bytes,
+                &source.name,
+                self.asr_model.as_deref(),
+            )
+            .map_err(|e| ConversionError::Parse(e.to_string()))?,
             // Without the full ML pipeline, `pdf-text` still converts a PDF's
             // embedded text layer (pure Rust — the wasm32 path), equivalent to
             // `--no-ocr`: flat paragraphs, no headings/tables/pictures. A

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -172,6 +172,7 @@ for preset in $ASR_PRESETS; do
     *) echo "unknown --asr-model '$preset' (available: whisper_tiny_en whisper_base_en whisper_small_en whisper_distil_small_en)" >&2; exit 2 ;;
   esac
   base="https://huggingface.co/onnx-community/$repo/resolve/main"
+  mkdir -p "models/asr/$preset"
   fetch "$base/onnx/encoder_model.onnx" "models/asr/$preset/encoder_model.onnx"
   fetch "$base/onnx/decoder_model.onnx" "models/asr/$preset/decoder_model.onnx"
   fetch "$base/vocab.json" "models/asr/$preset/vocab.json"

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -75,6 +75,7 @@ EMBED_BASE_URL="${DOCLING_RS_EMBED_MODELS_URL:-https://huggingface.co/aapot/bge-
 
 FORCE=false
 WITH_ASR=true
+ASR_PRESETS=
 WITH_INT8=true
 WITH_CHUNK=true
 WITH_ENRICH=false
@@ -84,6 +85,7 @@ for arg in "$@"; do
   case "$arg" in
     --force) FORCE=true ;;
     --no-asr) WITH_ASR=false ;;
+    --asr-model=*) ASR_PRESETS="$ASR_PRESETS ${arg#--asr-model=}" ;;
     --int8) WITH_INT8=true ;; # accepted for compatibility; int8 is the default
     --no-int8) WITH_INT8=false ;;
     --no-chunk) WITH_CHUNK=false ;;
@@ -91,7 +93,8 @@ for arg in "$@"; do
     --embed) WITH_EMBED=true ;;
     --ocr-en) WITH_OCR_EN=true ;;
     *)
-      echo "usage: download_dependencies.sh [--force] [--no-asr] [--no-int8] [--no-chunk] [--enrich] [--embed] [--ocr-en]" >&2
+      echo "usage: download_dependencies.sh [--force] [--no-asr] [--asr-model=<preset>] [--no-int8] [--no-chunk] [--enrich] [--embed] [--ocr-en]" >&2
+      echo "  ASR presets: whisper_tiny_en whisper_base_en whisper_small_en whisper_distil_small_en" >&2
       exit 2
       ;;
   esac
@@ -148,13 +151,34 @@ fetch_optional "$BASE_URL/bbox.onnx.data" models/tableformer/bbox.onnx.data
 
 if [ "$WITH_ASR" = true ]; then
   # Whisper tiny for audio/ASR: encoder + (cache-less) decoder + vocabulary;
-  # added_tokens.json only feeds non-English language selection, so a missing
-  # asset there is not fatal.
+  # added_tokens.json feeds non-English language selection and the special-
+  # token layout, so a missing asset there is not fatal for the default model.
   fetch "$ASR_BASE_URL/onnx/encoder_model.onnx" models/asr/encoder_model.onnx
   fetch "$ASR_BASE_URL/onnx/decoder_model.onnx" models/asr/decoder_model.onnx
   fetch "$ASR_BASE_URL/vocab.json" models/asr/vocab.json
   fetch_optional "$ASR_BASE_URL/added_tokens.json" models/asr/added_tokens.json
 fi
+
+# Named ASR model presets (docling's English-only / Distil-Whisper specs,
+# limited to variants with public ONNX exports): each lands in its own
+# models/asr/<preset>/ directory, selected at run time with
+# DocumentConverter::asr_model / the serve `asr_model` option.
+for preset in $ASR_PRESETS; do
+  case "$preset" in
+    whisper_tiny_en) repo="whisper-tiny.en" ;;
+    whisper_base_en) repo="whisper-base.en" ;;
+    whisper_small_en) repo="whisper-small.en" ;;
+    whisper_distil_small_en) repo="distil-small.en" ;;
+    *) echo "unknown --asr-model '$preset' (available: whisper_tiny_en whisper_base_en whisper_small_en whisper_distil_small_en)" >&2; exit 2 ;;
+  esac
+  base="https://huggingface.co/onnx-community/$repo/resolve/main"
+  fetch "$base/onnx/encoder_model.onnx" "models/asr/$preset/encoder_model.onnx"
+  fetch "$base/onnx/decoder_model.onnx" "models/asr/$preset/decoder_model.onnx"
+  fetch "$base/vocab.json" "models/asr/$preset/vocab.json"
+  # English-only exports keep their special tokens here; required for the
+  # shifted token layout to resolve.
+  fetch "$base/added_tokens.json" "models/asr/$preset/added_tokens.json"
+done
 
 if [ "$WITH_CHUNK" = true ]; then
   # The hybrid chunker's default tokenizer (all-MiniLM-L6-v2's tokenizer.json,


### PR DESCRIPTION
**Upstream capability**
Upstream's native ASR backend gained presets for the English-only Whisper variants and Distil-Whisper (smaller/faster distilled models).


- docling-asr currently loads one Whisper model from models/asr/. Add a preset/model-selection option (converter option + CLI flag + serve/bindings passthrough).
- Extend the model download script with the distil/en-only ONNX exports.
- Validate WER on the existing audio fixtures.
Medium effort; mostly plumbing + model packaging.


Closes #136