### PR TITLE
wasm: OCR the whole image when layout finds no text in it (#157)

### DIFF
--- a/crates/docling-wasm/src/ocr.rs
+++ b/crates/docling-wasm/src/ocr.rs
@@ -109,8 +109,9 @@ pub async fn ocr_image(
     match to.as_deref().unwrap_or("md") {
         "md" | "markdown" => Ok(doc.export_to_markdown()),
         "json" => Ok(doc.export_to_json()),
+        "doclang" => Ok(doc.export_to_doclang()),
         other => Err(JsError::new(&format!(
-            "unknown output format {other:?} (expected \"md\" or \"json\")"
+            "unknown output format {other:?} (expected \"md\", \"json\" or \"doclang\")"
         ))),
     }
 }

--- a/crates/docling-wasm/src/scanned.rs
+++ b/crates/docling-wasm/src/scanned.rs
@@ -313,9 +313,58 @@ pub async fn convert_scanned_image(
     let (w, h) = img.dimensions();
     let mut conv = ScannedConverter::new(dict);
     conv.add_page(img.as_raw(), w, h, 1.0, layout, rec).await?;
+    // A UI screenshot (a chat window, an app view) reads as wall-to-wall
+    // `picture` to the document layout model, so region-scoped OCR never fires
+    // and the "conversion" is just the embedded bitmap. Degrade to what stage 1
+    // always did for plain images: line-segment the whole bitmap and recognize
+    // every line — text out beats a faithful picture of the text.
+    if !conv.pages.iter().any(|(nodes, _)| nodes_have_text(nodes)) {
+        return crate::ocr::ocr_image(bytes, dict, rec, to).await;
+    }
     conv.finish(name, to, images)
+}
+
+/// Does any node carry text? Pictures, page breaks and their `Located`
+/// wrappers do not; everything else (paragraphs, headings, tables, …) does.
+fn nodes_have_text(nodes: &[docling_core::Node]) -> bool {
+    use docling_core::Node;
+    nodes.iter().any(|n| match n {
+        Node::Located { inner, .. } => nodes_have_text(std::slice::from_ref(inner)),
+        Node::Picture { .. } | Node::PageBreak => false,
+        _ => true,
+    })
 }
 
 // Silence the unused warning for SIDE re-export path (the JS side sizes its
 // tensor from the buffer length, but the constant documents the contract).
 const _: u32 = SIDE;
+
+#[cfg(test)]
+mod picture_only {
+    use docling_core::Node;
+
+    /// The regression's shape: a chat screenshot assembles into pictures only
+    /// (wrapped in `Located`), which must read as "no text" so the image
+    /// converter falls back to whole-image line OCR. Any text-bearing node —
+    /// even next to pictures — keeps the layout result.
+    #[test]
+    fn picture_only_pages_read_as_textless() {
+        let pic = Node::Located {
+            location: [1, 2, 3, 4],
+            inner: Box::new(Node::Picture {
+                caption: None,
+                image: None,
+                classification: None,
+            }),
+        };
+        assert!(!super::nodes_have_text(std::slice::from_ref(&pic)));
+        assert!(!super::nodes_have_text(&[Node::PageBreak]));
+        let with_text = [
+            pic,
+            Node::Paragraph {
+                text: "hello".into(),
+            },
+        ];
+        assert!(super::nodes_have_text(&with_text));
+    }
+}


### PR DESCRIPTION
Regression from unifying the demo pages: images now go through the full lite profile, whose first step is the document layout model — and a UI screenshot (the reported case: a chat window) reads as wall-to-wall `picture` to a model trained on documents. Region-scoped OCR then never fires, and the "conversion" is just the screenshot embedded back at the user. The old stage-1 page never had the problem because it line-segmented the whole bitmap unconditionally.

convert_scanned_image now degrades instead of shrugging: when the assembled page carries no text-bearing node at all (pictures and page breaks do not count, `Located` wrappers are looked through), it falls back to exactly that stage-1 path — whole-image line segmentation plus recognition. A document image keeps the layout result, headings and tables included; ocr_image also learns the `doclang` output the other paths already offer.

Verified end to end in headless Chromium (ORT, pdf.js, models and the recognition dictionary all served locally — this sandbox cannot reach the CDNs): a chat-window mock rendered and screenshotted in the same browser comes back as text — the heading and every message recognized, avatars as image placeholders — instead of one embedded bitmap. The textless-page predicate is unit-tested; host suite green (8 tests), wasm clippy clean.

Refs #157



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT