### PR TITLE
serve: async job API + batch uploads, conversion confidence in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,29 @@ curl -F file=@page.html   'localhost:5001/v1/convert?to=chunks'  # chunk records
 curl -H 'content-type: application/json' \
      -d '{"url": "https://example.com/doc.pdf", "to": "md"}' \
      localhost:5001/v1/convert                                   # fetch a URL
+
+curl -F file=@a.pdf -F file=@b.docx localhost:5001/v1/convert    # batch → JSON results array
+
+id=$(curl -F file=@big.pdf localhost:5001/v1/convert/async | jq -r .task_id)
+curl localhost:5001/v1/status/$id                                # pending|started|success|failure
+curl localhost:5001/v1/result/$id                                # the output, once done
 ```
+
+Long conversions don't have to hold the connection: `POST /v1/convert/async`
+accepts the same request and returns a task id immediately — poll
+`/v1/status/{id}`, fetch `/v1/result/{id}` (kept `--result-ttl` seconds,
+default 10 min; at most `--queue-size` jobs queue at once). Several `file`
+parts in one request convert as a batch with per-item status. PDF/image
+responses carry a conversion-confidence report (docling-serve v1.25 parity):
+an `X-Docling-Confidence` summary header (grades `poor`/`fair`/`good`/
+`excellent` + layout/OCR/parse scores) on every format, and the full per-page
+report under a top-level `confidence` key in `to=json` bodies.
 
 Options per request: `to=md|json|dclx|chunks`, `strict`, `images=placeholder|embedded`,
 `no_ocr`, `no_table_former`, `no_text_panels`, `pages`, `ocr_lang`, `fetch_images` — as query parameters, multipart
 fields, or JSON keys (body wins). Server flags: `--addr`, `--concurrency`,
-`--max-body-mb`, `--warmup`, `--no-url-fetch`, `--strict`. A container image
+`--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`, `--no-url-fetch`,
+`--strict`. A container image
 builds from [`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfile)
 (models + pdfium baked in, or mounted with `--build-arg FETCH_ASSETS=0`).
 URL inputs make the server fetch outbound (SSRF surface): it binds loopback by

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -432,7 +432,16 @@ fn run_serve(args: Vec<String>) -> ExitCode {
                 Some(v) if v >= 1 => cfg.max_body_bytes = v * 1024 * 1024,
                 _ => return serve_usage("--max-body-mb needs a positive integer"),
             },
+            "--queue-size" => match it.next().and_then(|v| v.parse().ok()) {
+                Some(v) if v >= 1 => cfg.queue_size = v,
+                _ => return serve_usage("--queue-size needs a positive integer"),
+            },
+            "--result-ttl" => match it.next().and_then(|v| v.parse().ok()) {
+                Some(v) if v >= 1 => cfg.result_ttl_secs = v,
+                _ => return serve_usage("--result-ttl needs a positive number of seconds"),
+            },
             "--warmup" => cfg.warmup = true,
+            "--allow-url-fetch" => cfg.allow_url_fetch = true,
             "--no-url-fetch" => cfg.allow_url_fetch = false,
             "--strict" => cfg.strict = true,
             other => return serve_usage(&format!("unknown argument '{other}'")),
@@ -457,7 +466,7 @@ fn run_serve(args: Vec<String>) -> ExitCode {
 #[cfg(feature = "serve")]
 fn serve_usage(err: &str) -> ExitCode {
     eprintln!("error: {err}");
-    eprintln!("usage: docling-rs serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--warmup] [--no-url-fetch] [--strict]");
+    eprintln!("usage: docling-rs serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--queue-size N] [--result-ttl SECS] [--warmup] [--allow-url-fetch] [--strict]");
     ExitCode::from(2)
 }
 

--- a/crates/docling-core/src/confidence.rs
+++ b/crates/docling-core/src/confidence.rs
@@ -1,0 +1,298 @@
+//! Conversion-confidence report — the Rust counterpart of docling's
+//! `ConfidenceReport` / `PageConfidenceScores` (`docling.datamodel.base_models`,
+//! surfaced per conversion by Python docling-serve v1.25+, #183).
+//!
+//! Semantics mirror docling exactly:
+//!
+//! - Four per-page scores, each in `[0, 1]` or *unset* (docling uses `NaN`;
+//!   here `Option<f64>` so JSON serializes as `null` instead of an invalid
+//!   `NaN` literal): `layout_score` (mean confidence of the kept layout
+//!   clusters), `ocr_score` (mean confidence of OCR-recognized cells),
+//!   `parse_score` (10th-percentile text-layer quality — the quantile
+//!   emphasises problems), `table_score` (unset; docling never assigns it
+//!   either, the field exists for wire compatibility).
+//! - A page's `mean_score`/`low_score` are the NaN-ignoring mean / 5th
+//!   percentile of its four scores; document-level `mean_score`/`low_score`
+//!   are the plain means of the per-page values (docling's
+//!   `ConfidenceReport` overrides — note: *mean*, not quantile, for both).
+//! - Document-level per-field aggregation: mean for layout/table/ocr,
+//!   10th percentile for parse.
+//! - Grades: `< 0.5` poor, `< 0.8` fair, `< 0.9` good, `≥ 0.9` excellent,
+//!   unset → unspecified.
+
+use std::collections::BTreeMap;
+
+/// docling's `QualityGrade`: a score bucketed for human consumption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QualityGrade {
+    Poor,
+    Fair,
+    Good,
+    Excellent,
+    /// No score available (e.g. a declarative conversion with no ML stages).
+    Unspecified,
+}
+
+impl QualityGrade {
+    /// docling's `_score_to_grade` thresholds.
+    pub fn from_score(score: Option<f64>) -> Self {
+        match score {
+            Some(s) if s < 0.5 => Self::Poor,
+            Some(s) if s < 0.8 => Self::Fair,
+            Some(s) if s < 0.9 => Self::Good,
+            Some(_) => Self::Excellent,
+            None => Self::Unspecified,
+        }
+    }
+
+    /// The wire spelling (docling's lowercase enum values).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Poor => "poor",
+            Self::Fair => "fair",
+            Self::Good => "good",
+            Self::Excellent => "excellent",
+            Self::Unspecified => "unspecified",
+        }
+    }
+}
+
+/// NaN-ignoring mean (docling's `np.nanmean`): `None` entries are skipped;
+/// all-unset yields `None` (where numpy would warn and return `NaN`).
+pub fn nanmean(values: &[Option<f64>]) -> Option<f64> {
+    let known: Vec<f64> = values.iter().filter_map(|v| *v).collect();
+    if known.is_empty() {
+        return None;
+    }
+    Some(known.iter().sum::<f64>() / known.len() as f64)
+}
+
+/// NaN-ignoring quantile with numpy's default linear interpolation
+/// (docling's `np.nanquantile(..., q)`).
+pub fn nanquantile(values: &[Option<f64>], q: f64) -> Option<f64> {
+    let mut known: Vec<f64> = values.iter().filter_map(|v| *v).collect();
+    if known.is_empty() {
+        return None;
+    }
+    known.sort_by(|a, b| a.total_cmp(b));
+    let pos = q * (known.len() - 1) as f64;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    if lo == hi {
+        return Some(known[lo]);
+    }
+    let frac = pos - lo as f64;
+    Some(known[lo] * (1.0 - frac) + known[hi] * frac)
+}
+
+/// One page's confidence scores (docling's `PageConfidenceScores`).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PageConfidence {
+    pub parse_score: Option<f64>,
+    pub layout_score: Option<f64>,
+    pub table_score: Option<f64>,
+    pub ocr_score: Option<f64>,
+}
+
+impl PageConfidence {
+    fn scores(&self) -> [Option<f64>; 4] {
+        // docling's aggregation order: ocr, table, layout, parse.
+        [
+            self.ocr_score,
+            self.table_score,
+            self.layout_score,
+            self.parse_score,
+        ]
+    }
+
+    /// NaN-ignoring mean of the four scores.
+    pub fn mean_score(&self) -> Option<f64> {
+        nanmean(&self.scores())
+    }
+
+    /// 5th percentile of the four scores (docling's `low_score`).
+    pub fn low_score(&self) -> Option<f64> {
+        nanquantile(&self.scores(), 0.05)
+    }
+
+    fn to_json(self) -> serde_json::Value {
+        serde_json::json!({
+            "parse_score": self.parse_score,
+            "layout_score": self.layout_score,
+            "table_score": self.table_score,
+            "ocr_score": self.ocr_score,
+            "mean_grade": QualityGrade::from_score(self.mean_score()).as_str(),
+            "low_grade": QualityGrade::from_score(self.low_score()).as_str(),
+            "mean_score": self.mean_score(),
+            "low_score": self.low_score(),
+        })
+    }
+}
+
+/// The document-level report (docling's `ConfidenceReport`): the four scores
+/// aggregated across pages, plus the per-page breakdown. Page keys are the
+/// **real 1-based page numbers** — the same numbering as the JSON export's
+/// `pages` map (#171), `--pages` windows included. (docling keys by its
+/// 0-based internal page index; ours is the more useful spelling and the
+/// difference is documented in `docs/MIGRATION.md`.)
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ConfidenceReport {
+    pub pages: BTreeMap<usize, PageConfidence>,
+}
+
+impl ConfidenceReport {
+    /// Build from per-page scores keyed by 1-based page number.
+    pub fn from_pages(pages: BTreeMap<usize, PageConfidence>) -> Self {
+        Self { pages }
+    }
+
+    fn field(&self, get: impl Fn(&PageConfidence) -> Option<f64>) -> Vec<Option<f64>> {
+        self.pages.values().map(get).collect()
+    }
+
+    /// Document `layout_score`: mean of the per-page values.
+    pub fn layout_score(&self) -> Option<f64> {
+        nanmean(&self.field(|p| p.layout_score))
+    }
+
+    /// Document `parse_score`: 10th percentile of the per-page values
+    /// (docling: quantile here too, to emphasise problem pages).
+    pub fn parse_score(&self) -> Option<f64> {
+        nanquantile(&self.field(|p| p.parse_score), 0.1)
+    }
+
+    /// Document `table_score`: mean of the per-page values.
+    pub fn table_score(&self) -> Option<f64> {
+        nanmean(&self.field(|p| p.table_score))
+    }
+
+    /// Document `ocr_score`: mean of the per-page values.
+    pub fn ocr_score(&self) -> Option<f64> {
+        nanmean(&self.field(|p| p.ocr_score))
+    }
+
+    /// Document `mean_score`: mean of the per-page mean scores.
+    pub fn mean_score(&self) -> Option<f64> {
+        nanmean(&self.field(|p| p.mean_score()))
+    }
+
+    /// Document `low_score`: mean (sic — docling's override uses `nanmean`,
+    /// not a quantile) of the per-page low scores.
+    pub fn low_score(&self) -> Option<f64> {
+        nanmean(&self.field(|p| p.low_score()))
+    }
+
+    pub fn mean_grade(&self) -> QualityGrade {
+        QualityGrade::from_score(self.mean_score())
+    }
+
+    pub fn low_grade(&self) -> QualityGrade {
+        QualityGrade::from_score(self.low_score())
+    }
+
+    /// The full report as JSON — docling's `ConfidenceReport` dump shape
+    /// (unset scores as `null`, grades as lowercase strings, `pages` keyed by
+    /// stringified page number).
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut value = self.summary_json();
+        value["pages"] = serde_json::Value::Object(
+            self.pages
+                .iter()
+                .map(|(n, p)| (n.to_string(), p.to_json()))
+                .collect(),
+        );
+        value
+    }
+
+    /// The document-level scores/grades only (no `pages`) — compact enough
+    /// for a response header.
+    pub fn summary_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "parse_score": self.parse_score(),
+            "layout_score": self.layout_score(),
+            "table_score": self.table_score(),
+            "ocr_score": self.ocr_score(),
+            "mean_grade": self.mean_grade().as_str(),
+            "low_grade": self.low_grade().as_str(),
+            "mean_score": self.mean_score(),
+            "low_score": self.low_score(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grades_follow_docling_thresholds() {
+        assert_eq!(QualityGrade::from_score(Some(0.49)), QualityGrade::Poor);
+        assert_eq!(QualityGrade::from_score(Some(0.5)), QualityGrade::Fair);
+        assert_eq!(QualityGrade::from_score(Some(0.79)), QualityGrade::Fair);
+        assert_eq!(QualityGrade::from_score(Some(0.8)), QualityGrade::Good);
+        assert_eq!(QualityGrade::from_score(Some(0.89)), QualityGrade::Good);
+        assert_eq!(QualityGrade::from_score(Some(0.9)), QualityGrade::Excellent);
+        assert_eq!(QualityGrade::from_score(None), QualityGrade::Unspecified);
+    }
+
+    #[test]
+    fn nan_handling_matches_numpy() {
+        // nanmean skips unset entries; all-unset is unset.
+        assert_eq!(nanmean(&[Some(0.5), None, Some(1.0)]), Some(0.75));
+        assert_eq!(nanmean(&[None, None]), None);
+        // Linear interpolation: quantile 0.05 over [0.2, 1.0] = 0.2 + 0.05*0.8.
+        let q = nanquantile(&[Some(1.0), Some(0.2)], 0.05).unwrap();
+        assert!((q - 0.24).abs() < 1e-12, "{q}");
+        // Single value: every quantile is that value.
+        assert_eq!(nanquantile(&[None, Some(0.7)], 0.1), Some(0.7));
+    }
+
+    #[test]
+    fn report_aggregates_like_docling() {
+        let mut pages = BTreeMap::new();
+        pages.insert(
+            1,
+            PageConfidence {
+                parse_score: Some(1.0),
+                layout_score: Some(0.9),
+                table_score: None,
+                ocr_score: None,
+            },
+        );
+        pages.insert(
+            2,
+            PageConfidence {
+                parse_score: Some(0.6),
+                layout_score: Some(0.7),
+                table_score: None,
+                ocr_score: Some(0.8),
+            },
+        );
+        let report = ConfidenceReport::from_pages(pages);
+        // layout: mean(0.9, 0.7); ocr: mean over the one page that has it.
+        assert_eq!(report.layout_score(), Some(0.8));
+        assert_eq!(report.ocr_score(), Some(0.8));
+        assert_eq!(report.table_score(), None);
+        // parse: 10th percentile of [0.6, 1.0] = 0.6 + 0.1*0.4.
+        let parse = report.parse_score().unwrap();
+        assert!((parse - 0.64).abs() < 1e-12, "{parse}");
+        // Document mean = mean of the page means: page1 (0.9+1.0)/2 = 0.95,
+        // page2 (0.8+0.7+0.6)/3 = 0.7 → 0.825.
+        let mean = report.mean_score().unwrap();
+        assert!((mean - 0.825).abs() < 1e-12, "{mean}");
+        assert_eq!(report.mean_grade(), QualityGrade::Good);
+
+        let json = report.to_json();
+        assert_eq!(json["mean_grade"], "good");
+        assert_eq!(json["table_score"], serde_json::Value::Null);
+        assert!(json["pages"]["1"]["layout_score"].as_f64().is_some());
+    }
+
+    #[test]
+    fn empty_report_is_unspecified() {
+        let report = ConfidenceReport::default();
+        assert_eq!(report.mean_score(), None);
+        assert_eq!(report.mean_grade(), QualityGrade::Unspecified);
+        assert_eq!(report.to_json()["low_grade"], "unspecified");
+    }
+}

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -30,6 +30,12 @@ pub struct DoclingDocument {
     /// (legacy/docling output is left byte-for-byte unchanged). The PDF backend
     /// populates this from pdfium link annotations; other backends leave it empty.
     pub links: Vec<(String, String)>,
+    /// Conversion-confidence report (#183), populated by the PDF/image ML
+    /// pipeline; `None` for declarative conversions. Deliberately **not**
+    /// part of any document export (docling keeps it on the conversion
+    /// result, outside the document schema) — docling-serve surfaces it in
+    /// the HTTP response instead.
+    pub confidence: Option<crate::confidence::ConfidenceReport>,
 }
 
 /// A single piece of document content.
@@ -420,6 +426,7 @@ impl DoclingDocument {
             strict_markdown: false,
             compact_tables: false,
             links: Vec::new(),
+            confidence: None,
         }
     }
 
@@ -464,8 +471,15 @@ impl DoclingDocument {
     /// `DoclingDocument.export_to_dict()` / `save_as_json()`. The output loads
     /// back into Python docling-core and round-trips to the same Markdown.
     pub fn export_to_json(&self) -> String {
-        serde_json::to_string_pretty(&crate::json::to_json(self))
+        serde_json::to_string_pretty(&self.export_to_json_value())
             .expect("DoclingDocument JSON is always serializable")
+    }
+
+    /// The same JSON wire format as [`Self::export_to_json`], as a
+    /// `serde_json::Value` — for callers that append response-level extras
+    /// (docling-serve adds the confidence report, #183) before serializing.
+    pub fn export_to_json_value(&self) -> serde_json::Value {
+        crate::json::to_json(self)
     }
 
     /// Serialize to DocLang XML (`<doclang version="0.7">…`), the markup that

--- a/crates/docling-core/src/lib.rs
+++ b/crates/docling-core/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod base64;
 pub mod chunker;
+pub mod confidence;
 mod doclang;
 pub mod doctags;
 mod document;
@@ -19,6 +20,7 @@ mod json;
 mod labels;
 mod markdown;
 
+pub use confidence::{ConfidenceReport, PageConfidence, QualityGrade};
 pub use doclang::inline_runs_from_markdown;
 pub use document::{
     inline_paragraph_node, ContentLayer, DoclingDocument, FieldItem, InlineRun, ListItemDclx, Node,

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -35,6 +35,8 @@ mod ocr;
 #[cfg(feature = "ocr-prep")]
 pub mod ocr_prep;
 pub mod pdfium_backend;
+#[cfg(feature = "ml")]
+pub mod quality;
 mod reading_order;
 // Pure-Rust region resampling (page→1024px box-average, crop→448 bilinear) —
 // available to the browser TableFormer path (#157 stage 3), not just `ml`.
@@ -354,9 +356,14 @@ fn decode_image_with_max_side(bytes: &[u8], max_side: u32) -> Result<image::RgbI
 }
 
 #[cfg(feature = "ml")]
-/// One page's assembled output: typed nodes plus the page's hyperlinks, kept
-/// separate so pages processed out of order can be stitched back in page order.
-type PageOut = (Vec<Node>, Vec<(String, String)>);
+/// One page's assembled output: typed nodes plus the page's hyperlinks (kept
+/// separate so pages processed out of order can be stitched back in page
+/// order) and its confidence scores (#183).
+type PageOut = (
+    Vec<Node>,
+    Vec<(String, String)>,
+    docling_core::confidence::PageConfidence,
+);
 
 #[cfg(feature = "ml")]
 /// The pool-wide TableFormer slot: one instance shared by every worker, loaded
@@ -485,13 +492,16 @@ impl Worker {
             // rescues text the detector missed — here it rescues *all* of it.
             // Pages with no embedded text layer (scanned/image-only) yield nothing;
             // convert those without `no_ocr`.
+            let parse = quality::parse_score(&page.cells);
             let mut regions = Vec::new();
             assemble::add_orphan_regions(&mut regions, &page.cells);
             let table_rows = vec![None; regions.len()];
             let enrich_out = vec![None; regions.len()];
-            return Ok(timing::timed("assemble_page", || {
+            let conf = quality::page_confidence(parse, &regions, &[]);
+            let (nodes, links) = timing::timed("assemble_page", || {
                 assemble::assemble_page(page, regions, &table_rows, &enrich_out)
-            }));
+            });
+            return Ok((nodes, links, conf));
         }
         let regions = timing::timed("layout.predict", || {
             self.layout
@@ -558,6 +568,12 @@ impl Worker {
         // is a sub-option of `do_ocr`; the no-ocr path never reaches here.)
         // Done here rather than in `process` so the batched layout path
         // (`process_batch` → `finish_page`) honors the flag too.
+        // Parse quality is scored on the extracted text layer before force-OCR
+        // discards it (docling's page-preprocessing stage runs before OCR too,
+        // so its parse_score also reflects the original text layer).
+        let parse = quality::parse_score(&page.cells);
+        // Recognition confidences of every OCR'd cell on this page → ocr_score.
+        let mut ocr_confs: Vec<f32> = Vec::new();
         if self.force_full_page_ocr {
             page.cells.clear();
             page.code_cells.clear();
@@ -643,7 +659,8 @@ impl Worker {
                     .ocr_page(&page.image, &regions, page.scale)
             })
             .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
-            page.cells = cells;
+            ocr_confs.extend(cells.iter().map(|(_, conf)| conf));
+            page.cells = cells.into_iter().map(|(cell, _)| cell).collect();
             // Table interiors carry no words yet: region-scoped OCR skips
             // table labels, and a scanned page has no pdfium text layer — so
             // TableFormer's cell matcher got an empty word list and the table
@@ -659,6 +676,8 @@ impl Worker {
                         .ocr_table_words(&page.image, &regions, page.scale)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+                ocr_confs.extend(words.iter().map(|(_, conf)| conf));
+                let words: Vec<_> = words.into_iter().map(|(cell, _)| cell).collect();
                 page.cells.extend(words.iter().cloned());
                 page.word_cells = words;
             }
@@ -709,13 +728,20 @@ impl Worker {
                 if self.ocr.is_none() {
                     self.ocr = Some(ocr::OcrModel::load(self.ocr_lang).map_err(PdfError::Ocr)?);
                 }
-                pic_cells = timing::timed("ocr.pictures", || {
+                let scored = timing::timed("ocr.pictures", || {
                     self.ocr
                         .as_mut()
                         .unwrap()
                         .ocr_page(&page.image, &bare, page.scale)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+                // Speculative in-picture OCR counts toward ocr_score only on
+                // OCR'd pages, where the recognized lines actually join the
+                // output; on a digital page they may be discarded below.
+                if ocred {
+                    ocr_confs.extend(scored.iter().map(|(_, conf)| conf));
+                }
+                pic_cells = scored.into_iter().map(|(cell, _)| cell).collect();
                 page.cells.extend(pic_cells.iter().cloned());
             }
         }
@@ -908,9 +934,13 @@ impl Worker {
                 });
             }
         }
-        Ok(timing::timed("assemble_page", || {
+        // Score the final region set (docling assigns layout_score over the
+        // postprocessed clusters — the same set assemble_page consumes).
+        let conf = quality::page_confidence(parse, &regions, &ocr_confs);
+        let (nodes, links) = timing::timed("assemble_page", || {
             assemble::assemble_page(page, regions, &table_rows, &enrich_out)
-        }))
+        });
+        Ok((nodes, links, conf))
     }
 }
 
@@ -1255,6 +1285,7 @@ impl Pipeline {
         range: Option<(usize, usize)>,
     ) -> Result<DoclingDocument, PdfError> {
         let mut doc = DoclingDocument::new(name);
+        let mut confs = std::collections::BTreeMap::new();
         let render_image = !self.no_ocr;
         let worker = self.primary()?;
         pdfium_backend::for_each_page(
@@ -1263,14 +1294,16 @@ impl Pipeline {
             render_image,
             range,
             |n, _total, mut page| {
-                let (mut nodes, links) = worker.process(n, &mut page)?;
+                let (mut nodes, links, conf) = worker.process(n, &mut page)?;
                 assemble::stamp_page_no(&mut nodes, n + 1);
                 doc.nodes.extend(nodes);
                 doc.links.extend(links);
+                confs.insert(n + 1, conf);
                 Ok::<(), PdfError>(())
             },
         )?;
         assemble::merge_continuations(&mut doc.nodes);
+        doc.confidence = Some(docling_core::ConfidenceReport::from_pages(confs));
         Ok(doc)
     }
 
@@ -1373,12 +1406,15 @@ impl Pipeline {
             .unwrap();
         results.sort_by_key(|(idx, _)| *idx);
         let mut doc = DoclingDocument::new(name);
-        for (idx, (mut nodes, links)) in results {
+        let mut confs = std::collections::BTreeMap::new();
+        for (idx, (mut nodes, links, conf)) in results {
             assemble::stamp_page_no(&mut nodes, idx + 1);
             doc.nodes.extend(nodes);
             doc.links.extend(links);
+            confs.insert(idx + 1, conf);
         }
         assemble::merge_continuations(&mut doc.nodes);
+        doc.confidence = Some(docling_core::ConfidenceReport::from_pages(confs));
         Ok(doc)
     }
 
@@ -1437,7 +1473,10 @@ impl Pipeline {
             render_image,
             range,
             |n, _total, mut page| {
-                let (nodes, links) = worker.process(n, &mut page)?;
+                // Confidence is dropped on the streaming path: the report is
+                // only complete once every page has run, which defeats
+                // page-by-page emission — buffered `convert` carries it.
+                let (nodes, links, _conf) = worker.process(n, &mut page)?;
                 emit(asm.push(nodes), links)
             },
         )?;
@@ -1551,7 +1590,7 @@ impl Pipeline {
                         if first_err.is_some() {
                             continue; // keep draining so the threads can exit
                         }
-                        while let Some((nodes, links)) = buffer.remove(&next) {
+                        while let Some((nodes, links, _conf)) = buffer.remove(&next) {
                             if let Err(e) = emit(asm.push(nodes), links) {
                                 first_err = Some(e);
                                 break;
@@ -1642,14 +1681,17 @@ impl Pipeline {
         name: &str,
     ) -> Result<DoclingDocument, PdfError> {
         let mut doc = DoclingDocument::new(name);
+        let mut confs = std::collections::BTreeMap::new();
         let worker = self.primary()?;
         for (n, page) in pages.iter_mut().enumerate() {
-            let (mut nodes, links) = worker.process(n, page)?;
+            let (mut nodes, links, conf) = worker.process(n, page)?;
             assemble::stamp_page_no(&mut nodes, n + 1);
             doc.nodes.extend(nodes);
             doc.links.extend(links);
+            confs.insert(n + 1, conf);
         }
         assemble::merge_continuations(&mut doc.nodes);
+        doc.confidence = Some(docling_core::ConfidenceReport::from_pages(confs));
         Ok(doc)
     }
 }

--- a/crates/docling-pdf/src/ocr.rs
+++ b/crates/docling-pdf/src/ocr.rs
@@ -13,7 +13,7 @@ use crate::layout::Region;
 // The ONNX-free half (line prep, batching, CTC decode) lives in `ocr_prep`
 // so the wasm build shares it verbatim (#79 phase 2).
 use crate::ocr_prep::{
-    batch_input, decode_row, dict_chars, prep_region_lines, prep_table_words, width_batches,
+    batch_input, decode_row_scored, dict_chars, prep_region_lines, prep_table_words, width_batches,
     PrepLine, REC_HEIGHT,
 };
 use crate::pdfium_backend::TextCell;
@@ -135,7 +135,7 @@ impl OcrModel {
         w: usize,
         chunk: &[usize],
         lines: &[PrepLine],
-    ) -> Result<Vec<String>, String> {
+    ) -> Result<Vec<(String, f32)>, String> {
         let n = chunk.len();
         let data = batch_input(w, chunk, lines);
         let input = Tensor::from_array(([n, 3, REC_HEIGHT as usize, w], data))
@@ -151,7 +151,7 @@ impl OcrModel {
         let nc = shape[2] as usize;
         Ok((0..n)
             .map(|i| {
-                decode_row(
+                decode_row_scored(
                     &self.chars,
                     &probs[i * t_len * nc..(i + 1) * t_len * nc],
                     nc,
@@ -161,20 +161,22 @@ impl OcrModel {
     }
 
     /// OCR a page: produce text cells (page points) for every line found inside
-    /// the text regions. `scale` is image-px per page-point.
+    /// the text regions, each paired with its recognition confidence (mean
+    /// emitted-character probability — feeds the page `ocr_score`, #183).
+    /// `scale` is image-px per page-point.
     pub fn ocr_page(
         &mut self,
         img: &RgbImage,
         regions: &[Region],
         scale: f32,
-    ) -> Result<Vec<TextCell>, String> {
+    ) -> Result<Vec<(TextCell, f32)>, String> {
         // Gather every line crop on the page first (shared with the browser
         // path), so equal-width lines can share a recognition run regardless
         // of which region they came from.
         let (bboxes, lines) = prep_region_lines(img, regions, scale);
 
         // Deterministic width-batching (shared with the wasm path).
-        let mut texts = vec![String::new(); lines.len()];
+        let mut texts = vec![(String::new(), 0.0f32); lines.len()];
         for (w, chunk) in width_batches(&lines) {
             for (&i, text) in chunk.iter().zip(self.recognize_batch(w, &chunk, &lines)?) {
                 texts[i] = text;
@@ -183,12 +185,12 @@ impl OcrModel {
 
         // Emit cells in page order, exactly as the sequential walk did.
         let mut cells = Vec::new();
-        for ((l, t, r, b), text) in bboxes.into_iter().zip(texts) {
+        for ((l, t, r, b), (text, conf)) in bboxes.into_iter().zip(texts) {
             let text = text.trim().to_string();
             if text.is_empty() {
                 continue;
             }
-            cells.push(TextCell { text, l, t, r, b });
+            cells.push((TextCell { text, l, t, r, b }, conf));
         }
         Ok(cells)
     }
@@ -203,21 +205,21 @@ impl OcrModel {
         img: &RgbImage,
         regions: &[Region],
         scale: f32,
-    ) -> Result<Vec<TextCell>, String> {
+    ) -> Result<Vec<(TextCell, f32)>, String> {
         let (bboxes, lines) = prep_table_words(img, regions, scale);
-        let mut texts = vec![String::new(); lines.len()];
+        let mut texts = vec![(String::new(), 0.0f32); lines.len()];
         for (w, chunk) in width_batches(&lines) {
             for (&i, text) in chunk.iter().zip(self.recognize_batch(w, &chunk, &lines)?) {
                 texts[i] = text;
             }
         }
         let mut cells = Vec::new();
-        for ((l, t, r, b), text) in bboxes.into_iter().zip(texts) {
+        for ((l, t, r, b), (text, conf)) in bboxes.into_iter().zip(texts) {
             let text = text.trim().to_string();
             if text.is_empty() {
                 continue;
             }
-            cells.push(TextCell { text, l, t, r, b });
+            cells.push((TextCell { text, l, t, r, b }, conf));
         }
         Ok(cells)
     }

--- a/crates/docling-pdf/src/ocr_prep.rs
+++ b/crates/docling-pdf/src/ocr_prep.rs
@@ -63,8 +63,18 @@ pub fn dict_chars(dict: &str) -> Vec<String> {
 
 /// Greedy CTC decode of one row's `(T, C)` probabilities.
 pub fn decode_row(chars: &[String], probs: &[f32], nc: usize) -> String {
+    decode_row_scored(chars, probs, nc).0
+}
+
+/// [`decode_row`] plus the line's recognition confidence: the mean probability
+/// of the emitted characters (PaddleOCR's per-line score — what docling's
+/// `TextCell.confidence` carries for OCR cells, feeding the `ocr_score`
+/// confidence aggregate, #183). `0.0` when nothing decodes.
+pub fn decode_row_scored(chars: &[String], probs: &[f32], nc: usize) -> (String, f32) {
     let mut out = String::new();
     let mut prev = 0usize;
+    let mut conf_sum = 0.0f32;
+    let mut conf_n = 0usize;
     for row in probs.chunks_exact(nc) {
         let mut best = 0usize;
         let mut bestv = row[0];
@@ -77,11 +87,18 @@ pub fn decode_row(chars: &[String], probs: &[f32], nc: usize) -> String {
         if best != prev && best != 0 {
             if let Some(ch) = chars.get(best) {
                 out.push_str(ch);
+                conf_sum += bestv;
+                conf_n += 1;
             }
         }
         prev = best;
     }
-    out
+    let conf = if conf_n == 0 {
+        0.0
+    } else {
+        conf_sum / conf_n as f32
+    };
+    (out, conf)
 }
 
 pub(crate) fn luma(p: &Rgb<u8>) -> f32 {

--- a/crates/docling-pdf/src/quality.rs
+++ b/crates/docling-pdf/src/quality.rs
@@ -1,0 +1,172 @@
+//! Per-page conversion-confidence scoring (#183) — the Rust port of docling's
+//! confidence plumbing: `rate_text_quality` from the page-preprocessing stage
+//! (parse quality of the extracted text layer) and the layout/OCR score
+//! aggregation the layout-postprocessing and OCR stages assign.
+
+use std::sync::OnceLock;
+
+use docling_core::confidence::{nanmean, nanquantile, PageConfidence};
+use regex::Regex;
+
+use crate::layout::Region;
+use crate::pdfium_backend::TextCell;
+
+/// docling's `rate_text_quality`: score one text cell's extraction quality.
+/// Hard garbage (replacement chars, `GLYPH<..>` references, `/G123`-style
+/// glyph ids, mostly-slash-number content) is a 0.0; otherwise fragmented-word
+/// runs (`W/or.ds/sp.lit` artifacts) are penalised 0.1 each once at least
+/// three appear.
+pub fn rate_text_quality(text: &str) -> f64 {
+    static GLYPH_RE: OnceLock<Regex> = OnceLock::new();
+    static SLASH_G_RE: OnceLock<Regex> = OnceLock::new();
+    static FRAG_RE: OnceLock<Regex> = OnceLock::new();
+    static SLASH_NUMBER_GARBAGE_RE: OnceLock<Regex> = OnceLock::new();
+    let glyph = GLYPH_RE.get_or_init(|| Regex::new(r"GLYPH<[0-9A-Fa-f]+>").unwrap());
+    let slash_g = SLASH_G_RE.get_or_init(|| Regex::new(r"(?:/G\d+){2,}").unwrap());
+    let frag =
+        FRAG_RE.get_or_init(|| Regex::new(r"\b[A-Za-z](?:/[a-z]{1,3}\.[a-z]{1,3}){2,}\b").unwrap());
+    // Python's `.match` anchors at the start of the string only.
+    let slash_number =
+        SLASH_NUMBER_GARBAGE_RE.get_or_init(|| Regex::new(r"^(?:/\w+\s*){2,}").unwrap());
+
+    if text.contains('\u{fffd}')
+        || glyph.is_match(text)
+        || slash_g.is_match(text)
+        || slash_number.is_match(text)
+    {
+        return 0.0;
+    }
+    let frag_matches = frag.find_iter(text).count();
+    let mut penalty = 0.0;
+    if frag_matches >= 3 {
+        penalty += 0.1 * frag_matches as f64;
+    }
+    (1.0 - penalty).max(0.0)
+}
+
+/// The page `parse_score`: the 10th-percentile `rate_text_quality` over the
+/// extracted text-layer cells (the quantile emphasises problem cells, matching
+/// docling's page-preprocessing stage). Unset when the page has no text layer
+/// (a scanned page — docling's `nanquantile([])` is `NaN` there too).
+pub fn parse_score(cells: &[TextCell]) -> Option<f64> {
+    let scores: Vec<Option<f64>> = cells
+        .iter()
+        .map(|c| Some(rate_text_quality(&c.text)))
+        .collect();
+    nanquantile(&scores, 0.10)
+}
+
+/// The page `layout_score`: mean confidence of the final (postprocessed)
+/// layout regions — `Some(0.0)` for a region-less page, exactly like
+/// docling's `float(np.mean(...)) if clusters else 0.0`.
+///
+/// Orphan-text regions carry the sentinel score `0.0` (detector scores always
+/// clear their ≥ 0.3 label thresholds, so 0.0 can only mean "rescued cell").
+/// docling scores an orphan cluster with its *cell's* confidence: 1.0 for a
+/// text-layer cell, the recognition confidence for an OCR cell — substitute
+/// accordingly (`ocr_mean` is the page's mean OCR confidence when the cells
+/// came from OCR, `None` on a digital page).
+pub fn layout_score(regions: &[Region], ocr_mean: Option<f64>) -> Option<f64> {
+    if regions.is_empty() {
+        return Some(0.0);
+    }
+    let scores: Vec<Option<f64>> = regions
+        .iter()
+        .map(|r| {
+            if r.score == 0.0 {
+                Some(ocr_mean.unwrap_or(1.0))
+            } else {
+                Some(r.score as f64)
+            }
+        })
+        .collect();
+    nanmean(&scores)
+}
+
+/// The page `ocr_score`: mean recognition confidence over the page's OCR'd
+/// cells; unset when nothing on the page came from OCR (docling only assigns
+/// it when OCR cells exist).
+pub fn ocr_score(confs: &[f32]) -> Option<f64> {
+    if confs.is_empty() {
+        return None;
+    }
+    Some(confs.iter().map(|&c| c as f64).sum::<f64>() / confs.len() as f64)
+}
+
+/// Assemble the page's [`PageConfidence`] (`table_score` stays unset — docling
+/// never assigns it either).
+pub fn page_confidence(
+    parse: Option<f64>,
+    regions: &[Region],
+    ocr_confs: &[f32],
+) -> PageConfidence {
+    let ocr = ocr_score(ocr_confs);
+    PageConfidence {
+        parse_score: parse,
+        layout_score: layout_score(regions, ocr),
+        table_score: None,
+        ocr_score: ocr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_quality_matches_docling_rules() {
+        assert_eq!(rate_text_quality("A perfectly ordinary sentence."), 1.0);
+        // Hard garbage → 0.0.
+        assert_eq!(rate_text_quality("bad \u{fffd} char"), 0.0);
+        assert_eq!(rate_text_quality("see GLYPH<0a3F> here"), 0.0);
+        assert_eq!(rate_text_quality("/G12/G34 rest"), 0.0);
+        assert_eq!(rate_text_quality("/x1 /y2 tail"), 0.0);
+        // The slash-number pattern only fires anchored at the start.
+        assert_eq!(rate_text_quality("word /x1 /y2"), 1.0);
+        // Fragmented words (a letter then ≥2 `/xx.yy` runs): below three
+        // matches no penalty applies; at three, 0.1 each.
+        let frag = "W/or.ds/sp.lit";
+        assert_eq!(rate_text_quality(frag), 1.0, "one match is tolerated");
+        assert_eq!(rate_text_quality(&format!("{frag} {frag}")), 1.0);
+        let three = format!("{frag} {frag} {frag}");
+        assert!((rate_text_quality(&three) - 0.7).abs() < 1e-12, "{three}");
+    }
+
+    #[test]
+    fn parse_score_is_tenth_percentile() {
+        let cell = |text: &str| TextCell {
+            text: text.into(),
+            l: 0.0,
+            t: 0.0,
+            r: 1.0,
+            b: 1.0,
+        };
+        assert_eq!(parse_score(&[]), None);
+        // Nine clean cells and one garbage cell: the 10th percentile sits at
+        // the interpolation between the sorted [0.0, 1.0 × 9] head.
+        let mut cells = vec![cell("ok"); 9];
+        cells.push(cell("GLYPH<12>"));
+        let s = parse_score(&cells).unwrap();
+        assert!((s - 0.9).abs() < 1e-9, "{s}");
+    }
+
+    #[test]
+    fn layout_score_substitutes_orphan_sentinel() {
+        let region = |score: f32| Region {
+            label: "text",
+            score,
+            l: 0.0,
+            t: 0.0,
+            r: 1.0,
+            b: 1.0,
+        };
+        assert_eq!(layout_score(&[], None), Some(0.0));
+        // Digital page: the 0.0-score orphan counts as a 1.0-confidence cell.
+        // (Tolerance covers the f32 detector score widened to f64.)
+        let s = layout_score(&[region(0.8), region(0.0)], None).unwrap();
+        assert!((s - 0.9).abs() < 1e-6, "{s}");
+        // OCR'd page: orphans inherit the page's mean OCR confidence.
+        let s = layout_score(&[region(0.8), region(0.0)], Some(0.6)).unwrap();
+        assert!((s - 0.7).abs() < 1e-6, "{s}");
+    }
+}

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "0.52.6"
+version = "0.52.9"
 dependencies = [
  "calamine",
  "csv",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "0.52.6"
+version = "0.52.9"
 dependencies = [
  "docling-core",
  "ort",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "0.52.6"
+version = "0.52.9"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "0.52.6"
+version = "0.52.9"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -83,7 +83,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
   <div class="row">
     <label><input type="radio" name="mode" value="file" checked> Upload</label>
     <label id="url-mode"><input type="radio" name="mode" value="url"> URL</label>
-    <input type="file" id="file">
+    <input type="file" id="file" multiple>
     <input type="text" id="url" placeholder="https://example.com/document.pdf" style="display:none">
   </div>
   <div class="hint" id="url-disabled-note" style="display:none">
@@ -114,8 +114,10 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
     (it's an outbound-fetch / SSRF surface, so off by default; see docs/SECURITY.md).
   </div>
   <div class="hint">PDF/image inputs run the ML pipeline — the first conversion loads the models
-  (tens of seconds), repeats are fast. Markdown responses stream in as they convert.</div>
+  (tens of seconds), repeats are fast. Markdown responses stream in as they convert.
+  Picking <em>several</em> files converts them as one batch (JSON results array).</div>
   <div class="out">
+    <div class="hint" id="confidence" style="display:none"></div>
     <pre id="result" style="display:none"></pre>
     <div class="gallery" id="gallery"></div>
   </div>
@@ -126,8 +128,19 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
   <tr><th>Method</th><th>Path</th><th>Description</th></tr>
   <tr><td><code>POST</code></td><td><code>/v1/convert</code></td>
       <td>Convert an upload (<code>multipart/form-data</code>, a <code>file</code> part — the filename's
-      extension selects the input format) or a URL (<code>application/json</code>:
-      <code>{"url": …, "file_name"?: …}</code>).</td></tr>
+      extension selects the input format; several <code>file</code> parts convert as a batch and
+      answer a JSON <code>results</code> array) or a URL (<code>application/json</code>:
+      <code>{"url": …, "file_name"?: …}</code>). PDF/image responses carry an
+      <code>X-Docling-Confidence</code> summary header; <code>to=json</code> bodies embed the full
+      per-page confidence report.</td></tr>
+  <tr><td><code>POST</code></td><td><code>/v1/convert/async</code></td>
+      <td>The same request, answered immediately with <code>{"task_id": …}</code> — the job queues on
+      the server's concurrency bound and reuses the warm pipeline.</td></tr>
+  <tr><td><code>GET</code></td><td><code>/v1/status/{id}</code></td>
+      <td>Async job status: <code>pending</code> | <code>started</code> | <code>success</code> | <code>failure</code>.</td></tr>
+  <tr><td><code>GET</code></td><td><code>/v1/result/{id}</code></td>
+      <td>Async job result — the same response the sync endpoint would have sent; kept until the
+      result TTL (default 10&nbsp;min) evicts it.</td></tr>
   <tr><td><code>GET</code></td><td><code>/v1/config</code></td><td>Server capabilities — currently <code>{"allow_url_fetch": bool}</code>, which this page adapts to.</td></tr>
   <tr><td><code>GET</code></td><td><code>/health</code></td><td>Liveness probe.</td></tr>
   <tr><td><code>GET</code></td><td><code>/ready</code></td><td>Readiness probe — 503 until <code>--warmup</code> finishes loading the ML models.</td></tr>
@@ -158,6 +171,13 @@ curl -F file=@page.html   'localhost:5001/v1/convert?to=chunks'    # chunk recor
 curl -H 'content-type: application/json' \
      -d '{"url": "https://example.com/doc.pdf", "to": "md"}' \
      localhost:5001/v1/convert                                     # convert a URL
+
+curl -F file=@a.pdf -F file=@b.docx \
+     'localhost:5001/v1/convert?to=md'                             # batch → JSON results array
+
+id=$(curl -F file=@big.pdf localhost:5001/v1/convert/async | jq -r .task_id)
+curl localhost:5001/v1/status/$id                                  # pending|started|success|failure
+curl localhost:5001/v1/result/$id                                  # the output, once done
 
 curl -O localhost:5001/openapi.yaml                                # the API description</pre>
 </main>
@@ -261,6 +281,7 @@ $('go').addEventListener('click', async () => {
   out.style.display = '';
   out.classList.remove('err');
   $('gallery').replaceChildren();
+  $('confidence').style.display = 'none';
   const to = $('to').value;
   const opts = {
     to,
@@ -273,10 +294,10 @@ $('go').addEventListener('click', async () => {
   };
   let request;
   if (document.querySelector('input[name=mode]:checked').value === 'file') {
-    const file = $('file').files[0];
-    if (!file) { out.textContent = 'Pick a file first.'; return; }
+    const files = $('file').files;
+    if (!files.length) { out.textContent = 'Pick a file first.'; return; }
     const form = new FormData();
-    form.append('file', file);
+    for (const file of files) form.append('file', file); // several = one batch (#182)
     for (const [k, v] of Object.entries(opts)) form.append(k, String(v));
     request = fetch('/v1/convert', { method: 'POST', body: form });
   } else {
@@ -298,6 +319,17 @@ $('go').addEventListener('click', async () => {
       try { out.textContent = `HTTP ${response.status}: ${JSON.parse(body).error}`; }
       catch { out.textContent = `HTTP ${response.status}: ${body}`; }
       return;
+    }
+    // Surface the conversion-confidence summary (#183) when the ML pipeline
+    // produced one — grades tell at a glance whether the output is trustable.
+    const conf = response.headers.get('x-docling-confidence');
+    if (conf) {
+      try {
+        const c = JSON.parse(conf);
+        $('confidence').textContent =
+          `confidence: ${c.mean_grade} (mean ${Number(c.mean_score).toFixed(3)}, low ${c.low_grade})`;
+        $('confidence').style.display = '';
+      } catch { /* unparseable header — skip the banner */ }
     }
     if (to === 'dclx') {
       const blob = await response.blob();
@@ -327,7 +359,9 @@ $('go').addEventListener('click', async () => {
       body += chunk;
       out.textContent += chunk;
     }
-    if (to === 'json' || to === 'chunks') {
+    // Batch responses are JSON whatever `to` says — go by the content type.
+    const isJson = (response.headers.get('content-type') || '').includes('application/json');
+    if (isJson || to === 'json' || to === 'chunks') {
       try {
         body = JSON.stringify(JSON.parse(body), null, 2);
         out.textContent = body;

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -7,6 +7,9 @@
 //! |--------|---------------|----------------------------------------------------|
 //! | GET    | `/`           | API docs + an interactive test form                |
 //! | POST   | `/v1/convert` | convert an upload (multipart) or a URL (JSON body) |
+//! | POST   | `/v1/convert/async` | same request, returns a task id (#182)       |
+//! | GET    | `/v1/status/{id}` | async job status (pending/started/success/failure) |
+//! | GET    | `/v1/result/{id}` | async job result (the sync response, stored)   |
 //! | GET    | `/v1/config`  | server capabilities (`{"allow_url_fetch": bool}`)  |
 //! | GET    | `/health`     | liveness probe                                     |
 //! | GET    | `/ready`      | readiness probe (200 once models are warm)         |
@@ -14,8 +17,10 @@
 //! | GET    | `/logo.svg`   | the playground's logo                              |
 //!
 //! `POST /v1/convert` accepts either `multipart/form-data` with a `file` part
-//! (the filename's extension selects the input format) or an
-//! `application/json` body `{"url": "https://…", "file_name"?: "override.pdf"}`.
+//! (the filename's extension selects the input format; **several file parts
+//! make a batch**, #182 — the response is then a JSON `results` array with
+//! per-item status) or an `application/json` body
+//! `{"url": "https://…", "file_name"?: "override.pdf"}`.
 //! Options ride along as multipart text parts, JSON fields, or query
 //! parameters (body wins over query):
 //!
@@ -30,7 +35,22 @@
 //!   fetch, so honored only under `--allow-url-fetch`)
 //!
 //! Markdown converts through the streaming serializer and the response body
-//! streams page by page (chunked transfer); `json`/`dclx`/`chunks` buffer.
+//! streams page by page (chunked transfer); `json`/`dclx`/`chunks` (and every
+//! batch/async result) buffer.
+//!
+//! Responses carry the conversion-confidence report (#183) when the PDF/image
+//! ML pipeline ran: an `X-Docling-Confidence` header with the document-level
+//! summary (grades + scores, docling's `ConfidenceReport` semantics) on every
+//! output format, and a top-level `"confidence"` key with the per-page
+//! breakdown appended to `to=json` bodies. Declarative conversions have no ML
+//! stages and carry neither.
+//!
+//! `POST /v1/convert/async` (#182) accepts exactly the `/v1/convert` request
+//! and answers `202 {"task_id": …}` immediately; the job queues on the same
+//! concurrency semaphore (reusing the warm pipeline) and the result is
+//! fetched with `GET /v1/result/{id}` once `GET /v1/status/{id}` reports
+//! `success`. Results are held for `--result-ttl` seconds; at most
+//! `--queue-size` jobs may be queued/unfetched at once (429 beyond that).
 //!
 //! One warm [`Pipeline`] (layout/OCR/TableFormer sessions) is shared across
 //! requests behind a mutex — PDF/image conversions serialize on it instead of
@@ -82,6 +102,13 @@ pub struct ServeConfig {
     pub allow_url_fetch: bool,
     /// Default `strict` for requests that don't set it.
     pub strict: bool,
+    /// Maximum async jobs (#182) waiting or running at once; further
+    /// `POST /v1/convert/async` submissions are refused with 429. Bounds the
+    /// memory held by queued request bytes.
+    pub queue_size: usize,
+    /// How long a finished async job's result stays fetchable before it is
+    /// evicted (idle results are the other thing holding memory).
+    pub result_ttl_secs: u64,
 }
 
 impl Default for ServeConfig {
@@ -93,6 +120,8 @@ impl Default for ServeConfig {
             warmup: false,
             allow_url_fetch: false,
             strict: false,
+            queue_size: 16,
+            result_ttl_secs: 600,
         }
     }
 }
@@ -104,6 +133,8 @@ struct AppState {
     /// Bounds total in-flight conversions (`Arc` so a permit can move into
     /// a streaming response's worker and outlive the handler).
     permits: Arc<Semaphore>,
+    /// Async conversion jobs (#182), keyed by task id.
+    jobs: Mutex<std::collections::HashMap<String, Job>>,
     ready: AtomicBool,
     cfg: ServeConfig,
 }
@@ -113,6 +144,7 @@ pub fn router(cfg: ServeConfig) -> Router {
     let state = Arc::new(AppState {
         pipeline: Mutex::new(None),
         permits: Arc::new(Semaphore::new(cfg.concurrency.max(1))),
+        jobs: Mutex::new(std::collections::HashMap::new()),
         ready: AtomicBool::new(!cfg.warmup),
         cfg: cfg.clone(),
     });
@@ -157,6 +189,9 @@ pub fn router(cfg: ServeConfig) -> Router {
         .route("/ready", get(ready))
         .route("/v1/config", get(config))
         .route("/v1/convert", post(convert))
+        .route("/v1/convert/async", post(convert_async))
+        .route("/v1/status/{id}", get(job_status))
+        .route("/v1/result/{id}", get(job_result))
         .layer(DefaultBodyLimit::max(cfg.max_body_bytes))
         .with_state(state)
 }
@@ -307,36 +342,54 @@ enum ApiError {
     Bad(String),
     Unsupported(String),
     Internal(String),
+    /// The async job queue is full (#182) — retry later.
+    Busy(String),
+}
+
+/// The HTTP status + message an [`ApiError`] answers with (also stored on a
+/// failed async job so `/v1/result/{id}` reproduces the sync status).
+fn api_error_parts(e: ApiError) -> (StatusCode, String) {
+    match e {
+        ApiError::Bad(m) => (StatusCode::BAD_REQUEST, m),
+        ApiError::Unsupported(m) => (StatusCode::UNPROCESSABLE_ENTITY, m),
+        ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
+        ApiError::Busy(m) => (StatusCode::TOO_MANY_REQUESTS, m),
+    }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let (status, msg) = match self {
-            ApiError::Bad(m) => (StatusCode::BAD_REQUEST, m),
-            ApiError::Unsupported(m) => (StatusCode::UNPROCESSABLE_ENTITY, m),
-            ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
-        };
+        let (status, msg) = api_error_parts(self);
         (status, Json(json!({"error": msg}))).into_response()
     }
 }
 
-async fn convert(
-    State(state): State<Arc<AppState>>,
-    Query(query): Query<ConvertOptions>,
+/// One parsed upload: the source, or the filename with why it couldn't become
+/// one (a batch converts around a bad item; a single-file request propagates
+/// the error as its response).
+type SourceItem = Result<SourceDocument, (String, ApiError)>;
+
+/// Parse a conversion request body — `multipart/form-data` uploads (one or
+/// more `file` parts, #182 batch) or an `application/json` `{"url": …}` — into
+/// sources plus the merged options. Shared by the sync and async endpoints so
+/// both accept exactly the same requests (and reject bad ones synchronously).
+async fn parse_convert_request(
+    state: &Arc<AppState>,
+    query: ConvertOptions,
     headers: HeaderMap,
     body: axum::extract::Request,
-) -> Result<Response, ApiError> {
+) -> Result<(Vec<SourceItem>, ConvertOptions), ApiError> {
     let content_type = headers
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_ascii_lowercase();
 
-    let (source, options) = if content_type.starts_with("multipart/form-data") {
+    if content_type.starts_with("multipart/form-data") {
         let multipart = Multipart::from_request(body, &())
             .await
             .map_err(|e| ApiError::Bad(format!("bad multipart body: {e}")))?;
-        read_multipart(multipart, query).await?
+        read_multipart(multipart, query).await
     } else if content_type.starts_with("application/json") {
         let bytes = axum::body::to_bytes(body.into_body(), state.cfg.max_body_bytes)
             .await
@@ -356,13 +409,17 @@ async fn convert(
         let source = tokio::task::spawn_blocking(move || fetch_url(&url, name.as_deref()))
             .await
             .map_err(|e| ApiError::Internal(format!("fetch task: {e}")))??;
-        (source, options)
+        Ok((vec![Ok(source)], options))
     } else {
-        return Err(ApiError::Bad(
+        Err(ApiError::Bad(
             "expected multipart/form-data (file upload) or application/json ({\"url\": …})".into(),
-        ));
-    };
+        ))
+    }
+}
 
+/// Validate the `to` / `images` options (shared by sync and async so an async
+/// submission fails fast instead of parking a doomed job in the queue).
+fn validate_output(options: &ConvertOptions) -> Result<(String, ImageMode), ApiError> {
     let to = options.to.clone().unwrap_or_else(|| "md".into());
     if !matches!(to.as_str(), "md" | "markdown" | "json" | "dclx" | "chunks") {
         return Err(ApiError::Bad(format!(
@@ -378,6 +435,17 @@ async fn convert(
             )))
         }
     };
+    Ok((to, image_mode))
+}
+
+async fn convert(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ConvertOptions>,
+    headers: HeaderMap,
+    body: axum::extract::Request,
+) -> Result<Response, ApiError> {
+    let (sources, options) = parse_convert_request(&state, query, headers, body).await?;
+    let (to, image_mode) = validate_output(&options)?;
 
     // Bound total in-flight conversions; excess requests queue here. The
     // permit is owned so the streaming path can hold it until the response
@@ -389,58 +457,450 @@ async fn convert(
         .await
         .map_err(|e| ApiError::Internal(format!("semaphore: {e}")))?;
 
+    // A single Markdown conversion streams; everything else (other formats,
+    // #182 batches — which need per-item framing) buffers.
     let is_markdown = matches!(to.as_str(), "md" | "markdown");
-    if is_markdown {
+    if is_markdown && sources.len() == 1 {
+        let source = sources
+            .into_iter()
+            .next()
+            .expect("checked len")
+            .map_err(|(_, e)| e)?;
         return stream_markdown(state.clone(), source, options, image_mode, permit).await;
     }
-    let _permit = permit;
 
-    // Buffered outputs: convert on a blocking thread, then serialize.
     let st = state.clone();
-    let name = source.name.clone();
-    let document = tokio::task::spawn_blocking(move || convert_document(&st, source, &options))
-        .await
-        .map_err(|e| ApiError::Internal(format!("convert task: {e}")))??;
+    let stored = tokio::task::spawn_blocking(move || {
+        run_conversion(&st, sources, &options, &to, image_mode)
+    })
+    .await
+    .map_err(|e| ApiError::Internal(format!("convert task: {e}")))?;
+    drop(permit);
+    Ok(stored?.into_response())
+}
 
-    Ok(match to.as_str() {
-        "json" => (
-            [(header::CONTENT_TYPE, "application/json")],
-            document.export_to_json(),
+/// One async conversion job (#182).
+struct Job {
+    state: JobState,
+    /// When the job left the queue (finished or failed) — drives TTL eviction.
+    done_at: Option<std::time::Instant>,
+}
+
+enum JobState {
+    /// Waiting for a conversion slot (the shared semaphore).
+    Pending,
+    Started,
+    Success(StoredResponse),
+    /// The HTTP status the sync endpoint would have answered with, plus the
+    /// error message.
+    Failure(StatusCode, String),
+}
+
+impl JobState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Started => "started",
+            Self::Success(_) => "success",
+            Self::Failure(..) => "failure",
+        }
+    }
+}
+
+/// Evict finished jobs whose result has outlived the TTL. Called from the job
+/// endpoints — no background sweeper thread needed, since memory only ever
+/// accumulates through those same endpoints' submissions.
+fn purge_expired(jobs: &mut std::collections::HashMap<String, Job>, ttl_secs: u64) {
+    let ttl = std::time::Duration::from_secs(ttl_secs);
+    jobs.retain(|_, job| job.done_at.is_none_or(|done| done.elapsed() < ttl));
+}
+
+/// An unguessable task id. The result endpoint is unauthenticated (like the
+/// rest of the API), so the id doubles as the fetch capability: 128 bits from
+/// two independently random-seeded `RandomState` hashers — not a substitute
+/// for real authentication (front the server with one), but not enumerable
+/// either.
+fn task_id() -> String {
+    use std::hash::{BuildHasher, Hasher};
+    let mut h1 = std::collections::hash_map::RandomState::new().build_hasher();
+    let mut h2 = std::collections::hash_map::RandomState::new().build_hasher();
+    h1.write_u64(0);
+    h2.write_u64(1);
+    format!("{:016x}{:016x}", h1.finish(), h2.finish())
+}
+
+/// `POST /v1/convert/async` (#182): accept the same request as `/v1/convert`,
+/// but return a task id immediately instead of holding the connection for the
+/// duration of the conversion. The job queues on the same semaphore as sync
+/// requests (reusing the warm pipeline); poll `GET /v1/status/{id}` and fetch
+/// `GET /v1/result/{id}`.
+async fn convert_async(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ConvertOptions>,
+    headers: HeaderMap,
+    body: axum::extract::Request,
+) -> Result<Response, ApiError> {
+    let (mut sources, options) = parse_convert_request(&state, query, headers, body).await?;
+    let (to, image_mode) = validate_output(&options)?;
+    // A single unconvertible upload fails the submission itself (a batch
+    // converts around bad items) — same surface as the sync endpoint, and no
+    // doomed job occupies the queue.
+    if sources.len() == 1 && sources[0].is_err() {
+        let (_, e) = sources.remove(0).expect_err("checked is_err");
+        return Err(e);
+    }
+
+    let id = task_id();
+    {
+        let mut jobs = state.jobs.lock().unwrap();
+        purge_expired(&mut jobs, state.cfg.result_ttl_secs);
+        // The bound counts jobs still holding request/result memory — queued,
+        // running, or finished-but-unfetched — so a burst can't grow the map
+        // (and the upload bytes it holds) without limit.
+        if jobs.len() >= state.cfg.queue_size {
+            return Err(ApiError::Busy(format!(
+                "job queue is full ({} jobs); retry after fetching or expiring results",
+                jobs.len()
+            )));
+        }
+        jobs.insert(
+            id.clone(),
+            Job {
+                state: JobState::Pending,
+                done_at: None,
+            },
+        );
+    }
+
+    let st = state.clone();
+    let job_id = id.clone();
+    tokio::spawn(async move {
+        // Queue on the shared conversion semaphore. Closed-semaphore errors
+        // only happen at shutdown; the job then just stays pending until the
+        // process exits.
+        let Ok(permit) = st.permits.clone().acquire_owned().await else {
+            return;
+        };
+        if let Some(job) = st.jobs.lock().unwrap().get_mut(&job_id) {
+            job.state = JobState::Started;
+        } else {
+            return; // evicted while queued (TTL abuse would need days)
+        }
+        let stx = st.clone();
+        let opts = options;
+        let outcome = tokio::task::spawn_blocking(move || {
+            run_conversion(&stx, sources, &opts, &to, image_mode)
+        })
+        .await
+        .map_err(|e| ApiError::Internal(format!("convert task: {e}")))
+        .and_then(|r| r);
+        drop(permit);
+        if let Some(job) = st.jobs.lock().unwrap().get_mut(&job_id) {
+            job.state = match outcome {
+                Ok(stored) => JobState::Success(stored),
+                Err(e) => {
+                    let (status, msg) = api_error_parts(e);
+                    JobState::Failure(status, msg)
+                }
+            };
+            job.done_at = Some(std::time::Instant::now());
+        }
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(json!({ "task_id": id, "task_status": "pending" })),
+    )
+        .into_response())
+}
+
+/// `GET /v1/status/{id}` (#182).
+async fn job_status(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    let mut jobs = state.jobs.lock().unwrap();
+    purge_expired(&mut jobs, state.cfg.result_ttl_secs);
+    match jobs.get(&id) {
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "unknown task id (never submitted, or its result expired)"})),
         )
             .into_response(),
-        "chunks" => {
-            let mut warnings: Vec<String> = Vec::new();
-            let mut records = docling::chunks::chunk_records(&document, &mut |m| warnings.push(m));
-            if !warnings.is_empty() {
-                records["warnings"] = json!(warnings);
+        Some(job) => {
+            let mut body = json!({ "task_id": id, "task_status": job.state.as_str() });
+            if let JobState::Failure(_, msg) = &job.state {
+                body["error"] = json!(msg);
             }
-            Json(records).into_response()
+            Json(body).into_response()
         }
-        "dclx" => {
-            let bytes = docling::dclx::to_dclx_bytes(&document);
-            (
-                [
-                    (header::CONTENT_TYPE, "application/octet-stream".to_string()),
-                    (
-                        header::CONTENT_DISPOSITION,
-                        format!("attachment; filename=\"{name}.dclx\""),
-                    ),
-                ],
-                bytes,
+    }
+}
+
+/// `GET /v1/result/{id}` (#182): the conversion output with the same content
+/// type / headers the sync endpoint would have used. Not ready yet → 202 with
+/// the status body; failed → the sync endpoint's error status; unknown or
+/// expired → 404. The result stays fetchable until the TTL evicts it.
+async fn job_result(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    let mut jobs = state.jobs.lock().unwrap();
+    purge_expired(&mut jobs, state.cfg.result_ttl_secs);
+    match jobs.get(&id) {
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "unknown task id (never submitted, or its result expired)"})),
+        )
+            .into_response(),
+        Some(job) => match &job.state {
+            JobState::Pending | JobState::Started => (
+                StatusCode::ACCEPTED,
+                Json(json!({ "task_id": id, "task_status": job.state.as_str() })),
             )
-                .into_response()
+                .into_response(),
+            JobState::Failure(status, msg) => {
+                (*status, Json(json!({"error": msg}))).into_response()
+            }
+            // Clone rather than remove: the result stays re-fetchable until
+            // the TTL evicts it (a client retrying a dropped response must not
+            // find a 404).
+            JobState::Success(stored) => StoredResponse {
+                content_type: stored.content_type,
+                disposition: stored.disposition.clone(),
+                confidence: stored.confidence.clone(),
+                body: stored.body.clone(),
+            }
+            .into_response(),
+        },
+    }
+}
+
+/// A fully materialized conversion response — what a buffered sync request
+/// answers with, and what an async job (#182) stores until the client fetches
+/// `/v1/result/{id}`.
+struct StoredResponse {
+    content_type: &'static str,
+    /// `Content-Disposition` for downloads (dclx).
+    disposition: Option<String>,
+    /// The `X-Docling-Confidence` summary (#183), when the pipeline made one.
+    confidence: Option<header::HeaderValue>,
+    body: Vec<u8>,
+}
+
+impl StoredResponse {
+    fn into_response(self) -> Response {
+        let mut response = ([(header::CONTENT_TYPE, self.content_type)], self.body).into_response();
+        if let Some(d) = self.disposition {
+            if let Ok(v) = header::HeaderValue::from_str(&d) {
+                response
+                    .headers_mut()
+                    .insert(header::CONTENT_DISPOSITION, v);
+            }
         }
-        _ => unreachable!("validated above"),
+        if let Some(v) = self.confidence {
+            response.headers_mut().insert("x-docling-confidence", v);
+        }
+        response
+    }
+}
+
+/// Convert one or more sources on the current (blocking) thread and serialize
+/// the result. A single source renders as the plain output format; multiple
+/// sources (#182 batch) render as a JSON results array with per-item status,
+/// so one bad file fails its item, not the whole batch.
+fn run_conversion(
+    state: &AppState,
+    sources: Vec<SourceItem>,
+    options: &ConvertOptions,
+    to: &str,
+    image_mode: ImageMode,
+) -> Result<StoredResponse, ApiError> {
+    if sources.len() == 1 {
+        let source = sources
+            .into_iter()
+            .next()
+            .expect("checked len")
+            .map_err(|(_, e)| e)?;
+        let name = source.name.clone();
+        let document = convert_document(state, source, options)?;
+        return Ok(render_stored(
+            state, to, image_mode, &name, &document, options,
+        ));
+    }
+    let items: Vec<serde_json::Value> = sources
+        .into_iter()
+        .map(|item| {
+            let source = match item {
+                Ok(source) => source,
+                Err((name, e)) => {
+                    return json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    })
+                }
+            };
+            let name = source.name.clone();
+            match convert_document(state, source, options) {
+                Ok(document) => batch_item(state, to, image_mode, &name, &document, options),
+                Err(e) => json!({
+                    "name": name,
+                    "status": "failure",
+                    "error": api_error_message(e),
+                }),
+            }
+        })
+        .collect();
+    Ok(StoredResponse {
+        content_type: "application/json",
+        disposition: None,
+        confidence: None,
+        body: serde_json::to_vec_pretty(&json!({ "results": items }))
+            .expect("batch JSON serializes"),
     })
 }
 
-/// Read the multipart request: a `file` part (bytes + filename) plus optional
-/// text parts mirroring the query options.
+/// Serialize a converted document for a buffered (non-streaming) response.
+/// Responses carry the conversion-confidence report (#183) when the ML
+/// pipeline produced one: as an `X-Docling-Confidence` summary header
+/// everywhere, and as a top-level `"confidence"` key (with the per-page
+/// breakdown) appended to the `json` body — the document keys themselves are
+/// untouched, so the body still parses as a docling-JSON document.
+fn render_stored(
+    state: &AppState,
+    to: &str,
+    image_mode: ImageMode,
+    name: &str,
+    document: &DoclingDocument,
+    options: &ConvertOptions,
+) -> StoredResponse {
+    let confidence = confidence_header(document);
+    match to {
+        "md" | "markdown" => StoredResponse {
+            content_type: "text/markdown; charset=utf-8",
+            disposition: None,
+            confidence,
+            body: markdown_string(state, document, image_mode, options).into_bytes(),
+        },
+        "json" => {
+            let mut value = document.export_to_json_value();
+            if let Some(report) = &document.confidence {
+                value["confidence"] = report.to_json();
+            }
+            StoredResponse {
+                content_type: "application/json",
+                disposition: None,
+                confidence,
+                body: serde_json::to_vec_pretty(&value).expect("document JSON serializes"),
+            }
+        }
+        "chunks" => {
+            let mut warnings: Vec<String> = Vec::new();
+            let mut records = docling::chunks::chunk_records(document, &mut |m| warnings.push(m));
+            if !warnings.is_empty() {
+                records["warnings"] = json!(warnings);
+            }
+            StoredResponse {
+                content_type: "application/json",
+                disposition: None,
+                confidence,
+                body: serde_json::to_vec(&records).expect("chunk records serialize"),
+            }
+        }
+        "dclx" => StoredResponse {
+            content_type: "application/octet-stream",
+            disposition: Some(format!("attachment; filename=\"{name}.dclx\"")),
+            confidence,
+            body: docling::dclx::to_dclx_bytes(document),
+        },
+        _ => unreachable!("validated above"),
+    }
+}
+
+/// One batch item (#182) as JSON. Text outputs inline as strings, the
+/// docling-JSON document as an object, binary dclx as base64; the confidence
+/// summary (#183) rides along as a sibling key where it isn't already inside
+/// the document JSON.
+fn batch_item(
+    state: &AppState,
+    to: &str,
+    image_mode: ImageMode,
+    name: &str,
+    document: &DoclingDocument,
+    options: &ConvertOptions,
+) -> serde_json::Value {
+    let mut item = json!({ "name": name, "status": "success" });
+    match to {
+        "md" | "markdown" => {
+            item["md"] = json!(markdown_string(state, document, image_mode, options));
+        }
+        "json" => {
+            let mut value = document.export_to_json_value();
+            if let Some(report) = &document.confidence {
+                value["confidence"] = report.to_json();
+            }
+            item["document"] = value;
+        }
+        "chunks" => {
+            let mut warnings: Vec<String> = Vec::new();
+            let mut records = docling::chunks::chunk_records(document, &mut |m| warnings.push(m));
+            if !warnings.is_empty() {
+                records["warnings"] = json!(warnings);
+            }
+            item["chunks"] = records;
+        }
+        "dclx" => {
+            item["dclx_base64"] = json!(docling::base64::encode(&docling::dclx::to_dclx_bytes(
+                document
+            )));
+        }
+        _ => unreachable!("validated above"),
+    }
+    if to != "json" {
+        if let Some(report) = &document.confidence {
+            item["confidence"] = report.summary_json();
+        }
+    }
+    item
+}
+
+/// Buffered Markdown export honoring the request's `strict` / `images`
+/// options — the non-streaming counterpart of `stream_markdown`'s serializer
+/// calls (batch items and async results can't stream).
+fn markdown_string(
+    state: &AppState,
+    document: &DoclingDocument,
+    image_mode: ImageMode,
+    options: &ConvertOptions,
+) -> String {
+    let mut doc = document.clone();
+    doc.strict_markdown = options.strict.unwrap_or(state.cfg.strict);
+    match image_mode {
+        ImageMode::Placeholder => doc.export_to_markdown(),
+        _ => {
+            doc.export_to_markdown_with_images(image_mode, "artifacts")
+                .0
+        }
+    }
+}
+
+/// The document-level confidence summary as a header value (compact JSON, no
+/// per-page breakdown — headers should stay small). `None` when the
+/// conversion had no ML stages (declarative formats).
+fn confidence_header(document: &DoclingDocument) -> Option<header::HeaderValue> {
+    let report = document.confidence.as_ref()?;
+    header::HeaderValue::from_str(&report.summary_json().to_string()).ok()
+}
+
+/// Read the multipart request: one or more `file` parts (bytes + filename —
+/// several files make a #182 batch; `files` is accepted as an alias) plus
+/// optional text parts mirroring the query options.
 async fn read_multipart(
     mut multipart: Multipart,
     query: ConvertOptions,
-) -> Result<(SourceDocument, ConvertOptions), ApiError> {
-    let mut file: Option<(String, Vec<u8>)> = None;
+) -> Result<(Vec<SourceItem>, ConvertOptions), ApiError> {
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
     let mut body_opts = ConvertOptions::default();
     while let Some(field) = multipart
         .next_field()
@@ -449,7 +909,7 @@ async fn read_multipart(
     {
         let name = field.name().unwrap_or("").to_string();
         match name.as_str() {
-            "file" => {
+            "file" | "files" => {
                 let file_name = field
                     .file_name()
                     .map(|s| s.to_string())
@@ -458,7 +918,7 @@ async fn read_multipart(
                     .bytes()
                     .await
                     .map_err(|e| ApiError::Bad(format!("reading upload: {e}")))?;
-                file = Some((file_name, bytes.to_vec()));
+                files.push((file_name, bytes.to_vec()));
             }
             "to" | "images" => {
                 let v = text_field(field).await?;
@@ -499,9 +959,18 @@ async fn read_multipart(
             _ => {} // unknown parts are ignored
         }
     }
-    let (file_name, bytes) = file.ok_or_else(|| ApiError::Bad("missing 'file' part".into()))?;
-    let source = source_from_named_bytes(&file_name, bytes)?;
-    Ok((source, body_opts.merge_over(query)))
+    if files.is_empty() {
+        return Err(ApiError::Bad("missing 'file' part".into()));
+    }
+    // Per-file errors (unknown extension) are deferred: a single-file request
+    // propagates them as its response, a batch fails only that item.
+    let sources = files
+        .into_iter()
+        .map(|(file_name, bytes)| {
+            source_from_named_bytes(&file_name, bytes).map_err(|e| (file_name, e))
+        })
+        .collect();
+    Ok((sources, body_opts.merge_over(query)))
 }
 
 async fn text_field(field: axum::extract::multipart::Field<'_>) -> Result<String, ApiError> {
@@ -839,12 +1308,16 @@ async fn stream_markdown(
     image_mode: ImageMode,
     permit: tokio::sync::OwnedSemaphorePermit,
 ) -> Result<Response, ApiError> {
-    let (tx, rx) = tokio::sync::mpsc::channel::<Result<String, String>>(8);
+    // A chunk is its text plus (first chunk of a pipeline conversion only) the
+    // confidence summary header — computable only after conversion, which is
+    // exactly when the PDF/image branch sends its single chunk.
+    type Chunk = (String, Option<header::HeaderValue>);
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Chunk, String>>(8);
     let st = state.clone();
     tokio::task::spawn_blocking(move || {
         // Held until this worker (and thus the response body) is done.
         let _permit = permit;
-        let send = |item: Result<String, String>| {
+        let send = |item: Result<Chunk, String>| {
             // The receiver disappearing means the client went away — stop.
             tx.blocking_send(item).is_ok()
         };
@@ -866,7 +1339,7 @@ async fn stream_markdown(
                                     .0
                             }
                         };
-                        send(Ok(md));
+                        send(Ok((md, confidence_header(&doc))));
                     }
                     Err(e) => {
                         send(Err(api_error_message(e)));
@@ -886,7 +1359,7 @@ async fn stream_markdown(
                         for chunk in stream {
                             match chunk {
                                 Ok(s) => {
-                                    if !send(Ok(s)) {
+                                    if !send(Ok((s, None))) {
                                         return;
                                     }
                                 }
@@ -919,27 +1392,31 @@ async fn stream_markdown(
         )
             .into_response()),
         Some(Err(e)) => Err(ApiError::Unsupported(e)),
-        Some(Ok(first_chunk)) => {
+        Some(Ok((first_chunk, confidence))) => {
             use tokio_stream::StreamExt;
             let rest = tokio_stream::wrappers::ReceiverStream::new(rx);
-            let stream = tokio_stream::once(Ok(first_chunk)).chain(rest).map(|item| {
-                item.map(String::into_bytes).map_err(|e| {
-                    std::io::Error::other(format!("conversion failed mid-stream: {e}"))
-                })
-            });
-            Ok((
+            let stream = tokio_stream::once(Ok((first_chunk, None)))
+                .chain(rest)
+                .map(|item| {
+                    item.map(|(text, _)| text.into_bytes()).map_err(|e| {
+                        std::io::Error::other(format!("conversion failed mid-stream: {e}"))
+                    })
+                });
+            let mut response = (
                 [(header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
                 Body::from_stream(stream),
             )
-                .into_response())
+                .into_response();
+            if let Some(value) = confidence {
+                response.headers_mut().insert("x-docling-confidence", value);
+            }
+            Ok(response)
         }
     }
 }
 
 fn api_error_message(e: ApiError) -> String {
-    match e {
-        ApiError::Bad(m) | ApiError::Unsupported(m) | ApiError::Internal(m) => m,
-    }
+    api_error_parts(e).1
 }
 
 #[cfg(test)]

--- a/crates/docling-serve/src/main.rs
+++ b/crates/docling-serve/src/main.rs
@@ -1,6 +1,7 @@
 //! `docling-serve` — standalone binary for the HTTP conversion API.
 //!
 //! Usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N]
+//!                      [--queue-size N] [--result-ttl SECS]
 //!                      [--warmup] [--allow-url-fetch] [--strict]
 //!
 //!   --addr HOST:PORT  bind address (default: 127.0.0.1:5001). Bind 0.0.0.0
@@ -8,6 +9,10 @@
 //!   --concurrency N   max conversions in flight; excess requests queue
 //!                     (default: 2)
 //!   --max-body-mb N   request body cap for uploads, in MiB (default: 256)
+//!   --queue-size N    max async jobs (#182) queued/unfetched at once; further
+//!                     submissions get 429 (default: 16)
+//!   --result-ttl SECS how long a finished async job's result stays fetchable
+//!                     (default: 600)
 //!   --warmup          load the PDF/image models at startup; /ready returns
 //!                     503 until they are loaded
 //!   --allow-url-fetch accept {"url": …} inputs (outbound fetch — SSRF surface;
@@ -37,6 +42,14 @@ fn main() -> ExitCode {
             "--max-body-mb" => match args.next().and_then(|v| v.parse::<usize>().ok()) {
                 Some(v) if v >= 1 => cfg.max_body_bytes = v * 1024 * 1024,
                 _ => return usage("--max-body-mb needs a positive integer"),
+            },
+            "--queue-size" => match args.next().and_then(|v| v.parse().ok()) {
+                Some(v) if v >= 1 => cfg.queue_size = v,
+                _ => return usage("--queue-size needs a positive integer"),
+            },
+            "--result-ttl" => match args.next().and_then(|v| v.parse().ok()) {
+                Some(v) if v >= 1 => cfg.result_ttl_secs = v,
+                _ => return usage("--result-ttl needs a positive number of seconds"),
             },
             "--warmup" => cfg.warmup = true,
             "--allow-url-fetch" => cfg.allow_url_fetch = true,
@@ -70,7 +83,7 @@ fn usage(err: &str) -> ExitCode {
         eprintln!("error: {err}");
     }
     eprintln!(
-        "usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--warmup] [--no-url-fetch] [--strict]"
+        "usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--queue-size N] [--result-ttl SECS] [--warmup] [--allow-url-fetch] [--strict]"
     );
     if err.is_empty() {
         ExitCode::SUCCESS

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -35,6 +35,17 @@ paths:
 
         `to=md` streams the Markdown as it converts (chunked response);
         `to=dclx` returns the archive as a download.
+
+        **Batch**: several `file` parts in one multipart request convert as a
+        batch — the response is then `{"results": [...]}` with per-item
+        status (one bad file fails its item, not the batch), regardless of
+        `to`; binary dclx output is base64 in `dclx_base64`.
+
+        **Confidence** (PDF/image ML conversions): every response carries an
+        `X-Docling-Confidence` header with the document-level summary, and
+        `to=json` bodies additionally embed the full report (per-page
+        breakdown) under a top-level `confidence` key. Declarative
+        conversions have no ML stages and omit both.
       operationId: convert
       parameters:
         - { $ref: "#/components/parameters/to" }
@@ -112,6 +123,12 @@ paths:
             Content-Disposition:
               description: Present for `to=dclx` (attachment filename).
               schema: { type: string }
+            X-Docling-Confidence:
+              description: >
+                Document-level conversion-confidence summary (compact JSON —
+                the `ConfidenceReport` without its `pages` breakdown).
+                Present when the PDF/image ML pipeline ran.
+              schema: { type: string }
         "400":
           description: Bad request — unreadable input, invalid option, or a URL input on a server without `--allow-url-fetch`.
           content:
@@ -129,6 +146,82 @@ paths:
               schema: { $ref: "#/components/schemas/Error" }
         "500":
           description: Conversion failed.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/convert/async:
+    post:
+      summary: Submit an async conversion job
+      description: |
+        Accepts exactly the `POST /v1/convert` request (including batches) but
+        answers immediately with a task id instead of holding the connection
+        for the duration of the conversion — submit → poll
+        `GET /v1/status/{id}` → fetch `GET /v1/result/{id}`. Jobs queue on
+        the same concurrency bound as sync requests and reuse the warm model
+        pipeline. At most `--queue-size` jobs may be queued or unfetched at
+        once; results are evicted `--result-ttl` seconds after completion.
+      operationId: convertAsync
+      responses:
+        "202":
+          description: The job was accepted and queued.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskStatus" }
+        "400":
+          description: Bad request (validated synchronously, nothing is queued).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: The job queue is full — retry after results are fetched or expire.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/status/{id}:
+    get:
+      summary: Async job status
+      operationId: jobStatus
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: The job's current state (`error` is set on failure).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskStatus" }
+        "404":
+          description: Unknown task id — never submitted, or its result already expired.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/result/{id}:
+    get:
+      summary: Async job result
+      description: >
+        The finished conversion, with the same body, content type, and headers
+        the sync endpoint would have answered with (batches: the JSON results
+        array). Stays fetchable until the TTL evicts it.
+      operationId: jobResult
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: The converted output (see `POST /v1/convert` responses).
+        "202":
+          description: Not finished yet — the status body is returned instead.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskStatus" }
+        "404":
+          description: Unknown task id — never submitted, or its result expired.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: The conversion failed; the stored error is returned.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
@@ -315,6 +408,36 @@ components:
             properties:
               text: { type: string }
               headings: { type: array, items: { type: string } }
+    TaskStatus:
+      type: object
+      description: An async conversion job's state.
+      properties:
+        task_id: { type: string }
+        task_status:
+          type: string
+          enum: [pending, started, success, failure]
+        error:
+          type: string
+          description: Present when `task_status` is `failure`.
+      required: [task_id, task_status]
+    ConfidenceReport:
+      type: object
+      description: >
+        Conversion-confidence scores (docling `ConfidenceReport` semantics):
+        each score is 0–1 or null when its stage didn't run; grades bucket the
+        aggregate (`poor` < 0.5 ≤ `fair` < 0.8 ≤ `good` < 0.9 ≤ `excellent`,
+        `unspecified` when nothing scored). `pages` is keyed by the real
+        1-based page number and carries the same fields per page.
+      properties:
+        layout_score: { type: [number, "null"], description: Mean confidence of the kept layout regions. }
+        ocr_score: { type: [number, "null"], description: Mean recognition confidence of OCR'd cells. }
+        parse_score: { type: [number, "null"], description: 10th-percentile text-layer extraction quality. }
+        table_score: { type: [number, "null"], description: Reserved (never set — matches Python docling). }
+        mean_score: { type: [number, "null"] }
+        low_score: { type: [number, "null"] }
+        mean_grade: { type: string, enum: [poor, fair, good, excellent, unspecified] }
+        low_grade: { type: string, enum: [poor, fair, good, excellent, unspecified] }
+        pages: { type: object, additionalProperties: { type: object } }
     Error:
       type: object
       properties:

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -85,8 +85,20 @@ async fn serves_its_logo_and_openapi_description() {
     // Every route the router answers is described, and every conversion option
     // the API accepts appears — the spec drifting from `ConvertOptions` is the
     // failure mode worth catching here.
-    for path in ["/v1/convert", "/v1/config", "/health", "/ready"] {
+    for path in [
+        "/v1/convert",
+        "/v1/convert/async",
+        "/v1/status/{id}",
+        "/v1/result/{id}",
+        "/v1/config",
+        "/health",
+        "/ready",
+    ] {
         assert!(spec.contains(path), "{path} missing from openapi.yaml");
+    }
+    // The #182/#183 additions stay described.
+    for schema in ["TaskStatus", "ConfidenceReport", "X-Docling-Confidence"] {
+        assert!(spec.contains(schema), "{schema} missing from openapi.yaml");
     }
     for opt in [
         "to:",
@@ -321,6 +333,194 @@ async fn fetch_images_is_gated_behind_allow_url_fetch() {
         out.contains("data:image/"),
         "gate on must embed the fetched image"
     );
+}
+
+/// A multipart body with several `file` parts — a #182 batch.
+fn multipart_files(files: &[(&str, &[u8])], fields: &[(&str, &str)]) -> (String, Vec<u8>) {
+    let boundary = "docling-serve-test-boundary";
+    let mut body = Vec::new();
+    for (file_name, content) in files {
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(content);
+        body.extend_from_slice(b"\r\n");
+    }
+    for (k, v) in fields {
+        body.extend_from_slice(
+            format!("--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n")
+                .as_bytes(),
+        );
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={boundary}"), body)
+}
+
+/// Several `file` parts in one request convert as a batch (#182): the
+/// response is a JSON results array with per-item status — and one bad file
+/// fails only its own item.
+#[tokio::test]
+async fn batch_upload_returns_results_array() {
+    let (ct, body) = multipart_files(
+        &[
+            ("a.md", b"# A\n"),
+            ("b.csv", b"x,y\n1,2\n"),
+            ("broken.xyz", b"?"),
+        ],
+        &[("to", "md")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    let results = v["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0]["status"], "success");
+    assert!(results[0]["md"].as_str().unwrap().contains("# A"));
+    assert_eq!(results[1]["status"], "success");
+    assert_eq!(results[2]["status"], "failure");
+    assert!(results[2]["error"].as_str().unwrap().contains("xyz"));
+}
+
+/// Async job lifecycle (#182): submit returns a task id, status reaches
+/// `success`, and the result endpoint replays the sync response (here: the
+/// converted Markdown). Unknown ids 404.
+#[tokio::test]
+async fn async_job_roundtrip() {
+    let app = app();
+    let (ct, body) = multipart("note.md", b"# Async\n\nhello.\n", &[]);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/convert/async")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    let id = v["task_id"].as_str().expect("task id").to_string();
+    assert_eq!(v["task_status"], "pending");
+
+    // Poll until the job finishes (a declarative conversion takes milliseconds;
+    // the deadline only bounds a hung test).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(format!("/v1/status/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+        match v["task_status"].as_str().unwrap() {
+            "success" => break,
+            "failure" => panic!("job failed: {v}"),
+            _ if std::time::Instant::now() > deadline => panic!("job never finished"),
+            _ => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+        }
+    }
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/v1/result/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "text/markdown; charset=utf-8"
+    );
+    let md = body_string(response).await;
+    assert!(md.contains("# Async"), "unexpected result body: {md}");
+
+    // The result stays fetchable (until the TTL): a retried GET must not 404.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/v1/result/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::get("/v1/status/no-such-task")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// A bad async submission fails synchronously (nothing queues) and a full
+/// queue answers 429 instead of growing without bound.
+#[tokio::test]
+async fn async_rejects_bad_requests_and_full_queue() {
+    let (ct, body) = multipart("x.md", b"x", &[("to", "pdf")]);
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/convert/async")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // queue_size 0 admits nothing — the first submission is already refused.
+    let cfg = ServeConfig {
+        queue_size: 0,
+        ..ServeConfig::default()
+    };
+    let (ct, body) = multipart("x.md", b"# x\n", &[]);
+    let response = router(cfg)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/convert/async")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+/// Declarative conversions have no ML stages, so no confidence surfaces
+/// (#183): no `X-Docling-Confidence` header, no `confidence` key in JSON.
+/// (The positive case — real scores from the PDF pipeline — is covered by the
+/// docling-pdf tests; here the router-level suite stays model-free.)
+#[tokio::test]
+async fn declarative_conversions_carry_no_confidence() {
+    let (ct, body) = multipart("t.csv", b"a,b\n1,2\n", &[("to", "json")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().get("x-docling-confidence").is_none());
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    assert!(v.get("confidence").is_none());
 }
 
 #[tokio::test]

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -49,9 +49,11 @@ pub use stream::MarkdownStream;
 
 // Re-export the core model so callers only need the one crate, and so
 // `result.document.export_to_markdown()` works without an extra import.
+pub use docling_core::base64;
 pub use docling_core::chunker;
 pub use docling_core::{
-    DocItemLabel, DoclingDocument, ImageMode, MarkdownStreamer, Node, PictureImage, Table,
+    ConfidenceReport, DocItemLabel, DoclingDocument, ImageMode, MarkdownStreamer, Node,
+    PictureImage, QualityGrade, Table,
 };
 
 // The reusable PDF/image pipeline (models loaded once, reused across documents),

--- a/crates/docling/tests/pages.rs
+++ b/crates/docling/tests/pages.rs
@@ -209,3 +209,69 @@ fn force_full_page_ocr_discards_the_text_layer() {
         "forced output must come from OCR, not the embedded text layer"
     );
 }
+
+/// #183: the PDF pipeline attaches a per-page confidence report to the
+/// converted document. On a digital page the layout model scores real
+/// clusters (well above the 0.3 label floor), the text layer parses cleanly
+/// (parse_score ≈ 1.0), and nothing came from OCR — so ocr_score stays unset
+/// and table_score is always unset (docling never assigns it either).
+#[test]
+fn pdf_pipeline_reports_confidence() {
+    if !pdfium_ready() || !ocr_models_ready() {
+        eprintln!("skipping: pdfium or the OCR models are not present");
+        return;
+    }
+    let src =
+        SourceDocument::from_file(repo_root().join("tests/data/pdf/sources/2305.03393v1-pg9.pdf"))
+            .expect("single-page fixture");
+    let doc = DocumentConverter::new()
+        .convert(src)
+        .expect("convert")
+        .document;
+    let report = doc.confidence.as_ref().expect("pipeline sets confidence");
+    assert_eq!(report.pages.len(), 1, "one page, one entry");
+    let page = report.pages.get(&1).expect("keyed by 1-based page number");
+    let layout = page.layout_score.expect("layout ran");
+    assert!((0.3..=1.0).contains(&layout), "layout_score {layout}");
+    let parse = page.parse_score.expect("text layer present");
+    assert!(parse > 0.9, "clean digital text layer, got {parse}");
+    assert_eq!(page.ocr_score, None, "digital page: nothing OCR'd");
+    assert_eq!(page.table_score, None, "never assigned (docling parity)");
+    // Aggregates exist and grade sanely.
+    let mean = report.mean_score().expect("scores present");
+    assert!((0.3..=1.0).contains(&mean), "mean_score {mean}");
+    assert_ne!(
+        report.mean_grade().as_str(),
+        "unspecified",
+        "scored conversion must grade"
+    );
+    // The report is a response-level extra, not part of the document schema:
+    // the JSON export must stay byte-identical to a confidence-free document.
+    assert!(
+        !doc.export_to_json().contains("confidence"),
+        "confidence must not leak into the docling-JSON export"
+    );
+}
+
+/// #183 on the no-OCR text-layer path: parse quality still scores (the cells
+/// are the same extraction the pipeline sees), layout is the orphan-rescue
+/// set (cell confidence 1.0), and OCR never ran. Needs pdfium only.
+#[test]
+fn no_ocr_conversion_reports_parse_confidence() {
+    if !pdfium_ready() {
+        eprintln!("skipping: pdfium library not found");
+        return;
+    }
+    let doc = DocumentConverter::new()
+        .no_ocr(true)
+        .page_range(1, 2)
+        .convert(pdf_source())
+        .expect("convert")
+        .document;
+    let report = doc.confidence.as_ref().expect("pipeline sets confidence");
+    assert_eq!(report.pages.len(), 2, "one entry per converted page");
+    assert!(report.pages.contains_key(&1) && report.pages.contains_key(&2));
+    let parse = report.parse_score().expect("text layer parsed");
+    assert!(parse > 0.5, "clean text layer, got {parse}");
+    assert_eq!(report.ocr_score(), None, "no OCR on the no_ocr path");
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -81,7 +81,7 @@ crates/
 ├── docling-node/   # Node.js/Bun N-API bindings (napi-rs), published to npm as `docling.rs`
 ├── docling-py/     # PyO3 bindings (maturin), published to PyPI as `docling-rs` (strangler-fig over docling-core)
 ├── docling-rag/    # RAG layer on top of the converter (chunking, embeddings, vector search, REST API)
-├── docling-serve/  # HTTP conversion API (docling-serve analogue): POST /v1/convert over a warm pipeline
+├── docling-serve/  # HTTP conversion API (docling-serve analogue): sync + async/batch /v1/convert over a warm pipeline
 └── docling-wasm/   # WebAssembly bindings: declarative converters + text-layer PDF in the browser
 ```
 
@@ -343,6 +343,15 @@ These are deliberate or unavoidable divergences, not bugs.
    (CSS-cascade) visibility suppression needs a rendered page, available behind
    the optional `web-browser` feature / `--use-web-browser` flag (Rust-driven
    Chromium) — see §5.
+
+9. **Confidence pages are keyed 1-based.** The PDF/image pipeline attaches a
+   docling-`ConfidenceReport`-shaped report (same grade thresholds, same
+   nanmean/nanquantile aggregation; `table_score` unset like upstream) that
+   docling-serve surfaces per response (v1.25 parity). Its `pages` map is
+   keyed by the **real 1-based page number** — consistent with the JSON
+   export's `pages` map and `--pages` windows — where Python docling keys by
+   its 0-based internal page index. Unset scores serialize as `null`, not
+   `NaN`.
 
 ---
 


### PR DESCRIPTION
Two docling-serve parity features, closing the gap to Python docling-serve v1.22/v1.25. Refs #182, Refs #183.

Async + batch (#182): POST /v1/convert/async accepts exactly the sync request and answers 202 {"task_id"} immediately instead of holding the connection for minutes on a long PDF; jobs queue on the same concurrency semaphore (reusing the warm pipeline) with GET /v1/status/{id} and GET /v1/result/{id} for polling and fetch. The in-memory job store is doubly bounded: --queue-size caps queued/unfetched jobs (429 beyond) and --result-ttl evicts finished results, so neither uploads nor results can grow memory without limit; task ids are 128-bit unguessable since the result endpoint, like the rest of the API, is unauthenticated. Several multipart `file` parts now convert as one batch — a JSON results array with per-item status, where a bad file fails its item, not the batch (dclx rides as base64). Bad submissions are validated synchronously so no doomed job ever occupies the queue.

Confidence (#183): the PDF/image pipeline now scores every page the way docling's stages do — layout_score as the mean confidence of the final postprocessed regions (orphan rescues counted at their cell confidence), ocr_score as the mean recognition confidence (the CTC decode now returns the emitted characters' mean probability, PaddleOCR semantics), parse_score as the 10th-percentile rate_text_quality over the text layer (the GLYPH/slash-garbage/fragmented-words rules ported verbatim), and table_score deliberately never (docling doesn't assign it either). docling-core gains the ConfidenceReport model with docling's exact grade thresholds and nanmean/nanquantile aggregation; the report rides on DoclingDocument.confidence but is intentionally absent from every document export, so all byte-conformance surfaces stay untouched — the regression suite and PDF snapshots pass unchanged. docling-serve surfaces it as an X-Docling-Confidence summary header on every output format and embeds the per-page report under a top-level "confidence" key in to=json bodies. Pages are keyed by real 1-based page number (our JSON-export numbering; deviation from docling's 0-based internal index noted in MIGRATION §4).

The playground learns multi-file selection, a confidence banner, and the new endpoints; openapi.yaml describes all of it (spec-drift asserted in tests); the CLI serve subcommand gains --queue-size/--result-ttl and the previously missing --allow-url-fetch. e2e: async roundtrip, batch with a per-item failure, queue-full 429, no-confidence-on-declarative, plus model-gated pipeline tests asserting real scores on a digital page and that confidence never leaks into the docling-JSON export.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT