### PR TITLE
perf: linear DocLang inline scanners + cache-friendly INTER_AREA resample

### DIFF
--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -121,40 +121,46 @@ enum Run {
 fn inline_runs(text: &str) -> Vec<Run> {
     let mut runs = Vec::new();
     let mut plain = String::new();
-    let bytes: Vec<char> = text.chars().collect();
-    let n = bytes.len();
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
     let mut i = 0;
-    let find = |open: usize, pat: &str| -> Option<usize> {
-        let hay: String = bytes[open..].iter().collect();
-        hay.find(pat).map(|p| open + hay[..p].chars().count())
+    // All scanning stays on the char slice: materializing the tail as a
+    // String per position (the previous shape) made this scanner O(n²) and
+    // dominated whole-document DocLang serialization.
+    let find = |open: usize, pat: &[char]| -> Option<usize> {
+        chars
+            .get(open..)?
+            .windows(pat.len())
+            .position(|w| w == pat)
+            .map(|p| open + p)
     };
+    let starts = |at: usize, pat: &[char]| chars[at..].starts_with(pat);
     while i < n {
-        let rest: String = bytes[i..].iter().collect();
         let take = |runs: &mut Vec<Run>, plain: &mut String, r: Run| {
             if !plain.is_empty() {
                 runs.push(Run::Plain(std::mem::take(plain)));
             }
             runs.push(r);
         };
-        if rest.starts_with("***") {
-            if let Some(end) = find(i + 3, "***") {
-                let inner: String = bytes[i + 3..end].iter().collect();
+        if starts(i, &['*', '*', '*']) {
+            if let Some(end) = find(i + 3, &['*', '*', '*']) {
+                let inner: String = chars[i + 3..end].iter().collect();
                 take(&mut runs, &mut plain, Run::BoldItalic(inner));
                 i = end + 3;
                 continue;
             }
         }
-        if rest.starts_with("**") {
-            if let Some(end) = find(i + 2, "**") {
-                let inner: String = bytes[i + 2..end].iter().collect();
+        if starts(i, &['*', '*']) {
+            if let Some(end) = find(i + 2, &['*', '*']) {
+                let inner: String = chars[i + 2..end].iter().collect();
                 take(&mut runs, &mut plain, Run::Bold(inner));
                 i = end + 2;
                 continue;
             }
         }
-        if rest.starts_with('*') && !rest.starts_with("**") {
-            if let Some(end) = find(i + 1, "*") {
-                let inner: String = bytes[i + 1..end].iter().collect();
+        if chars[i] == '*' && !starts(i, &['*', '*']) {
+            if let Some(end) = find(i + 1, &['*']) {
+                let inner: String = chars[i + 1..end].iter().collect();
                 if !inner.is_empty() {
                     take(&mut runs, &mut plain, Run::Italic(inner));
                     i = end + 1;
@@ -162,26 +168,26 @@ fn inline_runs(text: &str) -> Vec<Run> {
                 }
             }
         }
-        if rest.starts_with('`') {
-            if let Some(end) = find(i + 1, "`") {
-                let inner: String = bytes[i + 1..end].iter().collect();
+        if chars[i] == '`' {
+            if let Some(end) = find(i + 1, &['`']) {
+                let inner: String = chars[i + 1..end].iter().collect();
                 take(&mut runs, &mut plain, Run::Code(inner));
                 i = end + 1;
                 continue;
             }
         }
-        if rest.starts_with('[') {
-            if let (Some(close), true) = (find(i + 1, "]("), true) {
-                if let Some(endp) = find(close + 2, ")") {
-                    let anchor: String = bytes[i + 1..close].iter().collect();
-                    let uri: String = bytes[close + 2..endp].iter().collect();
+        if chars[i] == '[' {
+            if let Some(close) = find(i + 1, &[']', '(']) {
+                if let Some(endp) = find(close + 2, &[')']) {
+                    let anchor: String = chars[i + 1..close].iter().collect();
+                    let uri: String = chars[close + 2..endp].iter().collect();
                     take(&mut runs, &mut plain, Run::Link { anchor, uri });
                     i = endp + 1;
                     continue;
                 }
             }
         }
-        plain.push(bytes[i]);
+        plain.push(chars[i]);
         i += 1;
     }
     if !plain.is_empty() {
@@ -226,16 +232,21 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
     let n = chars.len();
     let mut i = 0;
     let mut plain = String::new();
-    let find = |open: usize, pat: &str| -> Option<usize> {
-        let hay: String = chars[open..].iter().collect();
-        hay.find(pat).map(|p| open + hay[..p].chars().count())
+    // Char-slice scanning throughout — the tail-String-per-position shape
+    // this replaces was O(n²) over every serialized text node.
+    let find = |open: usize, pat: &[char]| -> Option<usize> {
+        chars
+            .get(open..)?
+            .windows(pat.len())
+            .position(|w| w == pat)
+            .map(|p| open + p)
     };
+    let starts = |at: usize, pat: &[char]| chars[at..].starts_with(pat);
     let sub = |a: usize, b: usize| -> Vec<char> { chars[a..b].to_vec() };
     while i < n {
-        let rest: String = chars[i..].iter().collect();
         // Longest markers first so `**`/`***` aren't mis-split.
-        if rest.starts_with("***") {
-            if let Some(end) = find(i + 3, "***") {
+        if starts(i, &['*', '*', '*']) {
+            if let Some(end) = find(i + 3, &['*', '*', '*']) {
                 flush_md_plain(&mut plain, &style, out);
                 parse_md_runs(
                     &sub(i + 3, end),
@@ -250,8 +261,8 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
                 continue;
             }
         }
-        if rest.starts_with("**") {
-            if let Some(end) = find(i + 2, "**") {
+        if starts(i, &['*', '*']) {
+            if let Some(end) = find(i + 2, &['*', '*']) {
                 flush_md_plain(&mut plain, &style, out);
                 parse_md_runs(
                     &sub(i + 2, end),
@@ -265,8 +276,8 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
                 continue;
             }
         }
-        if rest.starts_with('*') {
-            if let Some(end) = find(i + 1, "*") {
+        if chars[i] == '*' {
+            if let Some(end) = find(i + 1, &['*']) {
                 if end > i + 1 {
                     flush_md_plain(&mut plain, &style, out);
                     parse_md_runs(
@@ -282,8 +293,8 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
                 }
             }
         }
-        if rest.starts_with("~~") {
-            if let Some(end) = find(i + 2, "~~") {
+        if starts(i, &['~', '~']) {
+            if let Some(end) = find(i + 2, &['~', '~']) {
                 flush_md_plain(&mut plain, &style, out);
                 parse_md_runs(
                     &sub(i + 2, end),
@@ -297,8 +308,8 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
                 continue;
             }
         }
-        if rest.starts_with('`') {
-            if let Some(end) = find(i + 1, "`") {
+        if chars[i] == '`' {
+            if let Some(end) = find(i + 1, &['`']) {
                 flush_md_plain(&mut plain, &style, out);
                 let inner: String = sub(i + 1, end).iter().collect();
                 let inner = inner.trim();
@@ -313,9 +324,9 @@ fn parse_md_runs(chars: &[char], style: InlineRun, out: &mut Vec<InlineRun>) {
                 continue;
             }
         }
-        if rest.starts_with('[') {
-            if let Some(close) = find(i + 1, "](") {
-                if let Some(endp) = find(close + 2, ")") {
+        if chars[i] == '[' {
+            if let Some(close) = find(i + 1, &[']', '(']) {
+                if let Some(endp) = find(close + 2, &[')']) {
                     flush_md_plain(&mut plain, &style, out);
                     // Inline scope drops the href; the anchor keeps its styling.
                     parse_md_runs(&sub(i + 1, close), style.clone(), out);

--- a/crates/docling-pdf/src/resample.rs
+++ b/crates/docling-pdf/src/resample.rs
@@ -31,35 +31,43 @@ pub fn inter_area(src: &RgbImage, dw: u32, dh: u32) -> RgbImage {
     let hw = area_weights(sw, dwu, sw as f64 / dw as f64);
     let vw = area_weights(sh, dhu, sh as f64 / dh as f64);
 
+    // Cache-friendly passes over the raw RGB buffer. The per-pixel addition
+    // order is exactly the loop-nest transpose of the naive form, so the f64
+    // accumulation — and thus the rounded output — stays bit-identical (the
+    // pixel-exactness contract above).
+    let raw = src.as_raw();
     let mut tmp = vec![[0f64; 3]; sh * dwu]; // (sh × dw)
     for y in 0..sh {
-        let row = y * dwu;
-        for (dx, ws) in hw.iter().enumerate() {
-            let mut acc = [0f64; 3];
+        let src_row = &raw[y * sw * 3..(y + 1) * sw * 3];
+        let dst_row = &mut tmp[y * dwu..(y + 1) * dwu];
+        for (acc, ws) in dst_row.iter_mut().zip(hw.iter()) {
             for &(si, w) in ws {
-                let p = src.get_pixel(si as u32, y as u32);
+                let p = &src_row[si * 3..si * 3 + 3];
                 acc[0] += p[0] as f64 * w;
                 acc[1] += p[1] as f64 * w;
                 acc[2] += p[2] as f64 * w;
             }
-            tmp[row + dx] = acc;
         }
     }
     let mut out = RgbImage::new(dw, dh);
+    let mut acc_row = vec![[0f64; 3]; dwu];
     for (dy, ws) in vw.iter().enumerate() {
-        for dx in 0..dwu {
-            let mut acc = [0f64; 3];
-            for &(si, w) in ws {
-                let t = tmp[si * dwu + dx];
+        acc_row.fill([0f64; 3]);
+        // Row-sequential accumulation: each source row streams once instead
+        // of striding column-wise through `tmp`.
+        for &(si, w) in ws {
+            let row = &tmp[si * dwu..(si + 1) * dwu];
+            for (acc, t) in acc_row.iter_mut().zip(row) {
                 acc[0] += t[0] * w;
                 acc[1] += t[1] * w;
                 acc[2] += t[2] * w;
             }
-            out.put_pixel(
-                dx as u32,
-                dy as u32,
-                Rgb([round_u8(acc[0]), round_u8(acc[1]), round_u8(acc[2])]),
-            );
+        }
+        let out_row = &mut (*out)[dy * dwu * 3..(dy + 1) * dwu * 3];
+        for (px, acc) in out_row.chunks_exact_mut(3).zip(&acc_row) {
+            px[0] = round_u8(acc[0]);
+            px[1] = round_u8(acc[1]);
+            px[2] = round_u8(acc[2]);
         }
     }
     out

--- a/crates/docling/examples/perf_serialize.rs
+++ b/crates/docling/examples/perf_serialize.rs
@@ -1,0 +1,43 @@
+//! Serializer profiling harness (#216 follow-up): convert once, serialize in
+//! a loop so Markdown / DocLang / JSON generation dominates the profile.
+//!
+//! ```bash
+//! cargo build --release --no-default-features --example perf_serialize
+//! target/release/examples/perf_serialize <file> [iters]
+//! valgrind --tool=callgrind target/release/examples/perf_serialize <file> 20
+//! ```
+
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: perf_serialize <file> [iters]");
+    let iters: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(100);
+
+    let source = docling::SourceDocument::from_file(&path).expect("read");
+    let t0 = Instant::now();
+    let result = docling::DocumentConverter::new()
+        .convert(source)
+        .expect("convert");
+    let document = result.document;
+    println!("convert: {:?}", t0.elapsed());
+
+    let mut sink = 0usize;
+    for (name, f) in [
+        (
+            "markdown",
+            Box::new(|d: &docling::DoclingDocument| d.export_to_markdown().len())
+                as Box<dyn Fn(&docling::DoclingDocument) -> usize>,
+        ),
+        ("doclang", Box::new(|d| d.export_to_doclang().len())),
+        ("json", Box::new(|d| d.export_to_json().len())),
+    ] {
+        let t = Instant::now();
+        for _ in 0..iters {
+            sink += f(&document);
+        }
+        let dt = t.elapsed();
+        println!("{name}: {:?}/iter ({iters} iters)", dt / iters as u32);
+    }
+    eprintln!("(sink {sink})");
+}


### PR DESCRIPTION
Profiled Markdown/DocLang/JSON generation (callgrind) on structured documents and the OCR PDF pipeline. Two real hotspots, both fixed with byte-identical output:

- doclang: inline_runs and parse_md_runs materialized the tail of the text as a fresh String at every character position (plus another full-tail String inside every find()) — O(n²) per text node, 70% of all DocLang-export instructions on a table-heavy DOCX. Both scanners now walk the char slice directly (slice starts_with + windows search). DocLang export on docx_rich_tables_01: 1.18 ms -> 0.17 ms per export (~7x); the regression corpus pins the unchanged output.

- pdf: resample::inter_area's vertical pass strode column-wise through the row-major intermediate buffer and both passes went through bounds-checked pixel accessors. Both passes now stream rows over the raw RGB buffer with a per-row accumulator — the loop-nest transpose keeps the f64 addition order per output pixel, so the rounded bytes are identical (verified by the pinned ML snapshot suites with models present). TableFormer's inter_area stage: 257 ms -> 182 ms on the scanned-page fixture.

Also adds the profiling harness (examples/perf_serialize: convert once, serialize in a loop) used for these measurements. Findings with no action: JSON export cost is the serde_json::Value tree build behind the public export_to_json_value API; the OCR pipeline is >90% ONNX inference + onnxruntime per-run overhead (our preprocessing is ~1.5%); DocLang's remaining cost on image-bearing docs is the content-address SHA-256 of asset names, computed once per export by design.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT