### PR TITLE
dev: full OpenAI response schema in the VLM shim (#153)

### DIFF
--- a/scripts/dev/granite_vlm_server.py
+++ b/scripts/dev/granite_vlm_server.py
@@ -105,9 +105,14 @@ class Handler(BaseHTTPRequestHandler):
             int(req.get("max_tokens", 8192)),
         )
         print(f"page converted in {time.time() - started:.1f}s, {len(text)} chars", flush=True)
+        # id/created/usage: Python docling validates the response against a
+        # full OpenAI schema (pydantic OpenAiApiResponse) and rejects a
+        # payload without them; docling.rs only reads choices[0].
         payload = json.dumps(
             {
+                "id": f"chatcmpl-{int(time.time() * 1000)}",
                 "object": "chat.completion",
+                "created": int(time.time()),
                 "model": req.get("model", "granite-docling"),
                 "choices": [
                     {
@@ -116,6 +121,11 @@ class Handler(BaseHTTPRequestHandler):
                         "finish_reason": "stop",
                     }
                 ],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
             }
         ).encode()
         self.send_response(200)


### PR DESCRIPTION
Python docling validates chat-completion responses with a pydantic OpenAiApiResponse model that requires id/created (and reads usage); the shim payload lacked them, so the reference side of the corpus run failed on every request while docling.rs (which only reads choices[0]) worked. Emit the full envelope.

Refs #153



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT