### PR TITLE
fix(py): thread no_text_panels through the DocumentConverter facade

### DIFF
--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "0.52.9"
+version = "0.53.1"
 dependencies = [
  "calamine",
  "csv",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "0.52.9"
+version = "0.53.1"
 dependencies = [
  "docling-core",
  "ort",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "0.52.9"
+version = "0.53.1"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "0.52.9"
+version = "0.53.1"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -131,6 +131,9 @@ class DocumentConverter:
       ``do_table_structure`` and ``accelerator_options.num_threads`` take effect.
     * ``do_ocr`` / ``do_table_structure`` — a shorthand for the same, used when no
       ``format_options`` is given.
+    * ``no_text_panels`` — PDF/image: keep every detected picture as a picture
+      (disable the demotion of uncaptioned dense-text "picture" regions into
+      paragraphs — the image-extraction escape hatch, #174).
     * ``fetch_images`` — resolve remote/local ``<img src>`` for HTML/EPUB.
     * ``use_web_browser`` — render HTML via headless Chrome before parsing.
     * ``allowed_formats`` — restrict conversion to these :class:`InputFormat`\\ s
@@ -150,6 +153,7 @@ class DocumentConverter:
         do_ocr: bool = True,
         do_table_structure: bool = True,
         force_full_page_ocr: bool = False,
+        no_text_panels: bool = False,
         do_picture_classification: bool = False,
         do_code_enrichment: bool = False,
         do_formula_enrichment: bool = False,
@@ -173,6 +177,7 @@ class DocumentConverter:
             ) or getattr(
                 getattr(pipeline, "ocr_options", None), "force_full_page_ocr", False
             )
+            no_text_panels = getattr(pipeline, "no_text_panels", no_text_panels)
             do_picture_classification = getattr(
                 pipeline, "do_picture_classification", do_picture_classification
             )
@@ -227,6 +232,7 @@ class DocumentConverter:
             fetch_images=fetch_images,
             do_ocr=do_ocr,
             force_full_page_ocr=force_full_page_ocr,
+            no_text_panels=no_text_panels,
             do_table_structure=do_table_structure,
             use_web_browser=use_web_browser,
             do_picture_classification=do_picture_classification,

--- a/crates/docling-py/python/docling_rs/options.py
+++ b/crates/docling-py/python/docling_rs/options.py
@@ -99,7 +99,10 @@ class PdfPipelineOptions:
     ``force_full_page_ocr`` (docling keeps it on ``ocr_options``; accepted here
     directly too — #187's escape hatch for undecodable text layers),
     ``do_picture_classification`` / ``do_code_enrichment`` /
-    ``do_formula_enrichment`` (the opt-in enrichment models) and
+    ``do_formula_enrichment`` (the opt-in enrichment models),
+    ``no_text_panels`` (a docling.rs extension, #173/#174: keep every detected
+    picture as a picture instead of demoting uncaptioned dense-text panels to
+    paragraphs) and
     ``accelerator_options.num_threads``. The remaining fields are accepted so
     docling code constructs unchanged, but do not alter the pipeline (images are
     always extracted; the export image mode is chosen by docling-core at
@@ -108,6 +111,7 @@ class PdfPipelineOptions:
     do_ocr: bool = True
     do_table_structure: bool = True
     force_full_page_ocr: bool = False
+    no_text_panels: bool = False
     do_picture_classification: bool = False
     do_code_enrichment: bool = False
     do_formula_enrichment: bool = False

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -185,3 +185,30 @@ def test_initialize_pipeline_noop_for_non_ml_format():
     # still works afterwards.
     conv.initialize_pipeline(InputFormat.MD)
     assert conv.convert(HTML).status == "success"
+
+
+def test_no_text_panels_reaches_the_native_converter():
+    """#197: the facade must accept ``no_text_panels`` — both as a direct
+    kwarg and via docling-shaped ``PdfPipelineOptions`` — and still convert
+    (declarative path; the flag only alters the ML pipeline, so constructing
+    without a TypeError and forwarding to the native converter is the bug
+    surface)."""
+    from docling_rs import (
+        DocumentConverter,
+        InputFormat,
+        PdfFormatOption,
+        PdfPipelineOptions,
+    )
+
+    for converter in (
+        DocumentConverter(no_text_panels=True),
+        DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(
+                    pipeline_options=PdfPipelineOptions(no_text_panels=True)
+                )
+            }
+        ),
+    ):
+        result = converter.convert(HTML)
+        assert "homepage" in result.document.export_to_markdown().lower()


### PR DESCRIPTION
The flag reached the native binding, CLI, serve, and Node in #174, but the Python facade never accepted it — DocumentConverter( no_text_panels=True) raised TypeError and pipeline options silently dropped it, leaving Python callers no way to disable text-panel demotion. Closes #197.

The facade now takes the keyword (docstring bullet included), reads a docling-shaped PdfPipelineOptions.no_text_panels override — the field is added to the options dataclass as a documented docling.rs extension — and forwards it to the native converter. Covered by a test driving both spellings through a real conversion; the full Python suite (41 tests) passes against a freshly built extension module. The py lockfile refresh (version sync to the current workspace) rides along.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT