### PR TITLE
ci: update GitHub Actions to current majors (Node 24 runtimes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           rustup toolchain install ${{ env.LINT_TOOLCHAIN }} --profile minimal --component rustfmt --component clippy
           rustup default ${{ env.LINT_TOOLCHAIN }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -100,7 +100,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -150,7 +150,7 @@ jobs:
       - name: Install Rust ${{ env.MSRV_CORE }} + ${{ env.MSRV_WORKSPACE }}
         run: rustup toolchain install ${{ env.MSRV_CORE }} ${{ env.MSRV_WORKSPACE }} --profile minimal
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -213,7 +213,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -262,7 +262,7 @@ jobs:
           rustup default stable
           rustup target add wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -324,7 +324,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -35,7 +35,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin
@@ -84,7 +84,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -95,7 +95,7 @@ jobs:
           rustup target add ${{ matrix.target }}
 
       # One workspace, key the cache per target so the 5 jobs don't collide.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -105,7 +105,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-${{ matrix.target }}-
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 
@@ -151,7 +151,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
@@ -248,7 +248,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -258,7 +258,7 @@ jobs:
           key: ${{ runner.os }}-cargo-cuda-node-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-cuda-node-
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
@@ -394,7 +394,7 @@ jobs:
           rustup default stable
           rustup target add wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -405,7 +405,7 @@ jobs:
           key: ${{ runner.os }}-cargo-v2-wasm-npm-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-v2-wasm-npm-
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,7 +51,7 @@ jobs:
           rustup default stable
           rustup target add wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -83,7 +83,7 @@ jobs:
           touch site/.nojekyll
           ls -la site site/pkg
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -96,4 +96,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -59,7 +59,7 @@ jobs:
     name: sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -81,7 +81,7 @@ jobs:
           sed -i.bak -E "0,/^version = \".*\"/s//version = \"$v\"/" pyproject.toml && rm -f pyproject.toml.bak
           echo "Building docling-rs $v"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -94,7 +94,7 @@ jobs:
           python -m pip install "maturin>=1.5,<2"
           maturin sdist -m crates/docling-py/Cargo.toml --out dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -119,7 +119,7 @@ jobs:
           # this environment. macOS users install the sdist (builds from source).
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sdist
           path: sdist
@@ -132,7 +132,7 @@ jobs:
           tar -xzf sdist/*.tar.gz -C pkg --strip-components=1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v4.2.0
         with:
           package-dir: pkg
           output-dir: wheelhouse
@@ -151,7 +151,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$HOME/.cargo/bin:$PATH"'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.arch }}
           path: wheelhouse/*.whl
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sdist
           path: sdist
@@ -236,7 +236,7 @@ jobs:
           sys.exit(f"provider libs missing from {wheel}: {missing}" if missing else 0)
           EOF
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-cuda
           path: wheelhouse/*.whl
@@ -260,7 +260,7 @@ jobs:
     steps:
       # All wheels + the sdist → a single dist/ for the upload.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
GitHub is force-running Node 20 actions on Node 24 since Sep 2025 (the deprecation warning on every windows-msvc job); bring every workflow to the current major in one sweep and align the stragglers:

- actions/checkout v4 -> v7 (one straggler; 14 uses already there)
- actions/cache v4 -> v6 (the Node 20 warning source)
- actions/upload-artifact v4 -> v7, download-artifact v4 -> v8 (aligns with the uses already on v7/v8; all >= v4 share the artifact backend)
- actions/setup-node v4/v6 -> v7, setup-python v5/v6 -> v7
- actions/upload-pages-artifact v3 -> v5, deploy-pages v4 -> v5
- pypa/cibuildwheel v2.21.3 -> v4.2.0: cp39 (our abi3 baseline) is still buildable in 4.2.0, the CIBW_* options we set are unchanged, and the new default manylinux image (manylinux_2_28) is what the workflow already pins explicitly
- pypa/gh-action-pypi-publish stays on the rolling release/v1



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT