### PR TITLE
pdf: a few typed-in form fields are not a text layer (#157)

### DIFF
--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -135,7 +135,15 @@ pub fn convert_text_layer_pages(
     }
     let mut doc = DoclingDocument::new(name);
     let mut total = 0usize;
-    for (i, page) in textparse::pdf_text_pages(bytes).into_iter().enumerate() {
+    let parsed = textparse::pdf_text_pages(bytes);
+    // A vestigial layer (a few typed-in form fields over scanned pages) is not
+    // the document's text: return the empty document, which callers already
+    // report as "no text layer" — so an OCR-capable caller falls back to OCR
+    // instead of proudly extracting thirteen characters.
+    if textparse::text_layer_is_vestigial(&parsed) {
+        return Ok(doc);
+    }
+    for (i, page) in parsed.into_iter().enumerate() {
         total += 1;
         if let Some((first, last)) = pages {
             if i + 1 < first || i + 1 > last {

--- a/crates/docling-pdf/src/textparse.rs
+++ b/crates/docling-pdf/src/textparse.rs
@@ -667,6 +667,31 @@ pub fn content_diagnosis(bytes: &[u8]) -> String {
     out
 }
 
+/// Is this "text layer" a vestige rather than the document's text?
+///
+/// Scanned forms often carry a handful of typed-in strings — a date filled
+/// into three form fields, say — on top of pages that are otherwise images.
+/// Treating that as a real text layer is the worst of both worlds: the text
+/// path proudly extracts thirteen characters, and no OCR ever runs on the
+/// letter the pages actually show. The reported form did exactly this (3
+/// lines, 13 chars, 3 pages).
+///
+/// The rule is deliberately tight so genuinely sparse *digital* documents are
+/// not misrouted into OCR: only a document averaging at most one line per page
+/// **and** totalling fewer than 32 characters is called vestigial.
+pub fn text_layer_is_vestigial(pages: &[crate::pdfium_backend::PdfPage]) -> bool {
+    let lines: usize = pages.iter().map(|p| p.cells.len()).sum();
+    if lines == 0 {
+        return true;
+    }
+    let chars: usize = pages
+        .iter()
+        .flat_map(|p| &p.cells)
+        .map(|c| c.text.chars().count())
+        .sum();
+    lines <= pages.len() && chars < 32
+}
+
 /// Why the cross-reference repair did or did not fire, for the `text_layer`
 /// diagnostic. A PDF that will not load is indistinguishable from a scan in
 /// production (both convert to nothing), so the reason has to be askable.
@@ -1974,5 +1999,52 @@ mod overpainted {
         ];
         super::drop_overpainted_cells(&mut cells);
         assert_eq!(cells.len(), 4);
+    }
+}
+
+#[cfg(test)]
+mod vestigial_layer {
+    use crate::pdfium_backend::{PdfPage, TextCell};
+
+    fn page_with(texts: &[&str]) -> PdfPage {
+        let cells = texts
+            .iter()
+            .enumerate()
+            .map(|(i, t)| TextCell {
+                text: t.to_string(),
+                l: 10.0,
+                t: 10.0 + 12.0 * i as f32,
+                r: 90.0,
+                b: 20.0 + 12.0 * i as f32,
+            })
+            .collect();
+        PdfPage::from_cells(595.0, 842.0, 1.0, cells)
+    }
+
+    /// The reported scanned form: three typed-in field values ("03", "05",
+    /// "2025") over three image pages. That must read as *no usable layer*,
+    /// so the browser routes the document to OCR instead of extracting
+    /// thirteen characters and skipping the letter entirely.
+    #[test]
+    fn typed_in_form_fields_are_not_a_text_layer() {
+        let pages = vec![
+            page_with(&["03", "05", "2025"]),
+            page_with(&[]),
+            page_with(&[]),
+        ];
+        assert!(super::text_layer_is_vestigial(&pages));
+        assert!(super::text_layer_is_vestigial(&[page_with(&[])]));
+    }
+
+    /// A short but genuine digital document — one page, a few real lines —
+    /// keeps the fast text path.
+    #[test]
+    fn sparse_but_real_documents_pass() {
+        let one_pager = vec![page_with(&[
+            "Confidential briefing",
+            "Prepared for the board meeting",
+            "Do not distribute",
+        ])];
+        assert!(!super::text_layer_is_vestigial(&one_pager));
     }
 }

--- a/crates/docling-wasm/src/digital.rs
+++ b/crates/docling-wasm/src/digital.rs
@@ -52,9 +52,12 @@ impl DigitalConverter {
     #[wasm_bindgen(constructor)]
     pub fn new(bytes: &[u8]) -> Result<DigitalConverter, JsError> {
         let pages = docling_pdf::textparse::pdf_text_pages(bytes);
-        if pages.iter().all(|p| p.cells.is_empty()) {
+        // Vestigial covers the all-empty case too — and the scanned form with a
+        // typed-in date, whose three tiny strings must not masquerade as the
+        // document's text (the letter on those pages needs OCR).
+        if docling_pdf::textparse::text_layer_is_vestigial(&pages) {
             return Err(JsError::new(
-                "PDF has no embedded text layer (scanned/image-only?) — use the OCR pipeline",
+                "PDF has no usable embedded text layer (scanned/image-only?) — use the OCR pipeline",
             ));
         }
         Ok(Self {


### PR DESCRIPTION
A scanned parental-consent form converted to almost nothing everywhere: its "text layer" is three typed-in field values — "03", "05", "2025", thirteen characters over three image pages. Every gate took that vestige at face value. The native pipeline saw cells on page 1 and skipped OCR for it, losing the letter that page actually shows. The browser's digital path saw "a text layer exists", ran layout — which finds only pictures on scanned pages — and produced six image placeholders and not one word.

text_layer_is_vestigial names the pattern: at most one line per page on average AND fewer than 32 characters in total. Deliberately tight, so short but genuine digital documents keep the fast path — the corpus's RTL fixtures (1.3-2.5 KB of text) and a three-line one-pager stay well clear of it.

Both non-ML gates now use it: convert_text_layer returns the empty document (its callers already phrase that as "no text layer", which the demo page turns into the OCR fallback), and DigitalConverter::new refuses with the same wording. The ML pipeline's per-page gate is untouched — its corpus is byte-pinned, and loosening it deserves its own change.

Verified in headless Chromium on the reporting file (local ORT/pdf.js/models — the sandbox cannot reach CDNs): the form now routes to OCR and comes back as 3.9 KB of recognized letter — "Nachste Schritte", the numbered instructions, the Tinkercad consent text — including page 1, which the native pipeline currently skips. Corpus green: docling 117, docling-pdf 43, docling-wasm 8.

Refs #157



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT