### PR TITLE
fix(ci): build Linux CLI binaries on ubuntu-24.04 (ort needs glibc 2.…

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -41,8 +41,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # ubuntu-24.04, not 22.04: ort's prebuilt static onnxruntime is built
+          # against glibc 2.38+ (__isoc23_strtol*) and GCC-13 libstdc++
+          # (_M_replace_cold) — linking on 22.04 fails with undefined symbols.
+          # Consequence: the shipped binary needs glibc >= 2.38 at runtime
+          # (Ubuntu 24.04+, Debian 13+, Fedora 39+); older distros build from
+          # source (install.sh verifies the downloaded binary runs and falls
+          # back automatically).
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-22.04
+            host: ubuntu-24.04
           # Native ARM64 Linux runner — avoids cross-compiling the ONNX/ort build.
           - target: aarch64-unknown-linux-gnu
             host: ubuntu-24.04-arm

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -74,8 +74,18 @@ if [ "${DOCLING_RS_FROM_SOURCE:-0}" != "1" ] && [ "$(uname -s)" = "Linux" ]; the
       PB_DIR="$(mktemp -d)"
       if curl -fsSL "$ASSET" 2>/dev/null | tar -xz -C "$PB_DIR" 2>/dev/null \
         && [ -x "$PB_DIR/docling-rs" ]; then
-        PREBUILT_BIN="$PB_DIR/docling-rs"
-        say "using the prebuilt $TAG binary for $TARGET (set DOCLING_RS_FROM_SOURCE=1 to build instead)"
+        # Verify the binary actually runs *on this system* before trusting it:
+        # the release binaries link ort's static onnxruntime, which needs
+        # glibc >= 2.38 — on an older distro the dynamic loader rejects it.
+        # No-args is the cheapest full load: the CLI prints usage and exits 2.
+        rc=0
+        "$PB_DIR/docling-rs" >/dev/null 2>&1 || rc=$?
+        if [ "$rc" = "2" ]; then
+          PREBUILT_BIN="$PB_DIR/docling-rs"
+          say "using the prebuilt $TAG binary for $TARGET (set DOCLING_RS_FROM_SOURCE=1 to build instead)"
+        else
+          say "the prebuilt $TAG binary does not run here (glibc older than 2.38?) — building from source"
+        fi
       else
         say "no prebuilt binary for $TAG/$TARGET — building from source"
       fi


### PR DESCRIPTION
…38+)

ort's prebuilt static onnxruntime is compiled against glibc 2.38 (__isoc23_strtol*) and GCC-13 libstdc++ (_M_replace_cold), so linking on the ubuntu-22.04 runner fails with undefined symbols — move the x86_64 job to ubuntu-24.04 (the arm64 job already runs there). The shipped binary therefore needs glibc >= 2.38 at runtime; install.sh now verifies the downloaded binary actually loads (no-args usage probe, exit 2) and falls back to the source build on older distros instead of failing later.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT