### PR TITLE
ci: least-privilege GITHUB_TOKEN; serve UI renders pictures from the …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
         required: false
         default: ""
 
+# Least privilege for GITHUB_TOKEN: every job here only reads the checkout.
+# The one exception — `publish`, which pushes the release commit and tag —
+# raises it to `contents: write` on the job itself.
+permissions:
+  contents: read
+
 # Cancel superseded PR runs, but never interrupt a master run (it may publish).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -14,9 +14,9 @@ on:
     - cron: "17 4 * * 1" # Mondays 04:17 UTC
   workflow_dispatch:
 
+# Least privilege by default; the `cargo-update` job raises what it needs.
 permissions:
-  contents: write # push the deps/cargo-update branch
-  pull-requests: write # open/refresh the update PR
+  contents: read
 
 jobs:
   # Weekly known-CVE scan of the committed lockfiles. Runs unconditionally
@@ -68,6 +68,9 @@ jobs:
 
   cargo-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the deps/cargo-update branch
+      pull-requests: write # open/refresh the update PR
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,6 +42,12 @@ on:
         type: boolean
         default: false
 
+# Least privilege for GITHUB_TOKEN: publishing goes to npm with NPM_TOKEN, so
+# the token only needs the checkout. `publish-cuda`, which uploads binaries to
+# a GitHub release, raises it to `contents: write` on the job itself.
+permissions:
+  contents: read
+
 concurrency:
   group: npm-publish-${{ inputs.tag || github.ref }}
   cancel-in-progress: false

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -170,7 +170,12 @@ function findDataImageSpans(text) {
     if (start === -1) break;
     const marker = text.indexOf(';base64,', start);
     const subtype = marker === -1 ? '' : text.slice(start + 11, marker);
-    if (marker === -1 || subtype.length > 20 || !/^[a-z.+-]+$/.test(subtype)) {
+    // `svg+xml` is excluded on purpose: an SVG is markup, and while a browser
+    // does not run scripts in one loaded through <img src>, the pipeline never
+    // emits SVG pictures anyway (crops are PNG) — so a data:image/svg+xml run
+    // in the output is not ours to render.
+    if (marker === -1 || subtype.length > 20 || !/^[a-z.+-]+$/.test(subtype)
+        || subtype === 'svg+xml') {
       from = start + 11;
       continue;
     }
@@ -263,18 +268,28 @@ $('go').addEventListener('click', async () => {
       return;
     }
     // Stream the body into the panel as it arrives (Markdown streams page by page).
+    // The text is accumulated in a variable and mirrored into the panel, never
+    // read back out of it: re-reading a multi-megabyte textContent per chunk is
+    // quadratic, and the gallery must render from the response we received
+    // rather than from DOM text (CodeQL js/xss-through-dom).
     out.textContent = '';
+    let body = '';
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
-      out.textContent += decoder.decode(value, { stream: true });
+      const chunk = decoder.decode(value, { stream: true });
+      body += chunk;
+      out.textContent += chunk;
     }
     if (to === 'json' || to === 'chunks') {
-      try { out.textContent = JSON.stringify(JSON.parse(out.textContent), null, 2); } catch {}
+      try {
+        body = JSON.stringify(JSON.parse(body), null, 2);
+        out.textContent = body;
+      } catch {}
     }
-    try { renderImages(out.textContent, to); } catch (e) { console.error('gallery:', e); }
+    try { renderImages(body, to); } catch (e) { console.error('gallery:', e); }
   } catch (e) {
     out.classList.add('err');
     out.textContent = String(e);


### PR DESCRIPTION
…response

Clears the open CodeQL code-scanning alerts on master.

Workflow permissions (8 medium alerts, actions/missing-workflow-permissions): ci.yml and npm-publish.yml declared no `permissions:` block, so every job ran with the repository's default GITHUB_TOKEN scope. Both now default to `contents: read` at the top level, with the two jobs that need more keeping their existing job-level grants (ci's `publish` pushes the release commit and tag; npm-publish's `publish-cuda` uploads binaries to a GitHub release — npm publishing itself uses NPM_TOKEN, not the workflow token). deps-update.yml was not flagged but had the same shape inverted — write for both jobs where only `cargo-update` opens the PR — so the grant moves onto that job and the weekly `audit` job drops to read.

DOM text reinterpreted as HTML (1 high, js/xss-through-dom): the serve UI streamed the conversion into the result panel and then re-read `out.textContent` to find embedded `data:image/...` URIs for the gallery, so DOM text flowed into `img.src`. The response is now accumulated in a variable and mirrored into the panel — the gallery renders from what we received, never from the DOM — which also drops a quadratic re-read of a multi-megabyte textContent per chunk. The span scanner additionally skips `svg+xml`: an SVG is markup, and the pipeline only ever emits PNG crops, so such a run in the output is not ours to render.

Verified: docling-serve suites green, the UI script parses (node --check), and the span scanner keeps a PNG data URI while rejecting an SVG one.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT