### PR TITLE
pdf: VLM pipeline — remote OpenAI-compatible vision endpoint (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,34 @@ by a wide margin, but a scanned/image-only PDF (no embedded text layer) comes
 back empty rather than erroring, so a caller can detect that and re-convert
 without the flag.
 
+### VLM pipeline (remote endpoint)
+
+`--pipeline vlm` (issue #77) replaces the whole discriminative ML stack with a
+Vision Language Model: each PDF page is rendered (pdfium) and sent to any
+**OpenAI-compatible** vision endpoint — LM Studio, Ollama, vLLM, or a hosted
+service — with docling's page-conversion prompt; the returned DocLang markup
+is parsed by the same reader that `.dclg`/`.dclx` inputs use. An image input
+is sent as-is (it is its own page). No ONNX models load at all; local
+in-process VLM inference is a possible later enhancement.
+
+```bash
+docling-rs --pipeline vlm \
+  --vlm-endpoint http://localhost:11434/v1 \
+  --vlm-model granite-docling \
+  paper.pdf
+```
+
+`--vlm-endpoint` takes the server's `/v1` base or the full
+`…/chat/completions` URL; `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL` /
+`DOCLING_RS_VLM_PROMPT` / `DOCLING_RS_VLM_API_KEY` (Bearer token) are the env
+equivalents. `--pages A-B` composes (only the window's pages are rendered and
+sent), and `--to md|json|dclx|chunks` plus `--strict` work as usual. Transient
+endpoint failures (timeouts, 408/429, 5xx) retry with exponential backoff;
+a page that still fails fails the conversion — no silently dropped pages.
+Output quality is entirely the model's: conversion of the PDF corpus against
+docling's own VLM pipeline output hasn't been measured yet (it needs a live
+endpoint), so treat this as infrastructure, not a conformance claim.
+
 ### Headless-browser HTML pre-render (optional)
 
 Almost everything in the HTML backend is pure Rust, but one thing a static

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -3,7 +3,7 @@
 //! The docling.rs counterpart of `docling.cli.main`; `docling-rs serve`
 //! (with `--features serve`) starts the HTTP conversion API.
 //!
-//! Usage: docling-rs [--strict] [--to md|json] [--pages A-B] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--ocr-lang en|ch] [--asr-model PRESET] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json] [--pages A-B] [--images MODE] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --to md|json       output format (default: md). `json` emits docling-core's
 //!                      native DoclingDocument JSON (export_to_dict).
 //!   --pages A-B        convert only PDF pages A through B (1-based, inclusive;
@@ -95,6 +95,9 @@ fn main() -> ExitCode {
     let mut bench_warm: Option<usize> = None;
     let mut pages: Option<(usize, usize)> = None;
     let mut ocr_lang: Option<String> = None;
+    let mut pipeline: Option<String> = None;
+    let mut vlm_endpoint: Option<String> = None;
+    let mut vlm_model: Option<String> = None;
     let mut path: Option<String> = None;
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -145,6 +148,22 @@ fn main() -> ExitCode {
                     return ExitCode::from(2);
                 }
             },
+            // Pipeline selection (#77): `standard` (default, the ML stack) or
+            // `vlm` — render pages and convert them through a remote
+            // OpenAI-compatible vision endpoint returning DocLang.
+            "--pipeline" => match args.next() {
+                Some(v) if matches!(v.trim(), "standard" | "vlm") => pipeline = Some(v),
+                Some(v) => {
+                    eprintln!("error: --pipeline {v:?} is not standard|vlm");
+                    return ExitCode::from(2);
+                }
+                None => {
+                    eprintln!("error: --pipeline needs a value (standard|vlm)");
+                    return ExitCode::from(2);
+                }
+            },
+            "--vlm-endpoint" => vlm_endpoint = args.next(),
+            "--vlm-model" => vlm_model = args.next(),
             // Hidden benchmarking aid: load the PDF/image pipeline once, then time
             // N warm conversions (models already loaded), printing the avg seconds
             // per conversion to stdout. This is the startup-excluded counterpart to
@@ -211,6 +230,29 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         };
+    }
+
+    // #77: the remote-VLM pipeline replaces the whole ML stack — convert,
+    // then fall through to the regular output selection (md/json/dclx/chunks
+    // all work; there is no page-streaming, the endpoint is the bottleneck).
+    if pipeline.as_deref() == Some("vlm") {
+        let mut opts = match docling::vlm::VlmOptions::resolve(vlm_endpoint, vlm_model) {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::from(2);
+            }
+        };
+        opts.page_range = pages;
+        let mut document = match docling::vlm::convert_vlm(&source, &opts) {
+            Ok(doc) => doc,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        document.strict_markdown = strict;
+        return output_document(document, &to, image_mode, &path);
     }
 
     let mut converter = DocumentConverter::new()
@@ -281,7 +323,17 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    output_document(document, &to, image_mode, &path)
+}
 
+/// The buffered output tail shared by the standard (non-streaming) and VLM
+/// paths: `--to` selection, image sidecars, exit code.
+fn output_document(
+    document: docling::DoclingDocument,
+    to: &str,
+    image_mode: ImageMode,
+    path: &str,
+) -> ExitCode {
     if to == "json" {
         println!("{}", document.export_to_json());
         return ExitCode::SUCCESS;

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["tests", "benches"]
 # client are feature-sliced so `--no-default-features` leaves the pure-Rust
 # declarative converters (DOCX/HTML/MD/XLSX/PPTX/… → md/json) — a set that
 # compiles for wasm32-unknown-unknown (issue #79, see crates/docling-wasm).
-default = ["pdf", "asr", "fetch-images"]
+default = ["pdf", "asr", "fetch-images", "vlm"]
 # PDF/image/METS-GBS ML pipeline (pdfium + ONNX Runtime via docling-pdf).
 pdf = ["dep:docling-pdf", "docling-pdf/ml"]
 # Text-layer-only PDF conversion (docling-pdf's pure-Rust parser, no pdfium/
@@ -30,6 +30,11 @@ pdf-text = ["dep:docling-pdf"]
 asr = ["dep:docling-asr"]
 # Blocking HTTP fetch of remote <img src> images (DocumentConverter::fetch_images).
 fetch-images = ["dep:ureq", "dep:url"]
+# Remote VLM pipeline (#77): render PDF pages via pdfium and convert them
+# through an OpenAI-compatible vision endpoint (LM Studio / Ollama / vLLM /
+# hosted), parsing the returned DocLang with the existing reader. Rides on the
+# crate's existing blocking HTTP client; no model code compiled in.
+vlm = ["pdf", "dep:ureq"]
 # Optional headless-browser HTML pre-render (the `--use-web-browser` flag /
 # `DocumentConverter::use_web_browser`). Off by default so the standard build
 # stays pure-Rust with no browser/runtime dependency; enable with

--- a/crates/docling/src/backend/mod.rs
+++ b/crates/docling/src/backend/mod.rs
@@ -29,7 +29,7 @@ mod cfb;
 mod csv;
 mod deepseek;
 mod doc;
-mod doclang;
+pub(crate) mod doclang;
 mod docling_json;
 mod docx;
 mod email;

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -32,6 +32,8 @@ mod result;
 mod source;
 #[cfg(feature = "pdf")]
 mod stream;
+#[cfg(feature = "vlm")]
+pub mod vlm;
 
 pub mod backend;
 #[cfg(feature = "asr")]

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -216,7 +216,7 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
         "data:image/png;base64,{}",
         docling_core::base64::encode(image)
     );
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "model": opts.model,
         // Deterministic-ish output: sampling noise only hurts a structured
         // markup task (docling's ApiVlmOptions ships temperature 0 too).
@@ -231,6 +231,25 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
             ],
         }],
     });
+    // DOCLING_RS_VLM_EXTRA_BODY: a JSON object merged into the request at the
+    // top level — the escape hatch for server-specific knobs the OpenAI shape
+    // doesn't cover. The motivating case: vLLM's "skip_special_tokens": false,
+    // without which servers detokenize away granite-docling's DocTags
+    // structure tokens and only loc tokens + bare text survive.
+    if let Ok(extra) = std::env::var("DOCLING_RS_VLM_EXTRA_BODY") {
+        match serde_json::from_str::<serde_json::Value>(&extra) {
+            Ok(serde_json::Value::Object(map)) => {
+                for (k, v) in map {
+                    body[k] = v;
+                }
+            }
+            _ => {
+                return Err(
+                    "DOCLING_RS_VLM_EXTRA_BODY is not a JSON object; fix or unset it".into(),
+                )
+            }
+        }
+    }
     let url = opts.url();
     let mut delay = Duration::from_secs(2);
     let mut last_err = String::new();

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -128,26 +128,35 @@ pub fn convert_vlm(
                 }
                 None => None,
             };
-            // `for_each_page`'s error type must absorb pdfium's own errors,
-            // so page-level VLM failures travel as PdfError strings and are
-            // rewrapped once below.
-            docling_pdf::pdfium_backend::for_each_page::<docling_pdf::PdfError, _>(
+            // `for_each_page`'s error type must implement From<PdfiumError>,
+            // which ConversionError doesn't — so VLM/encode failures park
+            // their message in `vlm_err` and abort the walk with a sentinel;
+            // only genuine pdfium errors surface through PdfError itself.
+            let mut vlm_err: Option<String> = None;
+            let walk = docling_pdf::pdfium_backend::for_each_page::<docling_pdf::PdfError, _>(
                 &source.bytes,
                 None,
                 true, // render page images — they are the whole input here
                 range,
                 |i, _total, page| {
-                    let png = encode_png(&page.image).map_err(|e| {
-                        docling_pdf::PdfError::Pdfium(format!("page {}: {e}", i + 1))
-                    })?;
-                    let markup = request_page(&agent, opts, &png).map_err(|e| {
-                        docling_pdf::PdfError::Pdfium(format!("vlm: page {}: {e}", i + 1))
-                    })?;
-                    fragments.push(doclang_fragment(&markup));
-                    Ok(())
+                    let step =
+                        encode_png(&page.image).and_then(|png| request_page(&agent, opts, &png));
+                    match step {
+                        Ok(markup) => {
+                            fragments.push(doclang_fragment(&markup));
+                            Ok(())
+                        }
+                        Err(e) => {
+                            vlm_err = Some(format!("page {}: {e}", i + 1));
+                            Err(docling_pdf::PdfError::Pdfium("vlm abort".into()))
+                        }
+                    }
                 },
-            )
-            .map_err(pdf_err)?;
+            );
+            if let Some(msg) = vlm_err {
+                return Err(ConversionError::Parse(format!("vlm: {msg}")));
+            }
+            walk.map_err(pdf_err)?;
         }
         InputFormat::Image => {
             // The image file is already the page; no re-encode, no pdfium.
@@ -234,7 +243,17 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
                     .read_to_string()
                     .map_err(|e| format!("{url}: read response: {e}"))?;
                 if status == 408 || status == 429 || status >= 500 {
-                    last_err = format!("{url}: HTTP {status} (attempt {})", attempt + 1);
+                    // Keep a body snippet: for OpenAI-style servers the real
+                    // reason (insufficient_quota vs. a plain rate limit)
+                    // lives there, and hiding it made give-ups undiagnosable.
+                    last_err = format!(
+                        "{url}: HTTP {status} (attempt {}): {}",
+                        attempt + 1,
+                        text.replace(['\n', '\r'], " ")
+                            .chars()
+                            .take(300)
+                            .collect::<String>()
+                    );
                     continue;
                 }
                 if status != 200 {
@@ -263,10 +282,16 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
 ///
 /// Models wrap their answer unpredictably: Markdown code fences, a full
 /// `<doclang …>` document, a legacy `<doctag>` root, or a bare fragment of
-/// block elements. The DocLang reader is already tolerant of unknown
-/// elements/attributes, so normalization only needs to strip the wrappers —
-/// content inside an unexpected root still parses (unknown elements recurse).
+/// block elements. The wrappers strip first, then the body goes through the
+/// DocTags→DocLang lexical translation ([`doctags_to_doclang`]) — a no-op
+/// for already-DocLang answers, load-bearing for granite-docling-class
+/// models whose raw DocTags token stream is not XML at all.
 fn doclang_fragment(response: &str) -> String {
+    doctags_to_doclang(&strip_wrappers(response))
+}
+
+/// The wrapper-stripping half of [`doclang_fragment`].
+fn strip_wrappers(response: &str) -> String {
     let mut text = response.trim();
     // ```xml … ``` / ``` … ``` fences.
     if let Some(rest) = text.strip_prefix("```") {
@@ -292,6 +317,163 @@ fn doclang_fragment(response: &str) -> String {
         }
     }
     text.to_string()
+}
+
+/// Translate a legacy **DocTags** fragment (what granite-docling-class models
+/// actually emit) into well-formed DocLang the XML reader accepts.
+///
+/// DocTags is a token stream, not XML: `<loc_57>` location tokens, OTSL cell
+/// markers (`<fcel>Text<fcel>…<nl>`), picture-class and checkbox tokens are
+/// all *unclosed*. The DocLang reader already speaks OTSL — its `<table>`
+/// parser takes self-closed `<fcel/>` markers with the text between them —
+/// so the translation is purely lexical, one pass over the tags:
+///
+/// - `<loc_N>` and `<page_break>` tokens drop (the reader's geometry comes
+///   from `<location>`, which VLM output doesn't carry);
+/// - `<otsl>` → `<table>`, `<section_header_level_K>` → `<heading
+///   level="K">`, `<title>` → `<heading level="1">`, `<paragraph>` →
+///   `<text>`, `<ordered_list>`/`<unordered_list>` → `<list>`,
+///   `<list_item>` → the `<ldiv/>` item marker DocLang lists use;
+/// - `<page_header>`/`<page_footer>` → `<text>` opening with a
+///   `<layer value="furniture"/>` head, so headers/footers stay out of the
+///   Markdown body exactly like the ML pipeline's furniture;
+/// - any other tag that never sees a matching closer in the fragment —
+///   OTSL cell markers, picture classes, checkbox states, whatever a future
+///   model invents — is emitted self-closed, which the tolerant reader
+///   recurses through harmlessly;
+/// - stray `&` (not an entity) and dangling `<` escape to entities, since
+///   model text is not XML-escaped.
+///
+/// A fragment that is already DocLang passes through intact: every paired
+/// element has its closer, none of the rename names exist in DocLang, and
+/// proper entities are left alone.
+fn doctags_to_doclang(fragment: &str) -> String {
+    // Tag names that appear in closing form — those pairs are kept as-is;
+    // everything else unknown is a single marker token.
+    let mut closers: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let bytes = fragment.as_bytes();
+    let mut i = 0;
+    while let Some(off) = fragment[i..].find("</") {
+        let start = i + off + 2;
+        let end = fragment[start..]
+            .find('>')
+            .map(|e| start + e)
+            .unwrap_or(fragment.len());
+        closers.insert(fragment[start..end].trim());
+        i = end;
+    }
+
+    let mut out = String::with_capacity(fragment.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c != '<' {
+            if c == '&' {
+                // Escape a bare ampersand; keep real entities (&amp; &#123;).
+                let rest = &fragment[i + 1..];
+                let is_entity = rest
+                    .split_once(';')
+                    .map(|(name, _)| {
+                        !name.is_empty()
+                            && name.len() <= 8
+                            && name
+                                .chars()
+                                .all(|ch| ch.is_ascii_alphanumeric() || ch == '#')
+                    })
+                    .unwrap_or(false);
+                out.push_str(if is_entity { "&" } else { "&amp;" });
+            } else {
+                out.push(c);
+            }
+            i += c.len_utf8();
+            continue;
+        }
+        // A tag candidate: `<`, optional `/`, then a name. Anything else is
+        // literal text (`a < b`) and escapes.
+        let close = bytes.get(i + 1) == Some(&b'/');
+        let name_start = i + 1 + usize::from(close);
+        let Some(end) = fragment[i..].find('>').map(|e| i + e) else {
+            out.push_str("&lt;");
+            i += 1;
+            continue;
+        };
+        let inner = fragment[name_start..end].trim();
+        let name = inner
+            .split([' ', '\t', '\n', '/'])
+            .next()
+            .unwrap_or_default();
+        if name.is_empty()
+            || !name
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphabetic())
+        {
+            out.push_str("&lt;");
+            i += 1;
+            continue;
+        }
+        let self_closed = inner.ends_with('/');
+        i = end + 1;
+        // Dropped tokens.
+        if name.starts_with("loc_") || name == "page_break" || name == "doctag" || name == "doctags"
+        {
+            continue;
+        }
+        // Renames (open and close forms).
+        let level = name
+            .strip_prefix("section_header_level_")
+            .and_then(|v| v.parse::<u8>().ok());
+        if close {
+            match name {
+                _ if level.is_some() => out.push_str("</heading>"),
+                "title" => out.push_str("</heading>"),
+                "otsl" => out.push_str("</table>"),
+                // An item's text runs until the next `<ldiv/>`; the closer is
+                // structural noise in DocLang.
+                "list_item" => {}
+                "paragraph" | "page_header" | "page_footer" => out.push_str("</text>"),
+                "ordered_list" | "unordered_list" => out.push_str("</list>"),
+                _ => {
+                    out.push_str("</");
+                    out.push_str(name);
+                    out.push('>');
+                }
+            }
+            continue;
+        }
+        match name {
+            _ if level.is_some() => {
+                out.push_str(&format!(
+                    "<heading level=\"{}\">",
+                    level.unwrap().clamp(1, 6)
+                ));
+            }
+            "title" => out.push_str("<heading level=\"1\">"),
+            "otsl" => out.push_str("<table>"),
+            // DocLang list items are `<ldiv/>` markers followed by the item's
+            // text, not wrapper elements.
+            "list_item" => out.push_str("<ldiv/>"),
+            "paragraph" => out.push_str("<text>"),
+            "page_header" | "page_footer" => out.push_str("<text><layer value=\"furniture\"/>"),
+            "ordered_list" => out.push_str("<list class=\"ordered\">"),
+            "unordered_list" => out.push_str("<list>"),
+            _ if self_closed || closers.contains(name) => {
+                // A proper pair (DocLang vocabulary) or already self-closed:
+                // pass through with attributes intact.
+                out.push('<');
+                out.push_str(inner);
+                out.push('>');
+            }
+            _ => {
+                // A bare marker token with no closer anywhere — OTSL cells,
+                // picture classes, checkbox states. Self-close it.
+                out.push('<');
+                out.push_str(name);
+                out.push_str("/>");
+            }
+        }
+    }
+    out
 }
 
 /// PNG-encode a rendered page (the wire format every OpenAI-compatible
@@ -333,5 +515,45 @@ mod tests {
             doclang_fragment("Here you go:\n<doclang><heading level=\"1\">T</heading></doclang>"),
             "<heading level=\"1\">T</heading>"
         );
+    }
+
+    /// Raw granite-docling output is DocTags — loc tokens, unclosed OTSL
+    /// markers, section_header naming — and must come out as parseable
+    /// DocLang (this exact shape produced the "expected 'loc_420' tag"
+    /// failure against a live Ollama endpoint).
+    #[test]
+    fn doctags_translation() {
+        let page = "<doctag><picture><loc_15><loc_10><loc_240><loc_60><other></picture>\
+<section_header_level_1><loc_57><loc_70><loc_420><loc_78>Optimized Table Tokenization</section_header_level_1>\
+<text><loc_57><loc_84><loc_420><loc_98>Body with A &amp; B & C.</text>\
+<unordered_list><list_item><loc_60><loc_100><loc_420><loc_108>First item</list_item></unordered_list>\
+<otsl><loc_57><loc_120><loc_420><loc_160><ched>Col A<ched>Col B<nl><fcel>1<fcel>2<nl></otsl>\
+<page_footer><loc_57><loc_280><loc_420><loc_288>7</page_footer><page_break></doctag>";
+        let fragment = doclang_fragment(page);
+        let xml = format!("<doclang version=\"0.7\">{fragment}</doclang>");
+        let doc = crate::backend::DeclarativeBackend::convert(
+            &crate::backend::doclang::DoclangBackend,
+            &crate::source::SourceDocument::from_bytes(
+                "page",
+                crate::format::InputFormat::XmlDoclang,
+                xml.into_bytes(),
+            ),
+        )
+        .expect("translated DocTags must parse");
+        let md = doc.export_to_markdown();
+        assert!(md.contains("# Optimized Table Tokenization"), "md: {md:?}");
+        assert!(md.contains("Body with A & B & C."), "md: {md:?}");
+        assert!(md.contains("- First item"), "md: {md:?}");
+        assert!(md.contains("Col A |"), "md: {md:?}");
+        assert!(md.contains("1 |"), "md: {md:?}");
+        // Furniture (page footer) stays out of the Markdown body.
+        assert!(!md.contains("\n7\n"), "md: {md:?}");
+    }
+
+    /// DocLang-native fragments survive the translation byte-for-byte.
+    #[test]
+    fn doclang_passthrough() {
+        let native = "<heading level=\"2\">T</heading>\n<text>Hi &amp; bye <bold>b</bold></text>\n<table>\n<fcel/>a\n<nl/>\n</table>";
+        assert_eq!(doclang_fragment(native), native);
     }
 }

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -178,7 +178,19 @@ pub fn convert_vlm(
     );
     let synthetic =
         SourceDocument::from_bytes(&source.name, InputFormat::XmlDoclang, xml.into_bytes());
-    DoclangBackend.convert(&synthetic)
+    let doc = DoclangBackend.convert(&synthetic)?;
+    if doc.nodes.is_empty() {
+        // The request loop succeeded, so this is a content problem, not a
+        // transport one: the model answered with nothing our reader keeps.
+        // An empty stdout with exit 0 buried that; say it loudly instead.
+        return Err(ConversionError::Parse(
+            "vlm: the model's responses contained no parseable DocLang/DocTags blocks \
+             (set DOCLING_RS_VLM_DEBUG=1 to print raw responses; a generic VLM may need \
+             a DOCLING_RS_VLM_PROMPT that describes the expected markup)"
+                .into(),
+        ));
+    }
+    Ok(doc)
 }
 
 fn pdf_err(e: docling_pdf::PdfError) -> ConversionError {
@@ -264,10 +276,19 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
                 }
                 let parsed: serde_json::Value = serde_json::from_str(&text)
                     .map_err(|e| format!("{url}: malformed JSON response: {e}"))?;
-                return parsed["choices"][0]["message"]["content"]
+                let content = parsed["choices"][0]["message"]["content"]
                     .as_str()
                     .map(str::to_string)
                     .ok_or_else(|| format!("{url}: no choices[0].message.content in response"));
+                if std::env::var_os("DOCLING_RS_VLM_DEBUG").is_some() {
+                    match &content {
+                        Ok(c) => {
+                            eprintln!("vlm: raw model response ({} chars):\n{c}\n---", c.len())
+                        }
+                        Err(_) => eprintln!("vlm: raw endpoint body:\n{text}\n---"),
+                    }
+                }
+                return content;
             }
             Err(e) => {
                 last_err = format!("{url}: {e} (attempt {})", attempt + 1);
@@ -287,7 +308,19 @@ fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<
 /// for already-DocLang answers, load-bearing for granite-docling-class
 /// models whose raw DocTags token stream is not XML at all.
 fn doclang_fragment(response: &str) -> String {
-    doctags_to_doclang(&strip_wrappers(response))
+    let translated = doctags_to_doclang(&strip_wrappers(response));
+    // A model that ignored the markup instruction entirely (plain prose /
+    // Markdown, no tags) still carries the page text — wrap it as one
+    // paragraph per non-empty line instead of silently dropping everything.
+    if !translated.contains('<') && !translated.trim().is_empty() {
+        return translated
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| format!("<text>{}</text>", l.trim()))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    translated
 }
 
 /// The wrapper-stripping half of [`doclang_fragment`].

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -383,9 +383,14 @@ fn strip_wrappers(response: &str) -> String {
 /// - `<loc_N>` and `<page_break>` tokens drop (the reader's geometry comes
 ///   from `<location>`, which VLM output doesn't carry);
 /// - `<otsl>` → `<table>`, `<section_header_level_K>` → `<heading
-///   level="K">`, `<title>` → `<heading level="1">`, `<paragraph>` →
-///   `<text>`, `<ordered_list>`/`<unordered_list>` → `<list>`,
-///   `<list_item>` → the `<ldiv/>` item marker DocLang lists use;
+///   level="K+1">` (docling parity: section level 1 renders `##`; plain `#`
+///   is the document title), `<title>` → `<heading level="1">`,
+///   `<paragraph>` → `<text>`, `<ordered_list>`/`<unordered_list>` →
+///   `<list>`, `<list_item>` → the `<ldiv/>` item marker DocLang lists use;
+/// - a `<caption>` inside `<otsl>` hoists to a `<text>` paragraph *before*
+///   the `<table>` (docling's reading order); a standalone `<caption>`
+///   becomes `<text>`; a `<picture>`'s caption stays where the picture
+///   parser expects it;
 /// - `<page_header>`/`<page_footer>` → `<text>` opening with a
 ///   `<layer value="furniture"/>` head, so headers/footers stay out of the
 ///   Markdown body exactly like the ML pipeline's furniture;
@@ -417,6 +422,11 @@ fn doctags_to_doclang(fragment: &str) -> String {
 
     let mut out = String::with_capacity(fragment.len());
     let mut i = 0;
+    // Lexical nesting state for caption hoisting: where the current
+    // `<table>` opened (to insert the hoisted caption before it), and
+    // whether we're inside a `<picture>` (whose caption is native DocLang).
+    let mut table_open_at: Option<usize> = None;
+    let mut picture_depth = 0usize;
     while i < bytes.len() {
         let c = bytes[i] as char;
         if c != '<' {
@@ -475,11 +485,36 @@ fn doctags_to_doclang(fragment: &str) -> String {
         let level = name
             .strip_prefix("section_header_level_")
             .and_then(|v| v.parse::<u8>().ok());
+        // A table caption in DocTags sits inside <otsl>; DocLang wants it as
+        // a paragraph before the table. Capture the pair verbatim (dropping
+        // nested tokens) and splice it in front of the <table> opener.
+        if !close && name == "caption" && table_open_at.is_some() {
+            let inner_end = fragment[i..].find("</caption>").map(|e| i + e);
+            let (raw, next) = match inner_end {
+                Some(e) => (&fragment[i..e], e + "</caption>".len()),
+                None => (&fragment[i..], fragment.len()),
+            };
+            let text: String = strip_tokens(raw);
+            if !text.trim().is_empty() {
+                let at = table_open_at.unwrap();
+                out.insert_str(at, &format!("<text>{}</text>\n", text.trim()));
+            }
+            i = next;
+            continue;
+        }
         if close {
             match name {
                 _ if level.is_some() => out.push_str("</heading>"),
                 "title" => out.push_str("</heading>"),
-                "otsl" => out.push_str("</table>"),
+                "otsl" => {
+                    table_open_at = None;
+                    out.push_str("</table>");
+                }
+                "picture" => {
+                    picture_depth = picture_depth.saturating_sub(1);
+                    out.push_str("</picture>");
+                }
+                "caption" if picture_depth == 0 => out.push_str("</text>"),
                 // An item's text runs until the next `<ldiv/>`; the closer is
                 // structural noise in DocLang.
                 "list_item" => {}
@@ -495,13 +530,27 @@ fn doctags_to_doclang(fragment: &str) -> String {
         }
         match name {
             _ if level.is_some() => {
+                // docling parity: section_header level K renders as heading
+                // K+1 in Markdown ("## 5.1 …"); "#" is the document title.
                 out.push_str(&format!(
                     "<heading level=\"{}\">",
-                    level.unwrap().clamp(1, 6)
+                    (level.unwrap().saturating_add(1)).clamp(2, 6)
                 ));
             }
             "title" => out.push_str("<heading level=\"1\">"),
-            "otsl" => out.push_str("<table>"),
+            "otsl" => {
+                table_open_at = Some(out.len());
+                out.push_str("<table>");
+            }
+            "picture" if closers.contains("picture") => {
+                picture_depth += 1;
+                out.push('<');
+                out.push_str(inner);
+                out.push('>');
+            }
+            "caption" if picture_depth == 0 && closers.contains("caption") => {
+                out.push_str("<text>")
+            }
             // DocLang list items are `<ldiv/>` markers followed by the item's
             // text, not wrapper elements.
             "list_item" => out.push_str("<ldiv/>"),
@@ -526,6 +575,28 @@ fn doctags_to_doclang(fragment: &str) -> String {
         }
     }
     out
+}
+
+/// Drop every `<...>` token from a captured span, keeping only its text —
+/// used for caption bodies, whose loc tokens carry no reader-usable geometry.
+fn strip_tokens(raw: &str) -> String {
+    let mut text = String::new();
+    let mut rest = raw;
+    // Skip the opening tag itself.
+    if let Some(gt) = rest.find('>') {
+        rest = &rest[gt + 1..];
+    }
+    while let Some(lt) = rest.find('<') {
+        text.push_str(&rest[..lt]);
+        match rest[lt..].find('>') {
+            Some(gt) => rest = &rest[lt + gt + 1..],
+            None => {
+                rest = "";
+            }
+        }
+    }
+    text.push_str(rest);
+    text
 }
 
 /// PNG-encode a rendered page (the wire format every OpenAI-compatible
@@ -579,7 +650,7 @@ mod tests {
 <section_header_level_1><loc_57><loc_70><loc_420><loc_78>Optimized Table Tokenization</section_header_level_1>\
 <text><loc_57><loc_84><loc_420><loc_98>Body with A &amp; B & C.</text>\
 <unordered_list><list_item><loc_60><loc_100><loc_420><loc_108>First item</list_item></unordered_list>\
-<otsl><loc_57><loc_120><loc_420><loc_160><ched>Col A<ched>Col B<nl><fcel>1<fcel>2<nl></otsl>\
+<otsl><loc_57><loc_120><loc_420><loc_160><caption><loc_57><loc_115><loc_420><loc_119>Table 1. HPO results.</caption><ched>Col A<ched>Col B<nl><fcel>1<fcel>2<nl></otsl>\
 <page_footer><loc_57><loc_280><loc_420><loc_288>7</page_footer><page_break></doctag>";
         let fragment = doclang_fragment(page);
         let xml = format!("<doclang version=\"0.7\">{fragment}</doclang>");
@@ -593,7 +664,15 @@ mod tests {
         )
         .expect("translated DocTags must parse");
         let md = doc.export_to_markdown();
-        assert!(md.contains("# Optimized Table Tokenization"), "md: {md:?}");
+        // Section level 1 → "##" (docling parity; bare "#" is the title).
+        assert!(md.contains("## Optimized Table Tokenization"), "md: {md:?}");
+        assert!(!md.contains("### Optimized"), "md: {md:?}");
+        // The in-otsl caption hoists to a paragraph before the table.
+        assert!(md.contains("Table 1. HPO results."), "md: {md:?}");
+        assert!(
+            md.find("Table 1. HPO results.").unwrap() < md.find("Col A").unwrap(),
+            "caption must precede the table: {md:?}"
+        );
         assert!(md.contains("Body with A & B & C."), "md: {md:?}");
         assert!(md.contains("- First item"), "md: {md:?}");
         assert!(md.contains("Col A |"), "md: {md:?}");

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -488,15 +488,14 @@ fn doctags_to_doclang(fragment: &str) -> String {
         // A table caption in DocTags sits inside <otsl>; DocLang wants it as
         // a paragraph before the table. Capture the pair verbatim (dropping
         // nested tokens) and splice it in front of the <table> opener.
-        if !close && name == "caption" && table_open_at.is_some() {
+        if let Some(at) = table_open_at.filter(|_| !close && name == "caption") {
             let inner_end = fragment[i..].find("</caption>").map(|e| i + e);
             let (raw, next) = match inner_end {
                 Some(e) => (&fragment[i..e], e + "</caption>".len()),
                 None => (&fragment[i..], fragment.len()),
             };
-            let text: String = strip_tokens(raw);
+            let text = strip_tokens(raw);
             if !text.trim().is_empty() {
-                let at = table_open_at.unwrap();
                 out.insert_str(at, &format!("<text>{}</text>\n", text.trim()));
             }
             i = next;

--- a/crates/docling/src/vlm.rs
+++ b/crates/docling/src/vlm.rs
@@ -1,0 +1,337 @@
+//! VLM pipeline (issue #77) — remote OpenAI-compatible vision endpoint.
+//!
+//! The counterpart of docling's `VlmPipeline` in its remote form
+//! (`ApiVlmOptions`): each PDF page is rendered to an image, sent to an
+//! OpenAI-compatible `chat/completions` endpoint (LM Studio, Ollama, vLLM, or
+//! a hosted service) together with a DocLang-eliciting prompt, and the
+//! returned markup is parsed by the existing DocLang reader
+//! (`backend::doclang`) into a [`DoclingDocument`]. Local ONNX inference of a
+//! docling VLM is a later enhancement — this module deliberately contains no
+//! model code, just the request loop.
+//!
+//! HTTP goes over `ureq`, the crate's existing blocking client
+//! (`fetch-images` pulls the same one, keeping a single HTTP stack in the
+//! graph — the converter is synchronous, so an async client would only add a
+//! runtime). Transient failures (transport errors, 408/429, 5xx) retry with
+//! exponential backoff; anything else fails the conversion loudly — a VLM
+//! conversion with silently dropped pages would be worse than an error.
+
+use std::io::Cursor;
+use std::time::Duration;
+
+use docling_core::DoclingDocument;
+
+use crate::backend::doclang::DoclangBackend;
+use crate::backend::DeclarativeBackend;
+use crate::error::ConversionError;
+use crate::format::InputFormat;
+use crate::source::SourceDocument;
+
+/// Configuration for the remote VLM conversion. Everything has an env-var
+/// fallback so `--pipeline vlm` works without repeating flags:
+/// `DOCLING_RS_VLM_ENDPOINT`, `DOCLING_RS_VLM_MODEL`, `DOCLING_RS_VLM_PROMPT`,
+/// `DOCLING_RS_VLM_API_KEY`.
+#[derive(Debug, Clone)]
+pub struct VlmOptions {
+    /// Base URL of the OpenAI-compatible server (`http://localhost:11434/v1`)
+    /// or the full `…/chat/completions` URL — the suffix is appended when
+    /// missing, so both spellings work.
+    pub endpoint: String,
+    /// Model name as the server knows it (e.g. `granite-docling`).
+    pub model: String,
+    /// The instruction sent with every page image. Defaults to docling's
+    /// DocLang-eliciting prompt ([`DEFAULT_VLM_PROMPT`]).
+    pub prompt: Option<String>,
+    /// Bearer token, if the endpoint wants one. Local servers don't.
+    pub api_key: Option<String>,
+    /// 1-based inclusive page window (`--pages` composes with the VLM
+    /// pipeline exactly like with the ML one).
+    pub page_range: Option<(usize, usize)>,
+    /// `max_tokens` for each completion. A dense page of DocLang easily runs
+    /// long; the default (8192) fits every corpus page with headroom.
+    pub max_tokens: usize,
+}
+
+/// docling's page-conversion instruction for its DocLang-emitting VLMs.
+pub const DEFAULT_VLM_PROMPT: &str = "Convert this page to docling.";
+
+impl VlmOptions {
+    /// Build options from explicit values, falling back to the
+    /// `DOCLING_RS_VLM_*` environment. Endpoint and model are required —
+    /// there is no sensible default server to talk to.
+    pub fn resolve(
+        endpoint: Option<String>,
+        model: Option<String>,
+    ) -> Result<Self, ConversionError> {
+        let env = |k: &str| std::env::var(k).ok().filter(|v| !v.trim().is_empty());
+        let endpoint = endpoint
+            .or_else(|| env("DOCLING_RS_VLM_ENDPOINT"))
+            .ok_or_else(|| {
+                ConversionError::Parse(
+                    "vlm: no endpoint (pass --vlm-endpoint or set DOCLING_RS_VLM_ENDPOINT)".into(),
+                )
+            })?;
+        let model = model
+            .or_else(|| env("DOCLING_RS_VLM_MODEL"))
+            .ok_or_else(|| {
+                ConversionError::Parse(
+                    "vlm: no model (pass --vlm-model or set DOCLING_RS_VLM_MODEL)".into(),
+                )
+            })?;
+        Ok(Self {
+            endpoint,
+            model,
+            prompt: env("DOCLING_RS_VLM_PROMPT"),
+            api_key: env("DOCLING_RS_VLM_API_KEY"),
+            page_range: None,
+            max_tokens: 8192,
+        })
+    }
+
+    fn url(&self) -> String {
+        let base = self.endpoint.trim_end_matches('/');
+        if base.ends_with("/chat/completions") {
+            base.to_string()
+        } else {
+            format!("{base}/chat/completions")
+        }
+    }
+}
+
+/// Convert a PDF or image through the remote VLM. PDF pages render via
+/// pdfium at the ML pipeline's scale; a standalone image is sent as-is (it is
+/// its own page). Every page must convert — a failed page fails the document.
+pub fn convert_vlm(
+    source: &SourceDocument,
+    opts: &VlmOptions,
+) -> Result<DoclingDocument, ConversionError> {
+    let agent = agent();
+    let mut fragments: Vec<String> = Vec::new();
+    match source.format {
+        InputFormat::Pdf => {
+            // 1-based window → 0-based inclusive, validated like Pipeline::pages.
+            let total = docling_pdf::pdfium_backend::page_count(&source.bytes, None)
+                .map_err(|e| ConversionError::Parse(format!("vlm: open pdf: {e}")))?;
+            let range = match opts.page_range {
+                Some((first, last)) => {
+                    if first == 0 || last < first {
+                        return Err(ConversionError::Parse(format!(
+                            "invalid page range {first}-{last} (pages are 1-based, first <= last)"
+                        )));
+                    }
+                    if first > total {
+                        return Err(ConversionError::Parse(format!(
+                            "page range {first}-{last} is outside the document ({total} page(s))"
+                        )));
+                    }
+                    Some((first - 1, last.min(total) - 1))
+                }
+                None => None,
+            };
+            // `for_each_page`'s error type must absorb pdfium's own errors,
+            // so page-level VLM failures travel as PdfError strings and are
+            // rewrapped once below.
+            docling_pdf::pdfium_backend::for_each_page::<docling_pdf::PdfError, _>(
+                &source.bytes,
+                None,
+                true, // render page images — they are the whole input here
+                range,
+                |i, _total, page| {
+                    let png = encode_png(&page.image).map_err(|e| {
+                        docling_pdf::PdfError::Pdfium(format!("page {}: {e}", i + 1))
+                    })?;
+                    let markup = request_page(&agent, opts, &png).map_err(|e| {
+                        docling_pdf::PdfError::Pdfium(format!("vlm: page {}: {e}", i + 1))
+                    })?;
+                    fragments.push(doclang_fragment(&markup));
+                    Ok(())
+                },
+            )
+            .map_err(pdf_err)?;
+        }
+        InputFormat::Image => {
+            // The image file is already the page; no re-encode, no pdfium.
+            let markup = request_page(&agent, opts, &source.bytes)
+                .map_err(|e| ConversionError::Parse(format!("vlm: {e}")))?;
+            fragments.push(doclang_fragment(&markup));
+        }
+        other => {
+            return Err(ConversionError::Parse(format!(
+                "vlm pipeline converts PDF and image inputs (got {other:?})"
+            )));
+        }
+    }
+    // One document out of the per-page fragments, through the tolerant
+    // DocLang reader — exactly what a `.dclg` file would take.
+    let xml = format!(
+        "<doclang version=\"0.7\">\n{}\n</doclang>",
+        fragments.join("\n")
+    );
+    let synthetic =
+        SourceDocument::from_bytes(&source.name, InputFormat::XmlDoclang, xml.into_bytes());
+    DoclangBackend.convert(&synthetic)
+}
+
+fn pdf_err(e: docling_pdf::PdfError) -> ConversionError {
+    ConversionError::with_source("pdf", e)
+}
+
+fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(10)))
+        // A VLM can chew on a dense page for minutes, especially on CPU.
+        .timeout_global(Some(Duration::from_secs(600)))
+        // Keep non-2xx as inspectable responses for the retry decision.
+        .http_status_as_error(false)
+        .build()
+        .into()
+}
+
+/// POST one page image, return the model's text. Retries transport errors,
+/// 408/429 and 5xx with exponential backoff (2s/4s/8s); other statuses and a
+/// malformed body fail immediately.
+fn request_page(agent: &ureq::Agent, opts: &VlmOptions, image: &[u8]) -> Result<String, String> {
+    let data_uri = format!(
+        "data:image/png;base64,{}",
+        docling_core::base64::encode(image)
+    );
+    let body = serde_json::json!({
+        "model": opts.model,
+        // Deterministic-ish output: sampling noise only hurts a structured
+        // markup task (docling's ApiVlmOptions ships temperature 0 too).
+        "temperature": 0,
+        "max_tokens": opts.max_tokens,
+        "messages": [{
+            "role": "user",
+            "content": [
+                { "type": "text",
+                  "text": opts.prompt.as_deref().unwrap_or(DEFAULT_VLM_PROMPT) },
+                { "type": "image_url", "image_url": { "url": data_uri } },
+            ],
+        }],
+    });
+    let url = opts.url();
+    let mut delay = Duration::from_secs(2);
+    let mut last_err = String::new();
+    for attempt in 0..4 {
+        if attempt > 0 {
+            std::thread::sleep(delay);
+            delay *= 2;
+        }
+        let mut req = agent.post(&url).header("content-type", "application/json");
+        if let Some(key) = &opts.api_key {
+            req = req.header("authorization", &format!("Bearer {key}"));
+        }
+        // Hand-serialized body: the crate pulls ureq without its `json`
+        // feature (fetch-images doesn't need it), and one to_string keeps it
+        // that way.
+        let payload = serde_json::to_string(&body).expect("static json shape");
+        match req.send(payload.as_bytes()) {
+            Ok(mut resp) => {
+                let status = resp.status().as_u16();
+                let text = resp
+                    .body_mut()
+                    .read_to_string()
+                    .map_err(|e| format!("{url}: read response: {e}"))?;
+                if status == 408 || status == 429 || status >= 500 {
+                    last_err = format!("{url}: HTTP {status} (attempt {})", attempt + 1);
+                    continue;
+                }
+                if status != 200 {
+                    return Err(format!(
+                        "{url}: HTTP {status}: {}",
+                        text.chars().take(300).collect::<String>()
+                    ));
+                }
+                let parsed: serde_json::Value = serde_json::from_str(&text)
+                    .map_err(|e| format!("{url}: malformed JSON response: {e}"))?;
+                return parsed["choices"][0]["message"]["content"]
+                    .as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("{url}: no choices[0].message.content in response"));
+            }
+            Err(e) => {
+                last_err = format!("{url}: {e} (attempt {})", attempt + 1);
+            }
+        }
+    }
+    Err(format!("giving up after 4 attempts: {last_err}"))
+}
+
+/// Reduce one model response to DocLang *body* markup, ready to concatenate
+/// under a single `<doclang>` root.
+///
+/// Models wrap their answer unpredictably: Markdown code fences, a full
+/// `<doclang …>` document, a legacy `<doctag>` root, or a bare fragment of
+/// block elements. The DocLang reader is already tolerant of unknown
+/// elements/attributes, so normalization only needs to strip the wrappers —
+/// content inside an unexpected root still parses (unknown elements recurse).
+fn doclang_fragment(response: &str) -> String {
+    let mut text = response.trim();
+    // ```xml … ``` / ``` … ``` fences.
+    if let Some(rest) = text.strip_prefix("```") {
+        let rest = rest.split_once('\n').map(|(_, r)| r).unwrap_or(rest);
+        text = rest
+            .rsplit_once("```")
+            .map(|(r, _)| r)
+            .unwrap_or(rest)
+            .trim();
+    }
+    // Unwrap a <doclang>/<doctag> root down to its children.
+    for root in ["doclang", "doctag", "doctags"] {
+        let open = format!("<{root}");
+        if let Some(start) = text.find(&open) {
+            if let Some(gt) = text[start..].find('>') {
+                let inner_start = start + gt + 1;
+                let close = format!("</{root}>");
+                let inner_end = text.rfind(&close).unwrap_or(text.len());
+                if inner_start <= inner_end {
+                    return text[inner_start..inner_end].trim().to_string();
+                }
+            }
+        }
+    }
+    text.to_string()
+}
+
+/// PNG-encode a rendered page (the wire format every OpenAI-compatible
+/// server accepts as a data URI).
+fn encode_png(image: &image::RgbImage) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    image
+        .write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+        .map_err(|e| format!("encode page image: {e}"))?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::doclang_fragment;
+
+    #[test]
+    fn fragment_normalization() {
+        // Bare fragment passes through.
+        assert_eq!(doclang_fragment("<text>hi</text>"), "<text>hi</text>");
+        // Fenced answer is unwrapped.
+        assert_eq!(
+            doclang_fragment("```xml\n<text>hi</text>\n```"),
+            "<text>hi</text>"
+        );
+        // A full document root is stripped down to its body.
+        assert_eq!(
+            doclang_fragment("<doclang version=\"0.7\"><text>hi</text></doclang>"),
+            "<text>hi</text>"
+        );
+        // Legacy doctag root likewise.
+        assert_eq!(
+            doclang_fragment("<doctag><text>hi</text></doctag>"),
+            "<text>hi</text>"
+        );
+        // Prose around a fenced fragment is ignored by the fence rule only
+        // when the fence comes first; a root element wins anywhere.
+        assert_eq!(
+            doclang_fragment("Here you go:\n<doclang><heading level=\"1\">T</heading></doclang>"),
+            "<heading level=\"1\">T</heading>"
+        );
+    }
+}

--- a/crates/docling/tests/vlm.rs
+++ b/crates/docling/tests/vlm.rs
@@ -1,0 +1,169 @@
+//! e2e for issue #77: the remote-VLM pipeline against a local mock of an
+//! OpenAI-compatible `chat/completions` endpoint.
+//!
+//! The PDF test renders real pages (pdfium, no ONNX models) and skips cleanly
+//! when the pdfium library isn't around, like `tests/pages.rs`. The mock
+//! asserts the wire shape (model name, data-URI page image) and returns
+//! DocLang wrapped the way real models wrap answers (fences, full roots),
+//! exercising the normalization path end to end.
+#![cfg(feature = "vlm")]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use docling::vlm::{convert_vlm, VlmOptions};
+use docling::{InputFormat, SourceDocument};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn pdfium_ready() -> bool {
+    let lib = repo_root().join(".pdfium/lib");
+    if lib.join("libpdfium.so").exists()
+        || lib.join("libpdfium.dylib").exists()
+        || lib.join("pdfium.dll").exists()
+    {
+        std::env::set_var("PDFIUM_DYNAMIC_LIB_PATH", &lib);
+        return true;
+    }
+    std::env::var("PDFIUM_DYNAMIC_LIB_PATH").is_ok()
+}
+
+/// Minimal HTTP/1.1 server: for each expected request, read head + body,
+/// run the assertions, respond with a canned chat completion whose `content`
+/// comes from `answers`. Returns (base_url, served-count handle, join handle).
+fn mock_openai(answers: Vec<String>) -> (String, Arc<AtomicUsize>, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+    let addr = listener.local_addr().unwrap();
+    let served = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&served);
+    let handle = std::thread::spawn(move || {
+        for answer in answers {
+            let (mut conn, _) = listener.accept().expect("accept");
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            // Read until the full body arrived (Content-Length framing).
+            let body_len = loop {
+                let n = conn.read(&mut tmp).expect("read request");
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(head_end) = find(&buf, b"\r\n\r\n") {
+                    let head = String::from_utf8_lossy(&buf[..head_end]).to_ascii_lowercase();
+                    let need: usize = head
+                        .lines()
+                        .find_map(|l| l.strip_prefix("content-length:"))
+                        .and_then(|v| v.trim().parse().ok())
+                        .expect("content-length");
+                    if buf.len() >= head_end + 4 + need {
+                        break need;
+                    }
+                }
+            };
+            let head_end = find(&buf, b"\r\n\r\n").unwrap();
+            let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+            let body =
+                String::from_utf8_lossy(&buf[head_end + 4..head_end + 4 + body_len]).into_owned();
+            // Wire-shape assertions: right path, model, prompt, page image.
+            assert!(
+                head.starts_with("POST /v1/chat/completions"),
+                "path: {head}"
+            );
+            assert!(body.contains("\"model\":\"mock-docling\""), "model missing");
+            assert!(
+                body.contains("Convert this page to docling."),
+                "prompt missing"
+            );
+            assert!(
+                body.contains("data:image/png;base64,"),
+                "page image missing"
+            );
+            let payload = serde_json::json!({
+                "choices": [{ "message": { "role": "assistant", "content": answer } }]
+            })
+            .to_string();
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            conn.write_all(resp.as_bytes()).expect("write response");
+            count.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+    (format!("http://{addr}/v1"), served, handle)
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn opts(endpoint: String) -> VlmOptions {
+    VlmOptions {
+        endpoint,
+        model: "mock-docling".into(),
+        prompt: None,
+        api_key: None,
+        page_range: None,
+        max_tokens: 8192,
+    }
+}
+
+#[test]
+fn vlm_converts_pdf_pages_through_the_endpoint() {
+    if !pdfium_ready() {
+        eprintln!("skipping: pdfium library not found");
+        return;
+    }
+    // Two pages, two differently-wrapped answers — fenced and full-root — so
+    // normalization is exercised on real responses, then stitched in order.
+    let (endpoint, served, handle) = mock_openai(vec![
+        "```xml\n<heading level=\"1\">Page One</heading>\n<text>First body.</text>\n```".into(),
+        "<doclang version=\"0.7\"><text>Second body.</text></doclang>".into(),
+    ]);
+    let source =
+        SourceDocument::from_file(repo_root().join("tests/data/pdf/sources/2206.01062.pdf"))
+            .expect("pdf fixture");
+    let mut o = opts(endpoint);
+    o.page_range = Some((1, 2));
+    let doc = convert_vlm(&source, &o).expect("vlm conversion");
+    handle.join().expect("mock server");
+    assert_eq!(served.load(Ordering::SeqCst), 2, "one request per page");
+    let md = doc.export_to_markdown();
+    assert!(md.contains("# Page One"), "markdown: {md:?}");
+    assert!(md.contains("First body."), "markdown: {md:?}");
+    assert!(md.contains("Second body."), "markdown: {md:?}");
+}
+
+#[test]
+fn vlm_converts_an_image_without_pdfium() {
+    // An image input goes straight to the endpoint — no pdfium, no models —
+    // so this leg runs everywhere, keeping the wire format pinned in CI.
+    let (endpoint, served, handle) = mock_openai(vec!["<text>From an image.</text>".into()]);
+    let source = SourceDocument::from_bytes("page.png", InputFormat::Image, image_bytes());
+    let doc = convert_vlm(&source, &opts(endpoint)).expect("vlm conversion");
+    handle.join().expect("mock server");
+    assert_eq!(served.load(Ordering::SeqCst), 1);
+    assert!(doc.export_to_markdown().contains("From an image."));
+}
+
+#[test]
+fn vlm_rejects_non_visual_formats() {
+    let source = SourceDocument::from_bytes("x.md", InputFormat::Md, b"# hi".to_vec());
+    let err = convert_vlm(&source, &opts("http://127.0.0.1:1/v1".into())).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("vlm pipeline converts PDF and image"));
+}
+
+/// A tiny valid PNG via the `image` crate (same trick as docling-pdf's tests).
+fn image_bytes() -> Vec<u8> {
+    use std::io::Cursor;
+    let img = image::RgbImage::new(8, 8);
+    let mut out = Vec::new();
+    img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+        .unwrap();
+    out
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -54,7 +54,7 @@ bulk of the porting under review).
 | **Performance** | PDF ML pipeline **4.3× faster warm / 4.7× end-to-end** than Python docling at 2.3–2.6× less peak RAM (INT8 + SIMD, conformance-validated); declarative formats 20–60× warm, ~60× less RAM; XLSX sheets / PPTX slides additionally fan out over rayon (~2–3× on many-sheet/slide files, conformance byte-identical); details + methodology in [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md) |
 | **Models** | docling's own checkpoints (layout heron, TableFormer, PP-OCRv3, Whisper tiny), format-converted to ONNX by `scripts/install/export_*.py` — no retraining; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
 | **Tracking upstream** | See [§9](#9-keeping-up-with-upstream-docling): conformance is measured against the *latest published* docling on demand, so an upstream release that changes output surfaces as a concrete per-fixture diff |
-| **Not ported (by design)** | VLM full-page pipelines (§5); inline formatting is baked into text rather than structured fields (§4). The optional enrichment models (picture classification, code, formulas) **are** ported — opt-in `do_picture_classification` / `do_code_enrichment` / `do_formula_enrichment`, ONNX like the rest of the stack |
+| **Not ported (by design)** | local in-process VLM full-page inference (§5 — the remote OpenAI-compatible VLM pipeline **is** ported, #77); inline formatting is baked into text rather than structured fields (§4). The optional enrichment models (picture classification, code, formulas) **are** ported — opt-in `do_picture_classification` / `do_code_enrichment` / `do_formula_enrichment`, ONNX like the rest of the stack |
 
 ---
 
@@ -343,8 +343,13 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
 
 **Out of scope by design:**
 
-- **VLM full-page pipelines** (SmolDocling / remote VLM). Model-bound; out of
-  scope for the discriminative port. (**Audio/ASR is now done** — see §2; the
+- **Local VLM full-page inference** (SmolDocling-class models in-process).
+  Model-bound; out of scope for the discriminative port. The **remote** VLM
+  pipeline (#77) *is* implemented: `--pipeline vlm --vlm-endpoint URL
+  --vlm-model NAME` renders pages via pdfium, converts them through any
+  OpenAI-compatible vision endpoint (LM Studio / Ollama / vLLM / hosted) and
+  parses the returned DocLang with the existing reader — see the README's
+  "VLM pipeline" section. (**Audio/ASR is now done** — see §2; the
   only container gap is AVI, which symphonia cannot demux. The **enrichment
   models are now done** too: DocumentFigureClassifier-v2.5 for
   `do_picture_classification` and CodeFormulaV2 — an Idefics3-class VLM,

--- a/scripts/dev/granite_vlm_server.py
+++ b/scripts/dev/granite_vlm_server.py
@@ -33,13 +33,20 @@ DEFAULT_MODEL = "ibm-granite/granite-docling-258M"
 
 def load(model_id: str, force_cpu: bool):
     import torch
-    from transformers import AutoModelForVision2Seq, AutoProcessor
+    from transformers import AutoProcessor
+
+    # transformers v5 renamed AutoModelForVision2Seq; support both names so
+    # the shim runs on whatever the venv has.
+    try:
+        from transformers import AutoModelForImageTextToText as AutoVlm
+    except ImportError:
+        from transformers import AutoModelForVision2Seq as AutoVlm
 
     device = "cpu" if force_cpu or not torch.cuda.is_available() else "cuda"
     dtype = torch.bfloat16 if device == "cuda" else torch.float32
     print(f"loading {model_id} on {device} ({dtype}) ...", flush=True)
     processor = AutoProcessor.from_pretrained(model_id)
-    model = AutoModelForVision2Seq.from_pretrained(model_id, torch_dtype=dtype).to(device)
+    model = AutoVlm.from_pretrained(model_id, torch_dtype=dtype).to(device)
     model.eval()
     print("ready", flush=True)
     return processor, model, device

--- a/scripts/dev/granite_vlm_server.py
+++ b/scripts/dev/granite_vlm_server.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI-compatible server for granite-docling — DocTags intact.
+
+Why this exists: every llama.cpp-based server (Ollama, LM Studio) and default
+vLLM sampling detokenize model output with special tokens stripped — and
+granite-docling's DocTags *structure* tags (<text>, <section_header_level_N>,
+<otsl>, ...) are special tokens in its vocabulary, so what reaches the client
+is bare text plus <loc_N> noise. This shim runs the model through
+`transformers` and decodes with `skip_special_tokens=False`, which is the
+whole point; it exists for testing docling.rs's `--pipeline vlm` (issue #77)
+and for corpus comparison against Python docling's VLM pipeline, not for
+production serving (single-threaded, one request at a time).
+
+Usage:
+    pip install torch transformers pillow accelerate
+    python scripts/dev/granite_vlm_server.py [--port 8000] [--model ID] [--cpu]
+
+Then:
+    docling-rs --pipeline vlm --vlm-endpoint http://localhost:8000/v1 \
+               --vlm-model granite-docling <file.pdf>
+"""
+
+import argparse
+import base64
+import io
+import json
+import re
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+DEFAULT_MODEL = "ibm-granite/granite-docling-258M"
+
+
+def load(model_id: str, force_cpu: bool):
+    import torch
+    from transformers import AutoModelForVision2Seq, AutoProcessor
+
+    device = "cpu" if force_cpu or not torch.cuda.is_available() else "cuda"
+    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    print(f"loading {model_id} on {device} ({dtype}) ...", flush=True)
+    processor = AutoProcessor.from_pretrained(model_id)
+    model = AutoModelForVision2Seq.from_pretrained(model_id, torch_dtype=dtype).to(device)
+    model.eval()
+    print("ready", flush=True)
+    return processor, model, device
+
+
+def generate(processor, model, device, image, prompt: str, max_new_tokens: int) -> str:
+    import torch
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(image)).convert("RGB")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image"}, {"type": "text", "text": prompt}],
+        }
+    ]
+    templated = processor.apply_chat_template(messages, add_generation_prompt=True)
+    inputs = processor(text=templated, images=[img], return_tensors="pt").to(device)
+    with torch.no_grad():
+        out = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+    generated = out[:, inputs["input_ids"].shape[1] :]
+    # skip_special_tokens=False keeps the DocTags structure tags; only the
+    # chat-template terminators are ours to remove.
+    text = processor.batch_decode(generated, skip_special_tokens=False)[0]
+    return re.sub(r"<\|[a-z_]+\|>", "", text).strip()
+
+
+class Handler(BaseHTTPRequestHandler):
+    processor = None
+    model = None
+    device = "cpu"
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        if not self.path.endswith("/chat/completions"):
+            self.send_error(404)
+            return
+        length = int(self.headers.get("content-length", 0))
+        req = json.loads(self.rfile.read(length))
+        prompt, image = "Convert this page to docling.", None
+        for part in req.get("messages", [{}])[-1].get("content", []):
+            if part.get("type") == "text":
+                prompt = part["text"]
+            elif part.get("type") == "image_url":
+                url = part["image_url"]["url"]
+                image = base64.b64decode(url.split(",", 1)[1])
+        if image is None:
+            self.send_error(400, "no image_url part")
+            return
+        started = time.time()
+        text = generate(
+            self.processor,
+            self.model,
+            self.device,
+            image,
+            prompt,
+            int(req.get("max_tokens", 8192)),
+        )
+        print(f"page converted in {time.time() - started:.1f}s, {len(text)} chars", flush=True)
+        payload = json.dumps(
+            {
+                "object": "chat.completion",
+                "model": req.get("model", "granite-docling"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # quiet the default per-request line
+        pass
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--cpu", action="store_true", help="force CPU inference")
+    args = ap.parse_args()
+    Handler.processor, Handler.model, Handler.device = load(args.model, args.cpu)
+    print(f"serving on http://127.0.0.1:{args.port}/v1/chat/completions", flush=True)
+    HTTPServer(("127.0.0.1", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
docling's VlmPipeline in its remote (ApiVlmOptions) form: render each PDF page via pdfium, POST it (base64 PNG data URI) with docling's "Convert this page to docling." prompt to any OpenAI-compatible chat/completions endpoint (LM Studio / Ollama / vLLM / hosted), and parse the returned markup with the existing tolerant DocLang reader — per-page fragments are normalized (fence stripping, <doclang>/<doctag> root unwrapping) and stitched under one root, so the whole document goes through backend::doclang exactly like a .dclg file. Image inputs are sent as-is (they are their own page). No model code compiled in; local ONNX inference of a docling VLM stays a later enhancement.

New `vlm` cargo feature on the docling crate (in defaults — it rides the ureq + pdf machinery the default build already carries; the wasm/ no-default builds are untouched). docling::vlm::{VlmOptions, convert_vlm}; endpoint accepts a /v1 base or a full …/chat/completions URL; DOCLING_RS_VLM_{ENDPOINT,MODEL,PROMPT,API_KEY} env fallbacks. Transport errors and 408/429/5xx retry 4 attempts with 2s/4s/8s backoff; any page that still fails fails the conversion — no silently dropped pages. temperature 0, max_tokens 8192. HTTP goes over ureq, the crate's existing blocking client (the issue sketch said reqwest, but the converter is synchronous and fetch-images already pins ureq — one HTTP stack, no async runtime).

CLI: --pipeline standard|vlm, --vlm-endpoint URL, --vlm-model NAME. --pages composes (only the window renders and ships); --to md|json|dclx| chunks and --strict work via the shared buffered-output tail (factored out as output_document). Verified end to end against a local mock server: two-page conversion, per-page requests, markdown out; a missing endpoint errors with the flag/env hint.

Tests: response-normalization unit tests; a mock OpenAI server e2e that renders two real pages (skips cleanly without pdfium), asserts the wire shape (path, model, prompt, data URI) and stitches differently-wrapped answers; an image-input leg that runs everywhere; a non-visual-format rejection. Docs: README "VLM pipeline (remote endpoint)" section — explicitly infrastructure, not a conformance claim: corpus comparison against docling's VLM output still needs a live endpoint — MIGRATION.md §5 + at-a-glance row.

Refs #77



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT