### PR TITLE
fix(pdf): fail EP-feature/OS mismatches at compile time with an actionable message

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,11 @@ cargo build --release -p docling-cli --features cuda      # NVIDIA CUDA (Linux/W
 #                                     --features coreml   # CoreML (macOS)
 ```
 
+Each provider only exists on its OS (ort ships no CoreML build for Linux, no
+DirectML outside Windows, no CUDA for macOS) — an impossible pairing now
+fails at compile time with a message naming the alternatives, instead of a
+linker error at the end of the build.
+
 A GPU build defaults to `auto`: it converts on the GPU when one is usable
 and falls back to CPU when not — you chose a GPU build, so it uses the GPU.
 `DOCLING_RS_EP` overrides:

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -68,6 +68,30 @@ use std::sync::mpsc::{sync_channel, Receiver};
 #[cfg(feature = "ml")]
 use std::sync::{Arc, Mutex};
 
+// An execution provider only exists on its OS, and ort's prebuilt ONNX
+// Runtime binaries follow suit — requesting an impossible pairing otherwise
+// surfaces as a cryptic ort-sys linker error ("no builds available that
+// satisfy the requested feature set"). Catch it at type-check time with an
+// actionable message instead.
+#[cfg(all(feature = "coreml", not(target_vendor = "apple")))]
+compile_error!(
+    "the `coreml` execution provider exists only on Apple targets (macOS/iOS). \
+     On Linux use `--features cuda` or `--features tensorrt` (NVIDIA), on \
+     Windows also `--features directml`, or build without EP features for CPU."
+);
+#[cfg(all(feature = "directml", not(target_os = "windows")))]
+compile_error!(
+    "the `directml` execution provider exists only on Windows. On Linux use \
+     `--features cuda` or `--features tensorrt` (NVIDIA), on macOS \
+     `--features coreml`, or build without EP features for CPU."
+);
+#[cfg(all(any(feature = "cuda", feature = "tensorrt"), target_vendor = "apple"))]
+compile_error!(
+    "the `cuda`/`tensorrt` execution providers have no Apple builds (no NVIDIA \
+     support on macOS). Use `--features coreml` there, or build without EP \
+     features for CPU."
+);
+
 use docling_core::DoclingDocument;
 // The env-knob helpers only gate ML-pipeline diagnostics and tuning; the
 // pure text-layer (wasm) build has no call sites.


### PR DESCRIPTION
`cargo build --features coreml` on Linux compiled for minutes and then died in the linker with ort-sys's "no builds available that satisfy the requested feature set 'coreml'" — technically true, practically cryptic. The execution providers only exist on their OS (CoreML: Apple; DirectML: Windows; CUDA/TensorRT: Linux + Windows), so docling-pdf now carries compile_error! guards for the impossible pairings, each naming the working alternatives for the current target. Wrong-feature builds fail in seconds at type-check time. README's GPU section states the per-OS matrix.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT