### PR TITLE
pdf: pictures no longer claim cells in orphan recovery (#165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,15 @@ validated for byte-for-byte conformance against upstream Python docling.
 
 - **Every commit must be signed off by the author.** End each commit message
   with `Signed-off-by: name <email>`.
+- **Releases are automatic on merge; only the `fix:` prefix matters.** CI
+  (`scripts/ci/bump_version.sh`): a merge whose commits are all
+  `fix:`/`perf:`/`revert:` cuts a patch (0.49.0 → 0.49.1); **any other
+  commit** — whatever its prefix — bumps the 0.x "major" (0.49.0 → 0.50.0).
+  So prefix bug fixes `fix(scope): …` and don't worry about the rest.
+  Docs/CI-only merges still release nothing (release.sh only fires when a
+  publishable crate's source changed). No automatic semver-major: v1.0.0 is
+  cut by hand (`force_version` dispatch input) when the repo hits its 100-star
+  milestone.
 - Claude Web: **Never open pull requests on `artiz/docling.rs`.** Push a `claude/<topic>`
   branch and hand back a compare link
   (`https://github.com/docling-project/docling.rs/compare/master...artiz:docling.rs:<branch>?expand=1`);

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -121,12 +121,24 @@ pub fn resolve(regions: Vec<Region>) -> Vec<Region> {
 }
 
 /// Drop a regular region that is >80% contained in a surviving special region we
-/// render **as a single unit** — a picture, or a table/table-of-contents index —
-/// ported from docling's "Remove regular clusters that are included in wrappers"
-/// step: the special absorbs it as a child (a table cell, an in-figure label), so
-/// it must not also be emitted as its own paragraph/list-item. This stops the
-/// survey list-items from appearing both inside the detected table and again as
-/// bullets (`table_mislabeled_as_picture`).
+/// render **as a single unit** — a table/table-of-contents index — ported from
+/// docling's "Remove regular clusters that are included in wrappers" step: the
+/// special absorbs it as a child (a table cell), so it must not also be emitted
+/// as its own paragraph/list-item. This stops the survey list-items from
+/// appearing both inside the detected table and again as bullets
+/// (`table_mislabeled_as_picture`).
+///
+/// `picture` regions stay in the swallow set even after #165: docling keeps a
+/// picture's contained clusters as the `PictureItem`'s *children* in the
+/// document JSON (`ReadingOrderModel._add_child_elements`), but its
+/// `MarkdownPictureSerializer` prints only the caption and the image — the
+/// children never reach the Markdown (verified against the corpus groundtruth:
+/// `amt_handbook`'s in-figure callout labels are absent). Dropping the
+/// fully-contained regulars here reproduces exactly that. What #165 *does*
+/// change is upstream, in [`add_orphan_regions`]: pictures no longer claim
+/// cells, so a line only partially under a figure box (straddling its border,
+/// ≤80 % contained) now forms an orphan region that survives this drop — those
+/// words were silently erased before, and docling emits them.
 ///
 /// `form` / `key_value_region` wrappers are deliberately **excluded**: this
 /// pipeline does not render them as a structured block (they are skipped), so
@@ -315,10 +327,23 @@ pub fn add_orphan_regions(regions: &mut Vec<Region>, cells: &[TextCell]) {
     // intersection-over-self > 0.2; only cells below that for *every* region are
     // orphans. (Our text extraction uses a stricter 0.5, but matching docling's
     // 0.2 here avoids emitting cells it already placed in a neighbouring region.)
+    //
+    // Only *regular* clusters claim cells: docling's `_find_unassigned_cells`
+    // walks `regular_clusters` alone, so a cell under a `picture` or a wrapper
+    // (`table`/`document_index`/`form`/`key_value_region`) that no regular
+    // cluster covers still becomes an orphan text cluster (#165). The orphans
+    // that end up *fully* inside the special are re-dropped by
+    // [`drop_contained_regulars`] (docling's Markdown drops them the same way
+    // — a picture's children never reach its `MarkdownPictureSerializer`
+    // output, a table's text renders through the reconstructed grid). The
+    // observable fix is the border-straddlers: a line only partially under a
+    // figure box used to lose its cells to the picture's 0.2 claim and vanish
+    // — now it forms an orphan region and is emitted, as docling does.
     let assigned = |c: &TextCell| {
         let ca = area(c.l, c.t, c.r, c.b).max(1.0);
         regions
             .iter()
+            .filter(|r| r.label != "picture" && !is_wrapper(r.label))
             .any(|r| inter(r, c.l, c.t, c.r, c.b) / ca > 0.2)
     };
     // Collect orphan cells (non-empty, unassigned), in page order.
@@ -400,6 +425,11 @@ pub fn recover_text_panels(regions: &mut Vec<Region>, cells: &[TextCell]) {
         })
         .collect();
     let mut out: Vec<Region> = Vec::with_capacity(regions.len());
+    // Synthesized paragraphs and the demoted panels' boxes are kept separate
+    // from `out` until the end: the dedup filter below must not confuse a
+    // paragraph we just built with a pre-existing region inside the panel.
+    let mut demoted_paras: Vec<Region> = Vec::new();
+    let mut demoted_boxes: Vec<(f32, f32, f32, f32)> = Vec::new();
     for (i, r) in regions.drain(..).enumerate() {
         if r.label != "picture" || captioned[i] {
             out.push(r);
@@ -468,7 +498,7 @@ pub fn recover_text_panels(regions: &mut Vec<Region>, cells: &[TextCell]) {
                 }
                 _ => {
                     if let Some((pl, pt, pr, pb)) = para.take() {
-                        out.push(Region {
+                        demoted_paras.push(Region {
                             label: "text",
                             score: r.score,
                             l: pl,
@@ -482,7 +512,7 @@ pub fn recover_text_panels(regions: &mut Vec<Region>, cells: &[TextCell]) {
             }
         }
         if let Some((pl, pt, pr, pb)) = para {
-            out.push(Region {
+            demoted_paras.push(Region {
                 label: "text",
                 score: r.score,
                 l: pl,
@@ -491,7 +521,23 @@ pub fn recover_text_panels(regions: &mut Vec<Region>, cells: &[TextCell]) {
                 b: pb,
             });
         }
+        demoted_boxes.push((r.l, r.t, r.r, r.b));
     }
+    // The paragraphs are rebuilt from *all* of the panel's cells, so any
+    // surviving text region inside a demoted panel (an orphan cluster or a
+    // layout-detected fragment — pictures no longer swallow them, #165) would
+    // say the same words twice. Consume those; wrappers and pictures stay.
+    if !demoted_boxes.is_empty() {
+        out.retain(|r| {
+            r.label == "picture" || is_wrapper(r.label) || {
+                let ra = area(r.l, r.t, r.r, r.b).max(1.0);
+                !demoted_boxes
+                    .iter()
+                    .any(|&(l, t, rr, b)| inter(r, l, t, rr, b) / ra > 0.5)
+            }
+        });
+    }
+    out.extend(demoted_paras);
     *regions = out;
 }
 
@@ -1879,6 +1925,58 @@ mod tests {
     use crate::layout::Region;
     use crate::pdfium_backend::{LinkAnnot, PdfPage, TextCell};
     use docling_core::Node;
+
+    /// #165: a picture no longer claims cells at 0.2 intersection-over-self.
+    /// A line straddling the figure border (≤80 % contained) becomes an orphan
+    /// region and survives the contained-regulars drop — before the fix its
+    /// cells were silently erased. A line fully inside the picture is still
+    /// re-dropped, matching docling's Markdown (a picture's children never
+    /// reach its serializer's output).
+    #[test]
+    fn border_straddling_lines_survive_picture_interior_is_still_dropped() {
+        let pic = Region {
+            label: "picture",
+            score: 0.9,
+            l: 0.0,
+            t: 0.0,
+            r: 100.0,
+            b: 100.0,
+        };
+        // ~35 % of this cell overlaps the picture (l=90..120 of 0..100): above
+        // the old 0.2 claim (was swallowed), below full containment (survives).
+        let straddler = TextCell {
+            text: "axis label".into(),
+            l: 90.0,
+            t: 40.0,
+            r: 120.0,
+            b: 48.0,
+        };
+        let interior = TextCell {
+            text: "in-figure callout".into(),
+            l: 10.0,
+            t: 10.0,
+            r: 60.0,
+            b: 18.0,
+        };
+        let mut regions = vec![pic];
+        super::add_orphan_regions(&mut regions, &[straddler, interior]);
+        assert_eq!(
+            regions.iter().filter(|r| r.label == "text").count(),
+            2,
+            "both unclaimed lines become orphans"
+        );
+        super::drop_contained_regulars(&mut regions);
+        let texts: Vec<(f32, f32)> = regions
+            .iter()
+            .filter(|r| r.label == "text")
+            .map(|r| (r.l, r.r))
+            .collect();
+        assert_eq!(
+            texts,
+            [(90.0, 120.0)],
+            "the straddler is emitted, the fully-contained callout is not"
+        );
+    }
 
     /// A colored terms-and-conditions panel detected as `picture` demotes into
     /// per-paragraph `text` regions (the blank line between C.7 and C.8 splits

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -595,14 +595,9 @@ impl Worker {
         // (picture_classification stays byte-exact), so the recognized cells
         // there only ever serve the panel-demotion decision above.
         if ocred && !pic_cells.is_empty() {
-            let mut probe: Vec<layout::Region> = regions
-                .iter()
-                .filter(|r| r.label != "picture")
-                .cloned()
-                .collect();
-            let keep_from = probe.len();
-            assemble::add_orphan_regions(&mut probe, &pic_cells);
-            regions.extend(probe.drain(keep_from..));
+            // Pictures (and wrappers) no longer count as claimers (#165), so
+            // the plain orphan pass places the recognized lines directly.
+            assemble::add_orphan_regions(&mut regions, &pic_cells);
         } else if !ocred && !pic_cells.is_empty() {
             // Digital page, picture kept: its speculative OCR cells must not
             // linger in the text-cell set (they were appended at the tail).

--- a/crates/docling-wasm/src/digital.rs
+++ b/crates/docling-wasm/src/digital.rs
@@ -245,14 +245,9 @@ impl DigitalConverter {
                     // Dense wide OCR text demotes the crop to paragraphs;
                     // sparse text keeps the picture and reads out beside it.
                     docling_pdf::assemble::recover_text_panels(&mut regions, &page.cells);
-                    let mut probe: Vec<Region> = regions
-                        .iter()
-                        .filter(|r| r.label != "picture")
-                        .cloned()
-                        .collect();
-                    let keep_from = probe.len();
-                    add_orphan_regions(&mut probe, &ocr_cells);
-                    regions.extend(probe.drain(keep_from..));
+                    // Pictures no longer count as claimers (#165), so the
+                    // plain orphan pass places the recognized lines directly.
+                    add_orphan_regions(&mut regions, &ocr_cells);
                 }
             }
         }

--- a/crates/docling-wasm/src/scanned.rs
+++ b/crates/docling-wasm/src/scanned.rs
@@ -250,14 +250,9 @@ impl ScannedConverter {
                 // text (a chat screenshot's bubbles) keeps the picture and
                 // reads out beside it, as before.
                 docling_pdf::assemble::recover_text_panels(&mut regions, &cells);
-                let mut probe: Vec<docling_pdf::layout::Region> = regions
-                    .iter()
-                    .filter(|r| r.label != "picture")
-                    .cloned()
-                    .collect();
-                let keep_from = probe.len();
-                docling_pdf::assemble::add_orphan_regions(&mut probe, &pcells);
-                regions.extend(probe.drain(keep_from..));
+                // Pictures no longer count as claimers (#165), so the plain
+                // orphan pass places the recognized lines directly.
+                docling_pdf::assemble::add_orphan_regions(&mut regions, &pcells);
             }
         }
 

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -29,8 +29,8 @@ are no longer scored.)
 | 2305.03393v1 | 26 | title-page reading order + author-ID run spacing |
 | normal_4pages | 50 | reading order (heading numbering, footnote order) + recovered panel text |
 | right_to_left_03 | 60 | RTL bidi |
-| table_mislabeled_as_picture | 86 | layout over-detects tables (survey rendered as tables) |
-| 2206.01062 | 80 | TableFormer multi-row headers + title-page reading order |
+| table_mislabeled_as_picture | 80 | layout over-detects tables (survey rendered as tables) |
+| 2206.01062 | 76 | TableFormer multi-row headers + title-page reading order |
 | 2203.01017v2 | 132 | TableFormer structure + reading order |
 | redp5110_sampled | 196 | TOC OTSL structure (model-level); cover-page ordering |
 
@@ -64,6 +64,16 @@ on 2203/normal_4pages/redp5110 are real recovered words (e.g.
 normal_4pages' cover publisher block), not regressions; captioned figures
 (the corpus' document screenshots) and sparse-label charts keep their crops
 and their byte-exact output — `picture_classification` stays **exact**.
+
+The #165 orphan-claimer fix mirrors docling's regular/special cluster split:
+only regular clusters claim cells (`_find_unassigned_cells` walks
+`regular_clusters` alone), so a line that merely *straddles* a figure border
+no longer loses its cells to the picture's 0.2 claim — it becomes an orphan
+text region and is emitted, as docling does. Orphans that end up fully inside
+a picture or table are still re-dropped, matching docling's Markdown (a
+picture's children never reach `MarkdownPictureSerializer` output; a table's
+text renders through the grid). Took 2206 80→76 and table_mislabeled 86→80
+with every other fixture byte-identical.
 
 ## DocLang (`.dclx`) conformance
 

--- a/scripts/ci/bump_version.sh
+++ b/scripts/ci/bump_version.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 #
-# Decide the next workspace version from the conventional-commit messages since
-# the last release tag, and print it to stdout. Prints NOTHING (exit 0) when no
-# release-worthy commit is found, so the caller can skip the release.
+# Decide the next workspace version from the commit messages since the last
+# release tag, and print it to stdout. Prints NOTHING (exit 0) when the range
+# is empty, so the caller can skip the release.
 #
-#   <type>!: …  or  "BREAKING CHANGE" in the body  -> major
-#   feat: …                                        -> minor
-#   fix:/perf:/revert: …                           -> patch
-#   docs/chore/ci/refactor/test/style/build/…      -> no release
+#   only fix:/perf:/revert: commits in the range   -> patch
+#   anything else                                  -> minor (the 0.x "major")
+#
+# Releases deliberately do NOT depend on conventional-commit prefixes: the
+# repo's de-facto style is bare area prefixes ("pdf: …", "wasm: …"), and
+# requiring feat:/fix: silently stopped every release after v0.49.0. Any
+# non-fix merge now bumps 0.49 -> 0.50; a docs/CI-only merge still releases
+# nothing because release.sh's source-change gate sees no publishable crate
+# source in the diff.
+#
+# There is intentionally NO automatic semver-major: v1.0.0 is a milestone the
+# maintainer cuts by hand (FORCE_VERSION=1.0.0 via the CI dispatch input) —
+# "когда 100 звёзд дадут". Until then everything stays 0.x.
 #
 # Pure: reads git history + the root Cargo.toml; writes nothing.
 # Usage: scripts/ci/bump_version.sh
@@ -23,15 +32,13 @@ else
   range="HEAD" # no release tag yet: consider the whole history
 fi
 
-# Subject + body of every non-merge commit in range.
-log="$(git log "$range" --no-merges --format='%s%n%b')"
+# Subjects decide the bump.
+subjects="$(git log "$range" --no-merges --format='%s')"
 
 bump=""
-if grep -qE '^[a-z]+(\([^)]*\))?!:' <<<"$log" || grep -q 'BREAKING CHANGE' <<<"$log"; then
-  bump="major"
-elif grep -qE '^feat(\([^)]*\))?:' <<<"$log"; then
+if grep -vE '^(fix|perf|revert)(\([^)]*\))?:' <<<"$subjects" | grep -q '[^[:space:]]'; then
   bump="minor"
-elif grep -qE '^(fix|perf|revert)(\([^)]*\))?:' <<<"$log"; then
+elif grep -q '[^[:space:]]' <<<"$subjects"; then
   bump="patch"
 fi
 
@@ -39,11 +46,6 @@ fi
 
 IFS=. read -r major minor patch <<<"$current"
 case "$bump" in
-major)
-  major=$((major + 1))
-  minor=0
-  patch=0
-  ;;
 minor)
   minor=$((minor + 1))
   patch=0

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #
 # Master-only release step (run by .github/workflows/ci.yml after the lint/test
-# gates pass). Computes the next version from conventional commits; if there is
-# one, it bumps the workspace version, commits + tags it, pushes to master,
-# publishes the changed crates, and assembles the GitHub Release notes (a commit
-# list since the previous tag) for the workflow to publish. A clean no-op when no
-# release-worthy commit landed since the last tag.
+# gates pass). Computes the next version from the commits since the last tag
+# (scripts/ci/bump_version.sh: fix:/perf:/revert:-only range -> patch, anything
+# else -> the 0.x "major"; no automatic 1.0.0); if there is one, it bumps the
+# workspace version, commits + tags it, pushes to master, publishes the changed
+# crates, and assembles the GitHub Release notes (a commit list since the
+# previous tag) for the workflow to publish. A clean no-op when nothing landed
+# since the last tag.
 #
 # The release commit is pushed with RELEASE_PAT (an admin token, so it satisfies
 # the master branch ruleset) and carries `[skip ci]`, so it does not re-trigger CI.
@@ -20,16 +22,17 @@ cd "$(dirname "$0")/../.."
 
 new="${FORCE_VERSION:-$(scripts/ci/bump_version.sh)}"
 if [[ -z "$new" ]]; then
-  echo "No release-worthy commits since the last tag — nothing to release."
+  echo "No commits since the last tag — nothing to release."
   exit 0
 fi
 [[ -n "${FORCE_VERSION:-}" ]] && echo ">> forced release of v$new"
 
-# A release-worthy *message* is not enough: only cut a new crates.io version when
-# a *publishable* crate's actual source changed since the last tag. This stops a
-# docs / CI / Python-binding-only change (e.g. `feat(docs): …`, `feat(docling-py): …`)
-# from minting and publishing a new version of every crate with no code change.
-# FORCE_VERSION bypasses the gate (a deliberate manual (re)publish).
+# Commits alone are not enough: only cut a new crates.io version when a
+# *publishable* crate's actual source changed since the last tag. This is what
+# stops a docs / CI / demo / Python-binding-only merge (now that every non-fix
+# commit is release-worthy) from minting and publishing a new version of every
+# crate with no code change. FORCE_VERSION bypasses the gate (a deliberate
+# manual (re)publish).
 if [[ -z "${FORCE_VERSION:-}" ]]; then
   gate_prev_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
   gate_range="${gate_prev_tag:+$gate_prev_tag..}HEAD"
@@ -42,7 +45,7 @@ if [[ -z "${FORCE_VERSION:-}" ]]; then
     gate_paths+=("crates/$c/src" "crates/$c/Cargo.toml" "crates/$c/build.rs")
   done
   if [[ -z "$(git diff --name-only "$gate_range" -- "${gate_paths[@]}")" ]]; then
-    echo "Release-worthy commit found, but no publishable crate source changed" \
+    echo "Commits since the last tag, but no publishable crate source changed" \
       "since ${gate_prev_tag:-the start of history} — skipping release."
     exit 0
   fi


### PR DESCRIPTION
docling's LayoutPostprocessor splits clusters into regular and special (picture + the table/document_index/form/key_value_region wrappers), and its _find_unassigned_cells walks regular_clusters alone — a special never claims a cell. Our add_orphan_regions counted every region as a claimer at 0.2 intersection-over-self, so a line that merely straddled a figure border lost its cells to the picture and vanished from the output; docling emits it as an orphan cluster.

The fix mirrors the split: only non-special regions claim cells. Orphans that end up *fully* (>80 %) inside a picture or table are still re-dropped by drop_contained_regulars — that too is docling parity, verified two ways: its MarkdownPictureSerializer prints only the caption and the image (the picture's child clusters exist in the document JSON but never reach the Markdown), and the corpus groundtruth confirms it (amt_handbook's in-figure callout labels are absent). The observable change is precisely the border-straddlers, plus the pic-OCR orphan probes in the native and browser paths collapsing into plain add_orphan_regions calls now that the claimer set is right. recover_text_panels additionally consumes any surviving text region inside a panel it demotes, so the #157 paragraphs can never double-emit with the new orphans.

Conformance moved toward docling and nothing else moved at all: 2206.01062 80→76, table_mislabeled_as_picture 86→80, every other fixture byte-identical (5/14 strict + 6/14 ws-normalized held; the XXXLutz panels still demote to text in both normal and force-OCR runs). Full battery green, wasm host tests green, clippy clean, wasm target compiles.

Refs #165



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT