### PR TITLE
feat: launch polish — actionable missing-assets errors, --no-ocr fall…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Something converts wrong, errors out, or crashes
 title: ''
 labels: ''
 assignees: ''
@@ -8,23 +8,32 @@ type: Bug
 
 ---
 
-**Description**
-A clear and concise description of what the bug is.
+**What happened**
+A clear description of the bug. If the output is wrong (vs Python docling or
+vs expectations), a snippet of *got* vs *expected* is ideal.
 
-**Steps to reproduce** (optional)
+**Command / code**
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+```bash
+docling-rs --to md input.pdf
+```
 
-**Expected behavior**  (optional)
-A clear and concise description of what you expected to happen.
+**Input document**
+Attach the file if you can (drag & drop; zip it if GitHub rejects the
+extension) — most conversion bugs are input-specific and reproduce instantly
+with the file. If it's confidential, say so; the format + a rough description
+(scanned/digital, language, produced by which app) still helps.
 
-**Screenshots**  (optional)
-If applicable, add screenshots to help explain your problem.
+**Full error output**
+
+```text
+paste stderr here
+```
 
 **Environment**
- - Desktop OS: [e.g. iOS]/Device: [e.g. iPhone6] + OS: [e.g. iOS8.1]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- docling.rs version: `docling-rs --version` / crate / npm / PyPI version
+- Installed via: `install.sh` | prebuilt binary | `cargo install` | npm | pip | Docker | source
+- OS / arch: e.g. Ubuntu 24.04 x86_64, macOS 15 arm64, Windows 11
+- For PDF/image issues: are the models + pdfium downloaded
+  (`scripts/install/download_dependencies.sh`)? GPU (`DOCLING_RS_EP`) or CPU?

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -1,0 +1,118 @@
+# Prebuilt `docling-rs` CLI binaries attached to each GitHub Release.
+# `cargo install docling-cli` means several minutes of compiling on the user's
+# machine; a downloadable binary is the first thing launch-day visitors look
+# for. Runs automatically when ci.yml publishes a release (the release is
+# created with RELEASE_PAT, so the `release: published` event fires for this
+# workflow), or on manual dispatch for an existing tag.
+#
+# macOS prebuilds are omitted for the same reason as in npm-publish.yml:
+# GitHub-hosted macOS runners are blocked in this environment, and darwin
+# can't be cross-compiled from Linux (needs the Apple SDK) — macOS users
+# `cargo install docling-cli` or build from source. To re-add when macOS
+# runners become available:
+#   - { target: aarch64-apple-darwin, host: macos-14 }
+#   - { target: x86_64-apple-darwin,  host: macos-14 }
+#
+# The binaries are the *default* build (CPU; ONNX Runtime statically linked by
+# ort's download-binaries, same as every other build of this workspace). The
+# runtime assets (pdfium + models) stay a separate download —
+# scripts/install/download_dependencies.sh — exactly as with a cargo install;
+# the CLI prints that instruction when they are missing.
+
+name: cli-binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build binaries for (e.g. v0.55.0). The assets upload to that release."
+        required: true
+
+permissions:
+  contents: write # gh release upload
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            host: ubuntu-22.04
+          # Native ARM64 Linux runner — avoids cross-compiling the ONNX/ort build.
+          - target: aarch64-unknown-linux-gnu
+            host: ubuntu-24.04-arm
+          - target: x86_64-pc-windows-msvc
+            host: windows-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      # rustup is preinstalled on GitHub-hosted runners; the org allowlists only
+      # GitHub-owned / vetted actions, so no marketplace toolchain action.
+      - name: Install Rust (stable)
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add ${{ matrix.target }}
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-cargo-cli-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-cli-${{ matrix.target }}-
+
+      - name: Build
+        shell: bash
+        run: cargo build --release --locked -p docling-cli --target ${{ matrix.target }}
+
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          bin="target/${{ matrix.target }}/release/docling-rs"
+          strip "$bin"
+          tar -czf "docling-rs-$TAG-${{ matrix.target }}.tar.gz" -C "$(dirname "$bin")" docling-rs
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: 7z a "docling-rs-$TAG-${{ matrix.target }}.zip" "./target/${{ matrix.target }}/release/docling-rs.exe"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-${{ matrix.target }}
+          path: docling-rs-*
+          if-no-files-found: error
+
+  upload:
+    name: attach to release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: cli-*
+          path: assets
+          merge-multiple: true
+
+      # Idempotent: --clobber replaces same-named assets on a re-run.
+      - name: Upload to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: gh release upload "$TAG" assets/* --repo "${{ github.repository }}" --clobber

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 A Rust port of [docling](https://github.com/docling-project/docling): convert
 documents into a unified `DoclingDocument` for downstream AI workflows.
 
+**Fast and small:** one static binary, no Python/PyTorch at runtime. The PDF
+ML pipeline runs **4.3× faster** than Python docling at **2.3–2.6× less peak
+RAM**; declarative formats (DOCX/HTML/XLSX/…) convert **20–60× faster** at
+**~60× less memory** — methodology and per-fixture numbers in
+[`docs/PDF_CONFORMANCE.md`](./docs/PDF_CONFORMANCE.md).
+
 The format migration is **complete** — every document format in docling's
 pipeline is supported, validated byte-for-byte against live docling. See
 [`docs/MIGRATION.md`](./docs/MIGRATION.md) for the full architecture, the Python → Rust
@@ -1021,16 +1027,20 @@ into `.venv-compare` automatically on first run. See
 
 ## Install locally / in CI (one-liner)
 
-`scripts/install/install.sh` builds the CLI from source and installs a self-contained
-tree — for a dev box or a pipeline step:
+`scripts/install/install.sh` installs a self-contained tree — for a dev box or
+a pipeline step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/docling-project/docling.rs/master/scripts/install/install.sh | bash
 docling-rs your.pdf > out.md
 ```
 
-It checks for a Rust toolchain (installs one via rustup if `cargo` is
-missing), runs `cargo build --release -p docling-cli`, installs the
+It grabs the **prebuilt CLI binary** from the latest
+[GitHub Release](https://github.com/docling-project/docling.rs/releases)
+(Linux x64/arm64; `DOCLING_RS_FROM_SOURCE=1` opts out) and only falls back to
+building from source when no matching asset exists — in that case it checks
+for a Rust toolchain (installs one via rustup if `cargo` is missing) and runs
+`cargo build --release -p docling-cli`. Either way it installs the
 binary + all models + pdfium under `/usr/local/docling.rs`, symlinks
 `/usr/local/bin/docling-rs`, and writes `/etc/profile.d/docling-rs.sh` with
 the `DOCLING_*`/`PDFIUM_*` exports. The env file is a convenience for other

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -71,7 +71,10 @@
 //!                      reading order (no headings/lists/tables/pictures). The
 //!                      fastest option, but a scanned/image-only PDF (no
 //!                      embedded text layer) yields no text — convert those
-//!                      without this flag.
+//!                      without this flag. Also works when pdfium/the models
+//!                      aren't installed at all (e.g. a bare `cargo install`):
+//!                      a digital PDF falls back to the pure-Rust text-layer
+//!                      extraction.
 //!   --use-web-browser  pre-render HTML/MHTML/EPUB in the system Chromium (driven
 //!                      from Rust) so stylesheet-driven `display:none` elements
 //!                      (e.g. a collapsed nav menu) are dropped before parsing.
@@ -344,6 +347,7 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    let is_pdf = source.format == InputFormat::Pdf;
 
     if let Some(runs) = bench_warm {
         return match bench_warm_conversion(&source, runs, no_table_former, no_ocr) {
@@ -419,12 +423,18 @@ fn main() -> ExitCode {
         let stream = match converter.convert_streaming_images(source, image_mode) {
             Ok(s) => s,
             Err(e) => {
+                if let Some(doc) =
+                    pdf_no_ocr_fallback(&e.to_string(), is_pdf, no_ocr, strict, &path, pages)
+                {
+                    return output_document(doc, &to, image_mode, &path);
+                }
                 eprintln!("error: {e}");
                 return ExitCode::FAILURE;
             }
         };
         let stdout = io::stdout();
         let mut out = io::BufWriter::new(stdout.lock());
+        let mut wrote_any = false;
         for chunk in stream {
             match chunk {
                 Ok(s) => {
@@ -432,9 +442,25 @@ fn main() -> ExitCode {
                         eprintln!("error: writing output: {e}");
                         return ExitCode::FAILURE;
                     }
+                    wrote_any = wrote_any || !s.is_empty();
                 }
                 Err(e) => {
                     let _ = out.flush();
+                    // The ML pipeline binds pdfium lazily, so the missing-assets
+                    // error can surface here — but only fall back while nothing
+                    // has been printed, to never emit a document twice.
+                    if !wrote_any {
+                        if let Some(doc) = pdf_no_ocr_fallback(
+                            &e.to_string(),
+                            is_pdf,
+                            no_ocr,
+                            strict,
+                            &path,
+                            pages,
+                        ) {
+                            return output_document(doc, &to, image_mode, &path);
+                        }
+                    }
                     eprintln!("error: {e}");
                     return ExitCode::FAILURE;
                 }
@@ -453,11 +479,53 @@ fn main() -> ExitCode {
     let document = match converter.convert(source) {
         Ok(result) => result.document,
         Err(e) => {
+            if let Some(doc) =
+                pdf_no_ocr_fallback(&e.to_string(), is_pdf, no_ocr, strict, &path, pages)
+            {
+                return output_document(doc, &to, image_mode, &path);
+            }
             eprintln!("error: {e}");
             return ExitCode::FAILURE;
         }
     };
     output_document(document, &to, image_mode, &path)
+}
+
+/// Launch-blocker fallback: a bare `cargo install docling-cli` ships neither
+/// pdfium nor the ONNX models, so the first PDF a new user tries dies at
+/// pipeline startup. Under `--no-ocr` the pure-Rust text-layer path needs no
+/// runtime assets at all — when the failure is exactly "assets missing"
+/// (matched on the markers docling-pdf's enriched errors carry), convert the
+/// embedded text layer instead of failing. Any other error, or a run without
+/// `--no-ocr`, returns `None` and the (actionable) error prints as usual.
+fn pdf_no_ocr_fallback(
+    err: &str,
+    is_pdf: bool,
+    no_ocr: bool,
+    strict: bool,
+    path: &str,
+    pages: Option<(usize, usize)>,
+) -> Option<docling::DoclingDocument> {
+    let assets_missing =
+        err.contains("pdfium library is not installed") || err.contains("model not found at");
+    if !is_pdf || !no_ocr || !assets_missing {
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    let name = Path::new(path).file_name()?.to_string_lossy().into_owned();
+    match docling::pdf_text_layer_pages(&bytes, &name, pages) {
+        Ok(mut doc) if !doc.nodes.is_empty() => {
+            eprintln!(
+                "warning: pdfium/models unavailable — --no-ocr extracted the embedded text \
+                 layer only (run scripts/install/download_dependencies.sh for the full pipeline)"
+            );
+            doc.strict_markdown = strict;
+            Some(doc)
+        }
+        // A scanned PDF has no text layer; the original error explains the
+        // missing assets better than an empty document would.
+        _ => None,
+    }
 }
 
 /// The buffered output tail shared by the standard (non-streaming) and VLM
@@ -758,6 +826,19 @@ fn run_batch(
                                     "fatal: the requested execution provider is \
                                      unavailable — aborting the batch (fix the \
                                      DOCLING_RS_EP runtime libraries or unset it)"
+                                );
+                            }
+                            // Missing pdfium/models fails every PDF/image the
+                            // same way — one report is enough (the error above
+                            // already says how to install the assets).
+                            if e.contains("pdfium library is not installed")
+                                || e.contains("model not found at")
+                            {
+                                abort.store(true, Ordering::Relaxed);
+                                eprintln!(
+                                    "fatal: the PDF runtime assets are missing — \
+                                     aborting the batch (every PDF/image would \
+                                     fail identically)"
                                 );
                             }
                         }

--- a/crates/docling-pdf/src/layout.rs
+++ b/crates/docling-pdf/src/layout.rs
@@ -156,6 +156,19 @@ impl LayoutModel {
     }
 
     fn open_session(path: &str, intra: usize) -> Result<Session, String> {
+        // The layout model is the pipeline's first hard model dependency; a
+        // missing file here almost always means the models were never
+        // downloaded (`cargo install` ships none) — say what to do.
+        if !std::path::Path::new(path).exists() {
+            return Err(format!(
+                "layout: model not found at {path} — PDF/image conversion needs \
+                 the ONNX models: fetch them with \
+                 scripts/install/download_dependencies.sh from a docling.rs \
+                 checkout (https://github.com/docling-project/docling.rs), or \
+                 set DOCLING_LAYOUT_ONNX. A digital PDF's embedded text layer \
+                 converts without models in no-OCR mode (CLI: --no-ocr)"
+            ));
+        }
         let builder = Session::builder()
             .map_err(|e| format!("layout: builder: {e}"))?
             // Let inference use the available cores (ort otherwise defaults low);

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -104,6 +104,27 @@ impl std::error::Error for PdfError {}
 #[cfg(feature = "ml")]
 impl From<pdfium_render::prelude::PdfiumError> for PdfError {
     fn from(e: pdfium_render::prelude::PdfiumError) -> Self {
+        // A failed dlopen means pdfium was never installed — the #1 first-run
+        // failure after a bare `cargo install` (which ships no runtime
+        // assets). Say what to do instead of leaking the raw loader error.
+        if matches!(e, pdfium_render::prelude::PdfiumError::LoadLibraryError(_)) {
+            // The loader error pretty-prints over several lines; compact it.
+            let detail = e
+                .to_string()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            return PdfError::Pdfium(format!(
+                "the pdfium library is not installed. PDF/image conversion needs \
+                 pdfium + the ONNX models: fetch both with \
+                 scripts/install/download_dependencies.sh from a docling.rs \
+                 checkout (https://github.com/docling-project/docling.rs), or \
+                 point PDFIUM_DYNAMIC_LIB_PATH at a directory containing the \
+                 pdfium library. A digital PDF's embedded text layer converts \
+                 without either in no-OCR mode (CLI: --no-ocr). Declarative \
+                 formats (DOCX, HTML, Markdown, …) never need them. [{detail}]"
+            ));
+        }
         PdfError::Pdfium(e.to_string())
     }
 }

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -61,6 +61,12 @@ pub use docling_core::{
 pub use docling_pdf::{
     model_inventory, page_count as pdf_page_count, EnrichmentOptions, ModelEntry, OcrLang, Pipeline,
 };
+// The pure-Rust text-layer extraction (no pdfium, no models) — compiled with
+// either PDF feature. The CLI uses it as the `--no-ocr` fallback when the
+// runtime assets are missing (launch blocker: a bare `cargo install` ships
+// neither pdfium nor the models).
+#[cfg(any(feature = "pdf", feature = "pdf-text"))]
+pub use docling_pdf::convert_text_layer_pages as pdf_text_layer_pages;
 
 /// Which PDF conversion this build compiled in: the full ML pipeline (`pdf`
 /// feature), the pure-Rust text-layer path (`pdf-text`, the wasm32 build), or

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -10,6 +10,9 @@
 #   scripts/install/install.sh
 #
 # What it does:
+#   0. Tries the prebuilt CLI binary from the latest GitHub Release first
+#      (Linux x64/arm64) — no toolchain, no build. Falls back to source on any
+#      mismatch; DOCLING_RS_FROM_SOURCE=1 skips the fast path.
 #   1. Checks for a Rust toolchain (>= 1.82 for the PDF crate); installs one
 #      via rustup (non-interactive) if `cargo` is missing.
 #   2. Builds the CLI in release mode (`cargo build --release -p docling-cli`).
@@ -50,28 +53,62 @@ if [ ! -w "$(dirname "$PREFIX")" ] || { [ -e "$PREFIX" ] && [ ! -w "$PREFIX" ]; 
   SUDO="sudo"
 fi
 
-# --- 1. Rust toolchain -------------------------------------------------------
-if ! command -v cargo >/dev/null 2>&1; then
-  # Respect an existing rustup installation that just isn't on PATH yet.
-  if [ -f "$HOME/.cargo/env" ]; then
+# --- 0. Prebuilt binary (fast path) -------------------------------------------
+# GitHub Releases carry prebuilt CLI binaries (.github/workflows/cli-binaries.yml)
+# for Linux x64/arm64 and Windows x64 — downloading one skips the Rust toolchain
+# and the multi-minute source build entirely. Any failure (no matching asset,
+# old release, no network to the API) quietly falls back to building from
+# source. DOCLING_RS_FROM_SOURCE=1 forces the source build.
+PREBUILT_BIN=""
+if [ "${DOCLING_RS_FROM_SOURCE:-0}" != "1" ] && [ "$(uname -s)" = "Linux" ]; then
+  case "$(uname -m)" in
+    x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+    aarch64 | arm64) TARGET="aarch64-unknown-linux-gnu" ;;
+    *) TARGET="" ;;
+  esac
+  if [ -n "$TARGET" ]; then
+    TAG="$(curl -fsSL "https://api.github.com/repos/docling-project/docling.rs/releases/latest" 2>/dev/null \
+      | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1 || true)"
+    if [ -n "${TAG:-}" ]; then
+      ASSET="$REPO_URL/releases/download/$TAG/docling-rs-$TAG-$TARGET.tar.gz"
+      PB_DIR="$(mktemp -d)"
+      if curl -fsSL "$ASSET" 2>/dev/null | tar -xz -C "$PB_DIR" 2>/dev/null \
+        && [ -x "$PB_DIR/docling-rs" ]; then
+        PREBUILT_BIN="$PB_DIR/docling-rs"
+        say "using the prebuilt $TAG binary for $TARGET (set DOCLING_RS_FROM_SOURCE=1 to build instead)"
+      else
+        say "no prebuilt binary for $TAG/$TARGET — building from source"
+      fi
+    fi
+  fi
+fi
+
+if [ -z "$PREBUILT_BIN" ]; then
+  # --- 1. Rust toolchain -----------------------------------------------------
+  if ! command -v cargo >/dev/null 2>&1; then
+    # Respect an existing rustup installation that just isn't on PATH yet.
+    if [ -f "$HOME/.cargo/env" ]; then
+      # shellcheck disable=SC1091
+      . "$HOME/.cargo/env"
+    fi
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    say "Rust toolchain not found — installing via rustup (stable, non-interactive)"
+    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal
     # shellcheck disable=SC1091
     . "$HOME/.cargo/env"
   fi
+  command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1 \
+    || die "no C compiler (cc/gcc/clang) — install build-essential / clang first"
+  say "using $(cargo --version)"
 fi
-if ! command -v cargo >/dev/null 2>&1; then
-  say "Rust toolchain not found — installing via rustup (stable, non-interactive)"
-  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal
-  # shellcheck disable=SC1091
-  . "$HOME/.cargo/env"
-fi
-command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1 \
-  || die "no C compiler (cc/gcc/clang) — install build-essential / clang first"
-say "using $(cargo --version)"
 
 # --- 2. Sources: use the checkout we're in, else clone ------------------------
+# Needed even with a prebuilt binary: download_dependencies.sh (models + pdfium)
+# runs from the source tree.
 if [ -f Cargo.toml ] && [ -d crates/docling-cli ]; then
   SRC_DIR="$(pwd)"
-  say "building from existing checkout: $SRC_DIR"
+  say "using existing checkout: $SRC_DIR"
 else
   SRC_DIR="$(mktemp -d)/docling.rs"
   say "cloning $REPO_URL ($REF) to $SRC_DIR"
@@ -84,14 +121,16 @@ else
   cd "$SRC_DIR"
 fi
 
-# --- 3. Build ------------------------------------------------------------------
-say "building the CLI (release)"
-cargo build --release -p docling-cli
+# --- 3. Build (skipped when a prebuilt binary was downloaded) -------------------
+if [ -z "$PREBUILT_BIN" ]; then
+  say "building the CLI (release)"
+  cargo build --release -p docling-cli
+fi
 
 # --- 4. Install tree -----------------------------------------------------------
 say "installing to $PREFIX"
 $SUDO mkdir -p "$PREFIX/bin"
-$SUDO cp target/release/docling-rs "$PREFIX/bin/docling-rs"
+$SUDO cp "${PREBUILT_BIN:-target/release/docling-rs}" "$PREFIX/bin/docling-rs"
 
 # Models + pdfium land inside the prefix; download_dependencies.sh fetches into
 # the *current* directory, so run it from there. It is idempotent (skips files


### PR DESCRIPTION
…back, prebuilt CLI binaries

The first PDF a `cargo install docling-cli` user converts died with a raw dlopen error (libpdfium.so not found) and no hint what to do. Now:

- docling-pdf: a pdfium LoadLibraryError and a missing layout model both produce an actionable message — run download_dependencies.sh (or set PDFIUM_DYNAMIC_LIB_PATH / DOCLING_LAYOUT_ONNX), declarative formats need nothing, and a digital PDF converts via --no-ocr. All surfaces (CLI, serve, bindings) inherit the text.
- CLI: under --no-ocr, when the failure is exactly "runtime assets missing", fall back to the pure-Rust text-layer extraction instead of failing — a digital PDF now converts on a machine with no pdfium and no models (scanned PDFs still surface the install hint). Batch mode aborts on the first missing-assets error instead of repeating it per file.
- cli-binaries.yml: prebuilt docling-rs binaries (Linux x64/arm64, Windows x64; macOS runners are blocked in this org, same as npm-publish) attached to every GitHub Release, triggered by the RELEASE_PAT-created release event or manual dispatch.
- install.sh: try the prebuilt release binary first (Linux x64/arm64) and only fall back to the source build — the curl|bash one-liner stops costing minutes of compilation once assets exist.
- Issue template: bug_report.md rewritten for a conversion tool (command, input file, install method, asset state) instead of web-app boilerplate.
- README: perf/memory numbers moved to the top above Status; install section documents the prebuilt-binary fast path.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT