### PR TITLE
fix(docs): sweep every doc against the current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ validated for byte-for-byte conformance against upstream Python docling.
 | `crates/docling-asr` | Whisper ASR: symphonia decode (audio + video containers) → log-mel → ONNX encoder/decoder |
 | `crates/docling-cli` | `docling-rs` binary (also `serve` subcommand behind `--features serve`) |
 | `crates/docling-serve` | axum HTTP conversion API (+ Dockerfile with ffmpeg) |
-| `crates/docling-py` / `docling-node` / `docling-wasm` | pyo3 / napi-rs / wasm-bindgen bindings — **excluded from the workspace default-members; py and wasm build from their own directories** |
+| `crates/docling-py` / `docling-node` / `docling-wasm` | pyo3 / napi-rs / wasm-bindgen bindings — **node and wasm are ordinary workspace members; only docling-py sits outside the workspace and builds from its own directory (maturin)** |
 | `crates/docling-rag` | RAG subsystem (embedder, store, web UI) |
 
 ## Build & test
@@ -52,9 +52,9 @@ validated for byte-for-byte conformance against upstream Python docling.
 cargo test --lib --tests -p docling-core -p docling -p docling-asr -p docling-serve -p docling-pdf
 cargo clippy --lib --tests --bins <same -p list>   # keep it warning-free
 cargo fmt --all
-cargo check -p docling --no-default-features        # pdf-text/wasm path
-(cd crates/docling-py && cargo check)               # pyo3 binding
-(cd crates/docling-wasm && cargo check)             # wasm binding
+cargo check -p docling --no-default-features --features pdf-text \
+  --target wasm32-unknown-unknown --locked           # the wasm CI gate
+(cd crates/docling-py && cargo check)               # pyo3 binding (outside the workspace)
 ```
 
 - Prefer `--lib --tests` over bare `cargo test`: it skips example binaries,
@@ -108,6 +108,7 @@ cargo check -p docling --no-default-features        # pdf-text/wasm path
 - Docs live in `README.md` (user-facing) + `docs/MIGRATION.md` (parity table
   with real conformance numbers) — update both with behavior changes;
   `docs/PDF_CONFORMANCE.md` for pipeline/model changes.
-- Rust 1.96, edition 2021, `cargo fmt` + clippy clean; comments explain *why*
+- MSRV 1.88 (1.85 for docling-core), edition 2021; CI lints on the 1.96
+  toolchain — `cargo fmt` + clippy clean; comments explain *why*
   (docling parity, perf tradeoffs), matching the existing dense doc-comment
   style.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ into Markdown, chunks them (streaming sliding window, or docling's
 hierarchical/hybrid chunkers via `RAG_CHUNKER`), embeds the chunks, and
 stores them in a vector database for semantic search. Every external dependency is
 a swappable trait — embedders (**Ollama**/Gemini/local-ONNX), vector stores
-(**SQLite+sqlite-vec**/PostgreSQL+pgvector), LLM (**OpenRouter**, DeepSeek-V3 by default),
+(**SQLite+sqlite-vec**/PostgreSQL+pgvector), LLM (**OpenRouter**, `deepseek/deepseek-chat` by default),
 document sources (**folder**/FTP/SFTP), and message queues
 (**in-process**/RabbitMQ/Redis). It ships Hybrid, Multi-Query fusion and HyDE
 retrieval plus an evaluation harness to compare configurations and an
@@ -140,7 +140,7 @@ curl -F file=@sheet.xlsx  'localhost:5001/v1/convert?to=dclx' -O # DocLang archi
 curl -F file=@page.html   'localhost:5001/v1/convert?to=chunks'  # chunk records
 curl -H 'content-type: application/json' \
      -d '{"url": "https://example.com/doc.pdf", "to": "md"}' \
-     localhost:5001/v1/convert                                   # fetch a URL
+     localhost:5001/v1/convert     # fetch a URL (needs --allow-url-fetch)
 
 curl -F file=@a.pdf -F file=@b.docx localhost:5001/v1/convert    # batch → JSON results array
 
@@ -160,14 +160,18 @@ an `X-Docling-Confidence` summary header (grades `poor`/`fair`/`good`/
 report under a top-level `confidence` key in `to=json` bodies.
 
 Options per request: `to=md|json|dclx|chunks`, `strict`, `images=placeholder|embedded`,
-`no_ocr`, `no_table_former`, `no_text_panels`, `pages`, `ocr_lang`, `fetch_images` — as query parameters, multipart
-fields, or JSON keys (body wins). Server flags: `--addr`, `--concurrency`,
-`--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`, `--no-url-fetch`,
-`--strict`. A container image
+`no_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
+`ocr_lang`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
+parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
+`--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
+`--allow-url-fetch`, `--no-url-fetch`, `--strict`. A container image
 builds from [`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfile)
 (models + pdfium baked in, or mounted with `--build-arg FETCH_ASSETS=0`).
-URL inputs make the server fetch outbound (SSRF surface): it binds loopback by
-default — front it with a policy proxy or pass `--no-url-fetch`.
+URL inputs are **off by default** (SSRF surface): pass `--allow-url-fetch` to
+enable them; the fetcher blocks private-IP targets
+(`DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` opts out) and caps the download size
+(`DOCLING_RS_MAX_FETCH_BYTES`). The server binds loopback by default — front
+it with a policy proxy for anything wider.
 
 ## In the browser — `docling-wasm`
 
@@ -176,8 +180,9 @@ pipelines) compile to `wasm32-unknown-unknown`:
 [`crates/docling-wasm`](./crates/docling-wasm) exposes
 `convert(bytes, filename, to)` → Markdown / docling JSON / DocLang via
 `wasm-bindgen`, so DOCX/HTML/XLSX/PPTX/EPUB/… convert **fully client-side** —
-no server, ~3.4 MB gzipped module, no models to download — something Python
-docling has no equivalent for. Ready to use from npm:
+no server, ~3.4 MB gzipped module, no models to download for the declarative
+formats (the default-on browser-OCR feature does fetch its ONNX models) —
+something Python docling has no equivalent for. Ready to use from npm:
 
 ```bash
 npm i docling.rs-wasm
@@ -187,9 +192,9 @@ npm i docling.rs-wasm
 import { convert } from "docling.rs-wasm";          // bundlers
 // import init, { convert } from "docling.rs-wasm/web"; await init();  // no bundler
 const markdown = convert(bytes, file.name, "md");
-``` Digital PDFs convert too: the opt-in
-`pdf-text` feature runs docling-pdf's pure-Rust text-layer parser (the same
-extraction as `--no-ocr`: flat paragraphs, no headings/tables/pictures),
+``` Digital PDFs convert too: the wasm build always compiles docling-pdf's
+pure-Rust text-layer parser (the `pdf-text` feature of the `docling` crate;
+the same extraction as `--no-ocr`: flat paragraphs, no headings/tables/pictures),
 while scanned PDFs get a clear "needs OCR" error instead of an empty
 document. The crate ships a drop-a-file demo page under
 [`www/`](./crates/docling-wasm/www). Native builds are untouched: the
@@ -275,7 +280,7 @@ corpus:
 use docling::chunker::{contextualize, HierarchicalChunker, HybridChunker, HuggingFaceTokenizer};
 
 let chunks = HierarchicalChunker.chunk(&result.document);          // structure-driven
-let tok = HuggingFaceTokenizer::from_file("models/tokenizer.json", 256)?; // feature "chunking", models should downloaded
+let tok = HuggingFaceTokenizer::from_file("models/chunk/tokenizer.json", 256)?; // feature "chunking"; fetched by download_dependencies.sh
 for chunk in HybridChunker::new(tok).chunk(&result.document) {
     let embed_me = contextualize(&chunk); // heading path + chunk text
 }
@@ -307,12 +312,12 @@ HuggingFace tokenizer (MiniLM etc.) sits behind the `chunking` cargo feature
 (on by default in the CLI); `--to chunks` dumps both chunkers' records.
 `scripts/install/download_dependencies.sh` fetches MiniLM's tokenizer to
 `models/chunk/tokenizer.json`, which every surface picks up automatically when
-no explicit tokenizer path is given (`DOCLING_CHUNK_TOKENIZER` overrides it
-for the CLI). The chunkers are also
+no explicit tokenizer path is given (`DOCLING_CHUNK_TOKENIZER` overrides the
+path and `DOCLING_CHUNK_MAX_TOKENS` the 256-token budget for the CLI). The chunkers are also
 exposed in the [Node bindings](./crates/docling-node) (`chunkFile` /
 `chunkDocument` + async variants), the
 [Python bindings](./crates/docling-py) (`docling_rs.chunking`), and the
-[RAG subsystem](./crates/docling-rag) (`RAG_CHUNKER=hierarchical|hybrid`). Conformance vs
+[RAG subsystem](./crates/docling-rag) (`RAG_CHUNKER=window|hierarchical|hybrid`, `window` default). Conformance vs
 docling's chunkers over the 83-doc corpus (`scripts/conformance/
 chunks_conformance.sh`): **hierarchical 98.8% / hybrid 96.2% identical chunk
 records** (text + headings), 79 and 76 of 83 documents fully exact.
@@ -608,7 +613,8 @@ instead — same models plus `pdfium.dll` — and see
 | CodeFormulaV2 (code/formula enrichment, ~1.3 GB; fetch with `--enrich`) | `models/code_formula/{vision,embed,decoder_kv}.onnx`, `models/code_formula/tokenizer.json` |
 
 Idempotent — safe to re-run; it skips files already on disk. Pass `--force` to
-re-fetch everything, or set `$DOCLING_RS_MODELS_URL` to fetch from a
+re-fetch everything, `--no-chunk` to skip the chunker tokenizer, `--embed` to
+also fetch the RAG embedder, or set `$DOCLING_RS_MODELS_URL` to fetch from a
 different host (your own export, an internal mirror, …); the Whisper assets
 come from Hugging Face (`$DOCLING_RS_ASR_MODELS_URL` overrides, or point
 `DOCLING_ASR_{ENCODER,DECODER,VOCAB}` at explicit files). pdfium is Linux x64
@@ -851,8 +857,15 @@ one host for convenience.
 
 To point at files you exported or placed elsewhere instead, set the env vars
 directly: `DOCLING_LAYOUT_ONNX`, `DOCLING_OCR_REC_ONNX`, `DOCLING_OCR_DICT`,
-`DOCLING_TABLEFORMER_{ENCODER,DECODER,BBOX}`, `PDFIUM_DYNAMIC_LIB_PATH` — an
-env var always wins over the `./models` / `./.pdfium` default.
+`DOCLING_TABLEFORMER_{ENCODER,DECODER,BBOX}`, `DOCLING_CODE_FORMULA_DIR`
+(enrichment models), `PDFIUM_DYNAMIC_LIB_PATH` — an
+env var always wins over the `./models` / `./.pdfium` default. Other
+process-wide knobs: `DOCLING_RS_PDF_THREADS` (total thread budget;
+`_WORKERS`/`_INTRA` below split it), `DOCLING_RS_TIMING=1` (per-stage
+timings on stderr), `DOCLING_RS_MAX_IMAGE_PIXELS` (image-input decompression
+cap), `DOCLING_RS_MAX_HTML_DEPTH`, `DOCLING_RS_MAX_PART_BYTES` (HTML/OOXML
+parser limits), `DOCLING_RS_IMAGE_FETCH_CONCURRENCY` (parallel `--fetch-images`
+downloads), `DOCLING_RS_VLM_EXTRA_BODY` (extra JSON merged into VLM requests).
 
 OCR recognition defaults to the **English** PP-OCRv3 model: the multilingual
 `ch_` model reads Latin text with broken word spacing (`Refactorexisting
@@ -910,7 +923,7 @@ export DOCLING_OCR_DICT="$(pwd)/models/ppocr_keys_v1.txt"
 export DOCLING_TABLEFORMER_ENCODER="$(pwd)/models/tableformer/encoder.onnx"
 export DOCLING_TABLEFORMER_DECODER="$(pwd)/models/tableformer/decoder.onnx"
 export DOCLING_TABLEFORMER_BBOX="$(pwd)/models/tableformer/bbox.onnx"
-bash scripts/conformance/pdf_conformance.sh     # regenerate + diff the snapshot baseline (91/91)
+bash scripts/conformance/pdf_conformance.sh     # regenerate + diff the snapshot baseline (94 outputs)
 ```
 
 ## Try it

--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -31,7 +31,7 @@ Decoupled from the crates.io release.
 
 This package lives in the docling.rs Cargo workspace and can also build the
 addon from Rust source — needed for local development or an unsupported
-platform. You need a Rust toolchain (1.82+) and Node.js 14+ (or Bun).
+platform. You need a Rust toolchain (1.88+) and Node.js 14+ (or Bun).
 
 ```bash
 cd crates/docling-node
@@ -339,6 +339,17 @@ then `convert` / `convertFile` / `convertFileAsync` / `convertAsync` /
 - `fetchImages`: for HTML/EPUB, resolve and embed external `<img src>`. Off by
   default; fetches http(s) URLs over the network — enable only for trusted input.
 - `allowedFormats`: restrict the converter to these format ids/extensions.
+- `pages`: convert only this PDF page window, `"A-B"` or `"N"` (1-based inclusive).
+- `ocrLang`: OCR recognition language for scanned pages, `"en"` (default) or
+  `"ch"` (the multilingual docling-conformance model).
+- `forceFullPageOcr`: OCR every PDF page even when it carries a text layer
+  (docling's `force_full_page_ocr`).
+- `noTextPanels`: keep every detected picture as a picture — disable the
+  demotion of uncaptioned dense-text "picture" regions into paragraphs (#173).
+- `asrModel` / `asrLang`: Whisper model preset and transcription language
+  (`"auto"` default) for audio/video sources.
+- `videoFrames`: max frames sampled from a video input as timestamped pictures
+  (`0` = transcript only; default 8, needs ffmpeg at runtime).
 
 ### `ConvertResult`
 

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -117,7 +117,7 @@ cd crates/docling-py
 # 1. Build + install into the CURRENT virtualenv (create one first):
 python -m venv .venv && source .venv/bin/activate
 pip install maturin
-maturin develop --release          # compiles the Rust engine, installs `docling.rs`
+maturin develop --release          # compiles the Rust engine, installs `docling-rs`
 
 # 2. One-time model download (~700 MB → ~/.cache/docling.rs), pure Python —
 #    fetched from the repo's models-v1 GitHub release, like docling fetches
@@ -139,7 +139,7 @@ PY
 
 | docling.rs | docling counterpart | notes |
 |---|---|---|
-| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, do_picture_classification=False, do_code_enrichment=False, do_formula_enrichment=False, fetch_images=False, use_web_browser=False, artifacts_path=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
+| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, force_full_page_ocr=False, no_text_panels=False, do_picture_classification=False, do_code_enrichment=False, do_formula_enrichment=False, fetch_images=False, use_web_browser=False, artifacts_path=None, ocr_lang=None, asr_lang=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
 | `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
 | `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
 | `.initialize_pipeline(format=None)` | same | pre-loads the PDF/image ML models so the first conversion isn't slow and later PDFs reuse the warm pipeline (no-op for non-ML formats; needs the models available) |

--- a/crates/docling-rag/README.md
+++ b/crates/docling-rag/README.md
@@ -110,7 +110,7 @@ curl -s -H 'X-Api-Key: dev-key' \
 | Embeddings   | `Embedder`       | **Ollama** (default, bge-m3, 1024-d), Gemini, local ONNX, hash |
 | Vector store | `VectorStore`    | **SQLite + sqlite-vec** (default), PostgreSQL + pgvector, in-memory |
 | Retrieval    | `Retriever`      | vector, BM25, **Hybrid** (RRF), Multi-Query fusion, HyDE       |
-| LLM          | `ChatModel`      | OpenRouter (default model DeepSeek-V3)                          |
+| LLM          | `ChatModel`      | OpenRouter (default model `deepseek/deepseek-chat`)                          |
 | Sources      | `DocumentSource` | **folder** (default), FTP, SFTP                                 |
 | Queues       | `MessageQueue`   | **in-process** (default), RabbitMQ, Redis pub/sub              |
 

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -58,6 +58,11 @@ convert(
 ): string
 supported_extensions(): string   // JSON array, e.g. for <input accept=…>
 version(): string
+
+// With the default-on `ocr` feature (see the browser-OCR sections below):
+new DigitalConverter()                       // reusable digital-PDF converter
+ocr_image(...)                               // recognize one raster image
+new ScannedConverter() / convert_scanned_image(...)  // scanned-page pipeline
 ```
 
 The filename's extension drives format detection, same as the CLI. `images`
@@ -296,7 +301,7 @@ multi-threading, memory-mapped models — none of which fit the wasm build.
 ```toml
 # src-tauri/Cargo.toml
 [dependencies]
-docling = { version = "0.49" }        # full default features (ml pipeline)
+docling = { version = "0.53" }        # full default features (ml pipeline)
 ```
 
 ```rust

--- a/crates/docling/src/format.rs
+++ b/crates/docling/src/format.rs
@@ -3,7 +3,7 @@
 //! Mirrors `docling.datamodel.base_models.InputFormat` and its
 //! `FormatToExtensions` map.
 
-/// A document format supported (or planned) by docling.rs backends.
+/// A document format supported by docling.rs backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InputFormat {
     Docx,
@@ -90,7 +90,7 @@ impl InputFormat {
     /// Best-effort format detection from a file extension (case-insensitive).
     ///
     /// Ambiguous extensions (notably bare `xml`) resolve to a single default
-    /// here; real disambiguation needs content sniffing, which Phase 1 adds.
+    /// here; the converter's content sniffing does the real disambiguation.
     pub fn from_extension(ext: &str) -> Option<Self> {
         Some(match ext.to_ascii_lowercase().as_str() {
             "docx" | "dotx" | "docm" | "dotm" => InputFormat::Docx,

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -19,9 +19,8 @@
 //! (including the KV-cached TableFormer decoder) into a slim, Python-free runtime
 //! image — see the "Deploy in a container" section of the README.
 //!
-//! See `docs/MIGRATION.md` for the architecture, the Python → Rust mapping, and the
-//! phased plan. Phase 0 ships the converter plumbing plus Markdown and CSV
-//! backends; PDF/DOCX/HTML and the ML pipeline land in later phases.
+//! See `docs/MIGRATION.md` for the architecture, format-by-format parity
+//! status, and how conformance against Python docling is measured.
 
 pub mod chunks;
 mod converter;

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -12,9 +12,9 @@ phased plan is kept at the end as history.)
 | Upstream Python: `docling` 2.114.0 (code wheel `docling-slim`) | 70,132 | 242 |
 | Upstream Python: `docling-core` 2.87.1 (document model, serializers, chunkers) | 30,888 | 103 |
 | **Upstream total** | **101,020** | **345** |
-| docling.rs — the port itself (`docling-core`, `docling`, `docling-pdf`, `docling-asr`, `docling-cli`) | 41,228 | — |
-| docling.rs — beyond upstream's packages (HTTP API, RAG, Python/Node/wasm bindings) | 10,538 | — |
-| **docling.rs total (`crates/*/**.rs`)** | **51,766** | **132** |
+| docling.rs — the port itself (`docling-core`, `docling`, `docling-pdf`, `docling-asr`, `docling-cli`) | 47,456 | — |
+| docling.rs — beyond upstream's packages (HTTP API, RAG, Python/Node/wasm bindings) | 11,327 | — |
+| **docling.rs total (`crates/*/src/**.rs`)** | **58,783** | **121** |
 
 Roughly **half the line count for the same behavior** — despite Rust carrying
 type/lifetime annotations Python doesn't — because the port reimplements from
@@ -27,7 +27,8 @@ ONNX pipelines), so the scope ratio understates the ported surface.
 
 **Timeline:** the first commit landed **2026-06-27**; the migration — every
 input format including PDF/ML, ASR and video, plus the serve/RAG/bindings
-extras — was done by **2026-07-23**: **26 days**, ~570 commits, migrated by
+extras — was done by **2026-07-23**: **26 days**, ~600 commits (development continues
+past that point — serve async API, confidence scores, PDF-parity work), migrated by
 [artiz](https://github.com/artiz) + Claude (Anthropic's Claude Code, doing the
 bulk of the porting under review).
 
@@ -42,7 +43,7 @@ bulk of the porting under review).
 > layout/TableFormer/OCR + a port of docling-parse's line sanitizer) and is also
 > measured byte-for-byte against live docling — **6 / 14 PDF fixtures exact, 7 / 14
 > whitespace-normalized** (see `PDF_CONFORMANCE.md`), with a snapshot baseline
-> guarding against regressions. `cargo test` is green (unit tests + a 133-source
+> guarding against regressions. `cargo test` is green (unit tests + a 159-source
 > output-regression suite).
 
 **At a glance** (for a first-time reader from the docling side):
@@ -52,7 +53,7 @@ bulk of the porting under review).
 | **What** | A Rust port of docling's converter, backends, and discriminative PDF/ASR pipelines; same `convert → DoclingDocument → export_to_markdown()/json()` shape, single static binary, no Python/torch at runtime |
 | **Conformance** | Declarative formats byte-for-byte vs *live* PyPI docling (most 100%, see §2); `.dclx` DocLang output ≈94% mean vs docling's own `.dclx`, OOXML all byte-exact (§2); PDF ML path 6/14 fixtures byte-exact, rest close; every optimization is gated on this not regressing |
 | **Performance** | PDF ML pipeline **4.3× faster warm / 4.7× end-to-end** than Python docling at 2.3–2.6× less peak RAM (INT8 + SIMD, conformance-validated); declarative formats 20–60× warm, ~60× less RAM; XLSX sheets / PPTX slides additionally fan out over rayon (~2–3× on many-sheet/slide files, conformance byte-identical); details + methodology in [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md) |
-| **Models** | docling's own checkpoints (layout heron, TableFormer, PP-OCRv3, Whisper tiny), format-converted to ONNX by `scripts/install/export_*.py` — no retraining; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
+| **Models** | docling's own checkpoints, no retraining: layout heron and TableFormer are format-converted to ONNX by `scripts/install/export_layout.py` / `export_tableformer.py` (CodeFormula by `export_code_formula.py`); PP-OCRv3 and Whisper tiny ship as their upstream ONNX exports; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
 | **Tracking upstream** | See [§9](#9-keeping-up-with-upstream-docling): conformance is measured against the *latest published* docling on demand, so an upstream release that changes output surfaces as a concrete per-fixture diff |
 | **Not ported (by design)** | local in-process VLM full-page inference (§5 — the remote OpenAI-compatible VLM pipeline **is** ported, #77); inline formatting is baked into text rather than structured fields (§4). The optional enrichment models (picture classification, code, formulas) **are** ported — opt-in `do_picture_classification` / `do_code_enrichment` / `do_formula_enrichment`, ONNX like the rest of the stack |
 
@@ -69,15 +70,17 @@ The layers mirror docling's:
 | **Backends** | `docling/backend/*` | `docling.rs` — `backend/*` (one per format) |
 | **PDF/ML pipeline** | `docling/pipeline/*`, `docling/models/*` | `docling-pdf` — pdfium + ONNX layout/OCR + assembly |
 | **Audio/ASR pipeline** | `docling/pipeline/asr_pipeline.py` | `docling-asr` — symphonia decode + log-mel + ONNX Whisper |
+| **Chunking** | `docling-core` chunkers (`HierarchicalChunker`/`HybridChunker`) | `docling-core::chunker`, re-exported as `docling::chunker` |
 | **CLI** | `docling/cli` | `docling-cli` |
+| **Beyond upstream's packages** | docling-serve (separate repo) | `docling-serve` (HTTP API), `docling-rag`, Python/Node/wasm bindings, GPU execution providers (`cuda`/`tensorrt`/`directml`/`coreml` features, `DOCLING_RS_EP`) |
 
 ```text
 crates/
-├── docling-core/   # DoclingDocument, Node model, markdown.rs, json.rs, base64.rs, labels.rs
+├── docling-core/   # DoclingDocument, Node model, markdown/json/doclang/doctags serializers, chunker.rs, confidence.rs
 ├── docling/        # DocumentConverter, source/format detection, backend/*.rs, ooxml.rs
 ├── docling-pdf/    # pdfium_backend, layout (RT-DETR/ONNX), ocr (PP-OCRv3/ONNX), assemble, mets
 ├── docling-asr/    # audio decode (symphonia), mel.rs, whisper.rs (ONNX), tokenizer.rs
-├── docling-cli/    # `--strict`, `--to md|json`, `--images placeholder|embedded|referenced`
+├── docling-cli/    # `--strict`, `--to md|json|dclx|chunks`, `--images …`, `--pages`, `--ocr-lang`, serve subcommand
 ├── docling-node/   # Node.js/Bun N-API bindings (napi-rs), published to npm as `docling.rs`
 ├── docling-py/     # PyO3 bindings (maturin), published to PyPI as `docling-rs` (strangler-fig over docling-core)
 ├── docling-rag/    # RAG layer on top of the converter (chunking, embeddings, vector search, REST API)
@@ -113,22 +116,23 @@ PyPI; run via `scripts/conformance/conformance.sh <fmt>`), not the committed gro
 | HTML | `html.rs` (scraper/html5ever) | **32/32 exact** (`wiki_duck` included — rich table cells, caption run spacing, indicator images, `<footer>` furniture all match docling 2.112) |
 | AsciiDoc | `asciidoc.rs` (regex) | **4/4 exact** |
 | DeepSeek-OCR Markdown | `deepseek.rs` | **3/3 exact** (auto-detected VLM-token variant) |
-| XLSX | `xlsx.rs` (calamine) | **9/9 exact** (incl. chart captions/classification/data grids) |
-| PPTX | `pptx.rs` (roxmltree) | **7/7 exact** |
-| DOCX | `docx.rs` (roxmltree) | **26/26 exact** |
+| XLSX | `xlsx.rs` (calamine) | **10/10 exact** (incl. chart captions/classification/data grids) |
+| PPTX | `pptx.rs` (roxmltree) | **8/8 exact** |
+| DOCX | `docx.rs` (roxmltree) | **27/27 exact** |
 | DOC (Word 97–2004) | `doc.rs` (native [MS-DOC]: CFB + piece table + PAPX/CHPX/STSH + Escher) | byte-identical Markdown to the DOCX backend on fixtures converted to `.doc` (headings, ordered/bullet lists, tables, bold/italic, and embedded pictures — inline PICF + floating shapes with decoded PNG/JPEG bytes); docling reaches these only by shelling out to LibreOffice (PR 3804) |
 | XLS (Excel 97–2004) | `xls.rs` (calamine BIFF8 + the XLSX region detection) | byte-identical to the XLSX backend on converted fixtures |
 | PPT (PowerPoint 97–2003) | `ppt.rs` (native [MS-PPT] + OfficeArt shape walker) | **byte-identical to the PPTX backend** on the sample fixture: tables reconstructed from shape-group geometry (spans included), bullet lists (StyleTextProp) and numbered lists (PP9 autonumber), titles, z-order |
 | WebVTT | `webvtt.rs` | **4/4 exact** |
 | Email (.eml) | `email.rs` (mail-parser) | **2/2 exact** |
 | EPUB | `epub.rs` → HTML backend | **0/1** — the single fixture is 4 diff lines (heading-italic nesting + a bold-run join, the HTML inline residual) |
-| ODF (odt/ods/odp) | `odf.rs` | **6/6 exact** on the native files — slide-title/name headings, shape text, speaker-notes drop, chart classification + data tables, merged-cell semantics (plain repeat vs rich dedup), and docling's run-tail quirk |
+| ODF (odt/ods/odp) | `odf.rs` | **7/7 exact** on the native files — slide-title/name headings, shape text, speaker-notes drop, chart classification + data tables, merged-cell semantics (plain repeat vs rich dedup), and docling's run-tail quirk |
 | JATS | `jats.rs` (roxmltree) | **3/4 exact**; the eLife plain-text route diverges (252 diff lines) |
 | USPTO | `uspto.rs` | **1/5 exact (2/5 whitespace-normalized)** on the sources live docling converts — it errors on the other 5 (those are validated byte-exact via `.dclx`), and its APS-text *Markdown* export is empty where ours emits the text dump (the `.dclx` matches exactly — §5) |
 | XBRL | `xbrl.rs` | arelle-free core (dei facts → title, `*TextBlock` → HTML); *vs committed groundtruth* 0/2 (30 / 346 diff lines) — live docling needs arelle, which the conformance venv doesn't ship |
-| JSON-docling | `docling_json.rs` (serde_json) | reads docling's native JSON; ~51/145 round-trip exact |
+| JSON-docling | `docling_json.rs` (serde_json) | reads docling's native JSON back into the `Node` model ($ref body tree, formatting, list nesting, table grids) |
 | DocLang (`.dclg`/`.dclx`) | `doclang.rs` (roxmltree) | **15/15 exact** vs live docling reading the same archives back (`tests/data/doclang`); the inverse of the `.dclx` output serializer, incl. docling's round-trip losses (list-item formatting, hyperlink targets) |
-| LaTeX | `latex.rs` (scanner) | simple `.tex` ≈ live (0/2 exact, but within 2 / 9 diff lines); multi-file arxiv out of scope |
+| DocTags (`.doctags`/`.dt`) | `docling-core::doctags` | reads the SmolDocling/granite-docling token stream back into a `DoclingDocument` (#152) |
+| LaTeX | `latex.rs` (scanner) | simple `.tex` ≈ live (0/2 exact, but within 2 / 9 diff lines); multi-file arXiv projects convert too — 6 projects carry committed groundtruth and snapshot pinning (`tests/snapshots/latex`) |
 | MHTML (.mhtml/.mht) | `mhtml.rs` (mail-parser) → HTML backend | **docling.rs extension — no docling backend to compare against**; embedded images resolved by `Content-Location`/`cid:` |
 
 Shared OOXML infrastructure (`ooxml.rs`): a `zip` reader, `.rels` parsing, part
@@ -154,7 +158,7 @@ close — see `PDF_CONFORMANCE.md`. A deterministic snapshot baseline
 The `.dclx` DocLang output (§3) is scored against docling's own `.dclx` archives
 with `scripts/conformance/dclx_conformance.sh` — the extracted `document.xml`
 line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈94% mean over the
-134-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format:
+136-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format:
 
 | Format | `.dclx` similarity | Format | `.dclx` similarity |
 |---|---|---|---|
@@ -237,7 +241,7 @@ work (checkbox inputs, fragmented-anchor folding, `<button>` blocks) plus the
   tables (`<ched>`/`<fcel>`/`<lcel>`…) with per-cell `<location>`, code, formulas,
   pictures and furniture. Conformance is scored against docling's own `.dclx`
   archives (`scripts/conformance/dclx_conformance.sh`): **≈94% mean similarity over
-  the 134-fixture non-PDF corpus** (issue #32's ≥90% target) — every OOXML fixture
+  the 136-fixture non-PDF corpus** (issue #32's ≥90% target) — every OOXML fixture
   (docx/pptx/xlsx) plus csv/asciidoc/email byte-exact, uspto/jats in the
   mid-to-high 90s, md/odf/latex low 90s, html/webvtt in the 80s (full table
   in §2). The format-by-format work was
@@ -253,7 +257,8 @@ work (checkbox inputs, fragmented-anchor folding, `<button>` blocks) plus the
 - **JSON** rebuilds docling's full `body`-tree-of-`$ref`s model from the `Node`
   tree (texts/groups/tables/pictures, labels, list grouping, table grids,
   formula/code items, picture `ImageRef`s). It loads back into Python
-  docling-core and **~91% round-trips** byte-identically to the direct Markdown.
+  docling-core and **~91% round-tripped** byte-identically to the direct
+  Markdown when measured at the JSON-export milestone.
 - **Image extraction** is wired for PDF/image (figure-region crops) and DOCX/PPTX
   (embedded blobs) by default, and — opt-in via
   `DocumentConverter::fetch_images` (`--fetch-images`) — for HTML/EPUB `<img src>`:
@@ -394,7 +399,7 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   placeholder is identical without rendering), pictures are emitted for
   heading/list/checkbox paragraphs too, and the textbox de-duplication matches
   docling's per-paragraph scope — `drawingml` and `textbox` are exact,
-  **DOCX is 26/26**.
+  **DOCX is 27/27**.
 
 - **Legacy APS-text patents.** USPTO covers the modern `v4x` XML, the 2001-era
   `pap-v15` applications (`pa`) and `PATDOC`/ST.32 grants (`pg`) with their CALS
@@ -403,7 +408,7 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   that serialization byte-exactly — the `.dclx` is a perfect match
   ([issue #44](https://github.com/docling-project/docling.rs/issues/44), done).
 
-- **ODF presentation frames** — done, **6/6 native files exact**: `.odp`
+- **ODF presentation frames** — done, **all native files exact**: `.odp`
   slides get their title frame (or slide name) as the title, free shape text,
   chart pictures with classification ("Bar chart") + data tables, and the
   speaker-notes drop; `.odt` merged cells repeat their text like docling's
@@ -455,12 +460,17 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   regression suite** (`crates/docling/tests/regression.rs`): every
   declarative source under `crates/docling/tests/data/<fmt>/sources/` is
   converted to legacy Markdown, strict Markdown and docling JSON and compared to
-  committed fixtures (133 sources × 3). `DOCLING_RS_REGEN=1` refreshes them.
+  committed fixtures (159 sources × 3). `DOCLING_RS_REGEN=1` refreshes them.
   The JSON fixtures double as a docling-core load check.
 - **Snapshot harness** — `scripts/conformance/pdf_conformance.sh` regenerates and diffs the
-  PDF/image/METS baseline (needs pdfium + the ONNX models; **91/91 exact**).
+  PDF/image/METS baseline (needs pdfium + the ONNX models; **94 outputs, all
+  matching the committed baseline**).
 - **Conformance** — `scripts/conformance/conformance.sh <fmt>` scores a format against the
   latest published docling (installed from PyPI; how-to in §9).
+- **VLM / DocLang extras** — `scripts/conformance/vlm_conformance.sh` (VLM
+  pipeline vs Python docling's `VlmPipeline`) and
+  `scripts/conformance/dclx_pdf_tol_sweep.sh` (geometry-tolerance sweep for
+  the PDF `.dclx` diff).
 - **Differential / perf** — `scripts/conformance/compare.sh`, `scripts/test/performance.sh`.
   The PDF pipeline's profiling data, the INT8/SIMD optimization results
   (4.3× warm vs Python docling on the ML pipeline), and the remaining
@@ -474,7 +484,8 @@ CI on unrelated commits; tests run on current `stable`. On master it then runs
 `scripts/ci/release.sh`: it derives the next version from the conventional-commit
 messages since the last `v*` tag (`feat:` → minor, `fix:`/`perf:` → patch, a
 `type!:`/`BREAKING CHANGE` → major; docs/chore/ci/etc → no release), bumps the
-workspace version, commits + tags it (with `[skip ci]`, via `GITHUB_TOKEN`, so it
+workspace version, commits + tags it (with `[skip ci]`, via the `RELEASE_PAT`
+admin token — needed to satisfy the master ruleset — so it
 doesn't loop), and publishes the crates with `scripts/ci/ci_publish.sh` in
 dependency order — skipping any version already on crates.io.
 
@@ -513,11 +524,11 @@ process instead of a guess:
    `.github/workflows/publish-models.yml` republishes the model release
    (bump the tag when the export itself changes).
 3. **Re-gate.** `scripts/conformance/pdf_conformance.sh` (deterministic snapshot baseline)
-   plus the 133-source regression suite in `cargo test` confirm nothing else
+   plus the 159-source regression suite in `cargo test` confirm nothing else
    moved. The committed PDF groundtruth is regenerated from live docling
    (`scripts/conformance/pdf_groundtruth.sh`) whenever upstream output legitimately
    changes, so "exact" always means *exact against current docling*.
-4. **New formats/features** follow the same recipe the existing 20 formats
+4. **New formats/features** follow the same recipe the existing 30 formats
    did: a backend module + fixtures + conformance scoring, tracked in §2.
 
 ### Running the comparison yourself

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -2,8 +2,11 @@
 
 How close the Rust PDF pipeline gets to docling's **default** Markdown, measured
 byte-for-byte against the committed groundtruth (`tests/data/pdf/groundtruth/*.md`).
-The groundtruth is regenerated from **live published docling**, so it agrees with
-`scripts/conformance/conformance.sh pdf`.
+The groundtruth is regenerated from **live published docling**. The numbers in
+this document are measured with `scripts/conformance/pdf_groundtruth.sh`,
+which pins the conformance model set (fp32 layout/OCR env overrides below);
+`scripts/conformance/conformance.sh pdf` runs the *default* (int8, English-OCR)
+models over every source PDF, so its totals differ from this table.
 
 > Measure locally with `scripts/conformance/pdf_groundtruth.sh` (diffs the checked-in
 > reference; no docling install needed) or `scripts/conformance/conformance.sh pdf` (installs
@@ -34,7 +37,7 @@ are no longer scored.)
 | 2203.01017v2 | 74 | caption order + reference-accent spacing (in-picture table recovered: same grid as docling, different OCR engine noise) |
 | 2206.01062 | 82 | author-block cluster splits (model-borderline) + one int8-borderline header rowspan |
 
-`amt` is the 6th under the whitespace-normalized metric: its only diff is
+`amt` is the 7th under the whitespace-normalized metric: its only diff is
 docling's spurious double space before the `1⁄4` fraction, where our single-spaced
 output is the more faithful rendering. The remaining non-exact PDFs are heavy
 multi-column / table docs whose gaps are model-level (TableFormer structure,
@@ -43,9 +46,10 @@ layout classification, title-page reading order), not text-layer.
 The heavy table docs improved with the docling-parse **word-cell** grouping
 feeding TableFormer and the #61 layout/reading-order postprocessor
 (2305.03393v1 93→30, 2203.01017v2 209→161, 2206.01062 198→92): the parser's
-per-word cells reproduce docling-parse's `word_cells` byte-for-byte, so
-cell-to-grid matching tracks docling more closely. See "Text reconstruction"
-below. The #60 matching work (docling's `MatchingPostProcessor` ported to
+per-word cells reproduced docling-parse's `word_cells` closely enough that
+cell-to-grid matching tracked docling much better (the word grouping was later
+replaced wholesale by the `create_word_cells` port described below). See
+"Text reconstruction" below. The #60 matching work (docling's `MatchingPostProcessor` ported to
 `tf_match.rs`, plus docling's exact table-crop rounding chain) took
 2203 157→150 and redp5110 204→202 with every other fixture unchanged; the
 #62 text fixes (docling-parse's quote-normalization table — every curly
@@ -183,9 +187,11 @@ TableFormer), picture-child divergence (2305's HTML/OTSL figure axis labels),
 RTL/checkbox forms (right_to_left_03), and docling-parse artifacts we
 deliberately don't reproduce (`/tildelow`, `/.notdef` glyph-name leaks).
 
-The audit exposed one systematic hole, now closed: docling assigns each cell
-to its best cluster at > 0.2 overlap and serializes the assigned cells, while
-our serializer takes cells at > 0.5 — a cell whose best overlap fell in
+The audit exposed one systematic hole, closed at the time by raising the
+orphan claim to mirror the then-> 0.5 serializer (and later closed
+*structurally* by the exclusive > 0.2 assignment above): docling assigns each
+cell to its best cluster at > 0.2 overlap and serializes the assigned cells,
+while our serializer took cells at > 0.5 — a cell whose best overlap fell in
 (0.2, 0.5] was "claimed" but emitted by nobody (right_to_left_03's standalone
 `20300`, several Korean labels on the skipped_1/2page scans). The orphan
 pass's claim test now mirrors the serializer's criterion, so **every
@@ -387,12 +393,13 @@ ligature recomposition, and loose-box geometry. On the clean parser boxes it use
 the Euclidean corner gap (matching docling); on pdfium's loose boxes it keeps the
 signed horizontal gap.
 
-The same contraction also produces **word cells** (`dp_lines::word_cells`): a word
-is a maximal run of glyphs the contraction merges *without* inserting a separator
-space, so the per-word segments split at exactly the `delta < gap` points — which
-reproduces docling-parse's `word_cells` byte-for-byte (377/377 on 2305-pg9). These
-are the per-word tokens TableFormer matches against table-grid cells, replacing
-pdfium's word cells (roadmap item 6). **Code cells** come from the parser too,
+**Word cells** come from a second contraction over the same char cells
+(`create_word_cells`, see the word-cell section above): the word factors
+(adjacency gate 0.33, space threshold 2 × 0.33) with space glyphs dropped up
+front as pure word-boundary barriers — verified against the installed
+docling-parse oracle (redp5110 pages byte-exact). These are the per-word
+tokens TableFormer matches against table-grid cells, replacing pdfium's word
+cells (roadmap item 6). **Code cells** come from the parser too,
 via a gap-based grouping (`Grouping::CodeGap`): the parser emits no space glyphs
 (a source space is a positioning gap), so a word breaks wherever the inter-glyph
 gap exceeds ~0.25× the line height, with no punctuation glue — `et al. 2000`
@@ -427,7 +434,8 @@ model-level (or by-design) residual each issue closed with:
    from live docling on the hard crops (redp5110's TOC predicts `ched` where
    docling gets `fcel`; multi-row headers / spans on 2206, 2203), so one
    cell-structure diff still cascades through the padded columns into many row
-   diffs (2206's ~92 table-row diffs trace to ~4 structure diffs). A parity
+   diffs (at the time, 2206's ~92 table-row diffs traced to ~4 structure
+   diffs; today its one remaining table diff is a single header rowspan). A parity
    harness (`DOCLING_RS_TF_MATCH_DUMP=dir` + `scripts/test/tf_match_reference.py`-style
    replay through docling's Python post-processor) confirmed the ported matcher
    reproduces the reference on identical inputs, isolating the residual to the
@@ -443,14 +451,18 @@ model-level (or by-design) residual each issue closed with:
    table-of-contents index), the picture-vs-table cross-type rule
    (`_handle_cross_type_overlaps`), and dropping a regular region absorbed by a
    table/index/picture so it isn't emitted twice. With this, table_mislabeled's
-   survey is no longer over-detected as tables (108 → 88 vs groundtruth), and
+   survey over-detection dropped sharply at the time (108 → 88 vs groundtruth;
+   54 today — over-detection remains its dominant blocker), and
    redp5110's table-of-contents is now classified and rendered as a **table**
    (`document_index`) instead of a picture. The TOC table's remaining diff is a
-   TableFormer dot-leader column-matching gap, tracked with the other
+   TableFormer dot-leader column-matching gap — later found to be largely
+   word-cell tokenization (the create_word_cells port took redp5110 164→73)
+   — tracked with the other
    table-structure work in
    [#60](https://github.com/docling-project/docling.rs/issues/60). *(The
-   groundtruth byte counts in the table above predate this change; regenerate the
-   committed snapshots with the `models-v1` models to refresh them.)*
+   per-fixture byte counts quoted in this item are from its era; the committed
+   snapshots and the Current-state table above are regenerated with every
+   parity change.)*
 3. **Complex title-page reading order**
    ([#62](https://github.com/docling-project/docling.rs/issues/62)). Author-block
    / abstract interleaving on the academic papers (band reading-order handles the
@@ -546,7 +558,8 @@ Two conclusions drive everything below:
 
 The worker-pool topology heuristic in `lib.rs` (`workers × intra ≈ cores`,
 default 2×2 on 4 cores) was re-validated: 2×2 beat both 4×1 and 1×4 on the
-16-page document (11.6 s vs 12.2 s vs 15.6 s).
+16-page document (11.6 s vs 12.2 s vs 15.6 s; separate run from the INT8
+table below, hence the ±0.1 s vs its 11.5 s).
 
 ### Validated win: INT8 quantization (quality-checked)
 
@@ -566,11 +579,17 @@ Calibrated on 42 real corpus pages preprocessed exactly like
 `layout.rs::predict`. Only the HGNetv2 backbone convolutions are quantized;
 the transformer decoder and detection-head MatMuls stay fp32.
 
-| Configuration | layout.predict (16-page doc) | end-to-end wall | model size |
+| Configuration | layout.predict (16-page doc)¹ | end-to-end wall | model size |
 |---|---:|---:|---:|
 | fp32 baseline | 17.2 s | 16.6 s | 172 MB |
 | **INT8 conv-only** | **7.2 s (2.4×)** | 11.5 s (1.45×) | 68 MB |
-| + INT8 TableFormer decoder | — | **12.3 s → see note** | — |
+| + INT8 TableFormer decoder | — | 12.3 s² | — |
+
+¹ `layout.predict` is summed across the parallel page workers, so it can
+exceed the end-to-end wall.
+² Separate run; within run-to-run noise of the 11.5 s conv-only wall — the
+INT8 decoder's own win is per-table (~10 % faster tables, byte-identical;
+see its section below), not end-to-end on this document.
 
 On text-dominated documents (layout = 80% of time) the end-to-end gain
 approaches ~1.7–2×; on table-heavy ones it is ~1.4×.
@@ -592,7 +611,8 @@ degradation. With layout halved, `image.resize` becomes the next stage
 (24.8% of the INT8 run), which is why backlog item 4 matters more after
 quantization.
 
-**Quality gate.** Markdown diffed across the full PDF+scanned corpus (23 files):
+**Quality gate** (measured at INT8-selection time over the then-23-file
+PDF+scanned corpus):
 
 - Conv-only INT8: 12/23 byte-identical to fp32; remaining diffs are small
   region-classification flips. Against the committed groundtruth the summed
@@ -757,7 +777,7 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
      them in place. Per-step decode fell 17 → 10 ms and `tableformer.structure`
      1.40 → 0.91 s on the huge-table page (2305.03393v1-pg9, fp32); the
      remaining step cost is real compute (28 small projection/FFN GEMMs).
-     Output stays byte-identical (91/91 snapshot corpus; the export
+     Output stays byte-identical (the full snapshot corpus, 94 outputs; the export
      self-verifies a 64-step argmax-identical rollout vs the legacy graph).
      Export subtlety: the example inputs must carry `past>0` or
      `torch.export` specializes `pe[cache.shape[3]]` to `pe[0]` and decode
@@ -777,9 +797,9 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
    from the torch-folded constant (enough to flip borderline detections
    corpus-wide — groundtruth exact matches dropped 5/14 → 0/14 before the
    fix), so the exporter folds the static graph's position-embedding subgraph
-   offline and splices the constant into the dynamic graph. Verified:
-   groundtruth parity restored (5/14 exact, 6/14 normalized), and batch=1 ==
-   batch=4 **bit-identical** across the whole corpus.
+   offline and splices the constant into the dynamic graph. Verified at the
+   time: groundtruth parity restored (then 5/14 exact, 6/14 normalized), and
+   batch=1 == batch=4 **bit-identical** across the whole corpus.
 4. **The 3×→2× page downscale** (~15% of a text-heavy conversion, ~25% after
    INT8): ~~replace the scalar `image`-crate CatmullRom with a SIMD
    convolution.~~ **Done on this branch:** `fast_image_resize` with the same
@@ -800,15 +820,16 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
      name, which feeds the docling-parse font hash). Identical output across
      the corpus; 3–10% off the `textparse` stage on the test fixtures (their
      ToUnicode CMaps are small — CJK/form-heavy documents benefit far more).
-   - ~~`line_cells` + `word_cells` run the identical build+contract twice per
-     page; one pass can emit both.~~ **Done on this branch**
-     (`dp_lines::line_and_word_cells`): ~1.25× faster `--no-ocr` conversion,
-     identical output.
+   - ~~`line_cells` + `word_cells` re-built the char cells twice per page.~~
+     **Done** (`dp_lines::line_and_word_cells`): the glyph build is shared;
+     the line and word views each run their own contraction (docling-parse's
+     `create_line_cells` / `create_word_cells` pair — deliberately two
+     passes, since the factors differ).
    - `decode_code`/`decompose_ligatures` allocate a `String` per glyph
-     (`textparse.rs:94-145`); decompose once at font-parse time and return
+     (`textparse.rs`); decompose once at font-parse time and return
      borrowed `&str`.
-   - RTL merge is O(n²) (string prepend + `Vec::remove(0)`,
-     `dp_lines.rs:87-155`); accumulate reversed and flip once per line.
+   - RTL merge is O(n²) (string prepend in `merge_with`, `dp_lines.rs`);
+     accumulate reversed and flip once per line.
 6. ~~**OCR line batching** (`ocr.rs::recognize`): lines are recognized one at
    a time on one thread (deliberately, for CTC determinism). Batching
    same-width buckets keeps determinism per line.~~ **Done on this branch**


### PR DESCRIPTION
Full audit of README, MIGRATION, PDF_CONFORMANCE, CLAUDE.md and the crate READMEs against the code, fixing everything that no longer describes it:

README:
- serve: URL inputs are OFF by default — document --allow-url-fetch (the flag list only had --no-url-fetch, inverting reality), the private-IP block + DOCLING_RS_{MAX_FETCH_BYTES,ALLOW_PRIVATE_IP_FETCH} knobs, and the missing per-request options (force_full_page_ocr, asr_model, asr_lang, video_frames)
- chunker example used models/tokenizer.json (no such path) instead of models/chunk/tokenizer.json; DOCLING_CHUNK_MAX_TOKENS documented
- wasm: text-layer PDF is always compiled in (not 'opt-in pdf-text'), 'no models to download' qualified (browser OCR fetches ONNX)
- download script: --no-chunk / --embed flags; RAG_CHUNKER gains its 'window' default; more user-facing env vars listed

MIGRATION: fixture counts refreshed (DOCX 27/27, XLSX 10/10, PPTX 8/8, ODF 7/7, regression suite 159x3, dclx corpus 136, snapshots 94, 30 formats), DocTags input row added, LaTeX arXiv-project support noted, LOC table recounted (58.8k/121 files), layer table gains chunking and the beyond-upstream extras (incl. GPU EPs), crate-tree lines updated, model-export script list corrected, release push credited to RELEASE_PAT (not GITHUB_TOKEN), VLM/DocLang harnesses listed.

PDF_CONFORMANCE: 'amt is the 6th' -> 7th; era-qualified the paragraphs superseded by later work (pre-create_word_cells word-cell claims, the
>0.5 orphan-claim mirror, 2206's ~92 table diffs, table_mislabeled
108->88, redp's dot-leader attribution, the 5/14 export verification); the Text-reconstruction section now describes the dual line/word contraction; conformance.sh vs pdf_groundtruth.sh measurement scope clarified (only the latter pins the conformance models); INT8 table footnoted (summed-across-workers, run-to-run delta); stale code line refs replaced with name refs.

Crate READMEs: docling-py constructor signature gains force_full_page_ocr/no_text_panels/ocr_lang/asr_lang and installs docling-rs (not docling.rs); docling-node options list gains pages/ ocrLang/forceFullPageOcr/noTextPanels/asrModel/asrLang/videoFrames and MSRV 1.88; docling-wasm Tauri snippet bumped 0.49 -> 0.53 and the API block lists the OCR-feature exports; docling-rag default model named exactly (deepseek/deepseek-chat).

CLAUDE.md: only docling-py sits outside the workspace; the wasm check is the wasm32-target CI gate; MSRV 1.88 vs the 1.96 lint toolchain. Stale rustdoc in docling (Phase-0 framing, 'planned' formats, 'Phase 1 adds sniffing') rewritten to the current state.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT