### PR TITLE
feat(serve): to=images — rasterize PDF pages to PNG over HTTP (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ curl -F file=@paper.pdf localhost:5001/v1/convert                # Markdown
 curl -F file=@report.docx 'localhost:5001/v1/convert?to=json'    # docling JSON
 curl -F file=@sheet.xlsx  'localhost:5001/v1/convert?to=dclx' -O # DocLang archive
 curl -F file=@page.html   'localhost:5001/v1/convert?to=chunks'  # chunk records
+curl -F file=@paper.pdf   'localhost:5001/v1/convert?to=images&pages=1-3'  # pages → PNG (base64 JSON)
 curl -H 'content-type: application/json' \
      -d '{"url": "https://example.com/doc.pdf", "to": "md"}' \
      localhost:5001/v1/convert     # fetch a URL (needs --allow-url-fetch)
@@ -183,9 +184,15 @@ an `X-Docling-Confidence` summary header (grades `poor`/`fair`/`good`/
 `excellent` + layout/OCR/parse scores) on every format, and the full per-page
 report under a top-level `confidence` key in `to=json` bodies.
 
-Options per request: `to=md|json|dclx|chunks`, `strict`, `images=placeholder|embedded`,
+`to=images` skips conversion entirely and rasterizes a PDF's pages to PNG
+through pdfium — `{"pages": [{"page", "width", "height", "png_base64"}]}` —
+honoring `pages=A-B` and a `scale` of 0.1–4.0 pixels per PDF point (default
+2.0 = 144 dpi). Capped at 100 pages per request
+(`DOCLING_RS_MAX_RASTER_PAGES`); narrow big documents with `pages`.
+
+Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placeholder|embedded`,
 `no_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
-`ocr_lang`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
+`ocr_lang`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
 `--allow-url-fetch`, `--no-url-fetch`, `--strict`. A container image

--- a/README.md
+++ b/README.md
@@ -324,6 +324,16 @@ From the CLI, `--to dclx` writes `<input-stem>.dclx` next to the CWD:
 cargo run -p docling-cli -- --to dclx crates/docling/sample.html   # -> sample.dclx
 ```
 
+`--to images` (#243) is the CLI counterpart of serve's rasterization: it skips
+conversion and writes a PDF's pages as `<stem>_page_NNNN.png` files (CWD, or
+`--output DIR` in batch mode), honoring `--pages A-B` (absolute page numbers
+survive the window) and `--scale` (0.1–4.0 px per PDF point, default 2.0 =
+144 dpi):
+
+```sh
+docling-rs --to images --pages 2-3 --scale 1.5 paper.pdf  # -> paper_page_0002.png, paper_page_0003.png
+```
+
 Conformance against docling's own `.dclx` output is tracked by
 `scripts/conformance/gen_dclx.py` (generates the groundtruth) and
 `scripts/conformance/dclx_conformance.sh` (line-diffs the extracted

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -3,7 +3,7 @@
 //! The docling.rs counterpart of `docling.cli.main`; `docling-rs serve`
 //! (with `--features serve`) starts the HTTP conversion API.
 //!
-//! Usage: docling-rs [--strict] [--to md|json] [--pages A-B] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
 //!                      shell doesn't expand it) instead of one positional file.
@@ -24,7 +24,12 @@
 //!                      in parallel; PDF/image files share the one warm ML
 //!                      pipeline (which parallelizes internally per document).
 //!   --to md|json       output format (default: md). `json` emits docling-core's
-//!                      native DoclingDocument JSON (export_to_dict).
+//!                      native DoclingDocument JSON (export_to_dict); `images`
+//!                      (#243) skips conversion and rasterizes a PDF's pages to
+//!                      `<stem>_page_NNNN.png` files (combines with `--pages`).
+//!   --scale X          `--to images` render scale in pixels per PDF point:
+//!                      0.1-4.0, default 2.0 (144 dpi, the ML pipeline's own
+//!                      render scale).
 //!   --pages A-B        convert only PDF pages A through B (1-based, inclusive;
 //!                      a single page number also works). Skipped pages are
 //!                      never rasterized, so a small window over a huge PDF is
@@ -130,6 +135,7 @@ fn main() -> ExitCode {
     let mut enrich_formula = false;
     let mut bench_warm: Option<usize> = None;
     let mut pages: Option<(usize, usize)> = None;
+    let mut scale: f32 = 2.0;
     let mut ocr_lang: Option<String> = None;
     let mut pipeline: Option<String> = None;
     let mut vlm_endpoint: Option<String> = None;
@@ -187,6 +193,17 @@ fn main() -> ExitCode {
             // 0 = transcript only). Default 8.
             "--video-frames" => video_frames = args.next().and_then(|v| v.parse().ok()),
             "--images" => images = args.next().unwrap_or_default(),
+            // `--to images` render scale, pixels per PDF point (#243).
+            "--scale" => match args.next().and_then(|v| v.parse::<f32>().ok()) {
+                Some(v) if (0.1..=4.0).contains(&v) => scale = v,
+                _ => {
+                    eprintln!(
+                        "error: --scale needs a number in 0.1-4.0 \
+                         (pixels per PDF point; default 2.0 = 144 dpi)"
+                    );
+                    return ExitCode::from(2);
+                }
+            },
             // PDF page window, 1-based inclusive: `--pages 3-7` or `--pages 3`.
             "--pages" => match args.next().as_deref().map(docling::parse_page_range) {
                 Some(Ok(range)) => pages = Some(range),
@@ -250,8 +267,11 @@ fn main() -> ExitCode {
         }
     }
 
-    if !matches!(to.as_str(), "md" | "markdown" | "json" | "dclx" | "chunks") {
-        eprintln!("error: unknown --to '{to}' (expected: md, json, dclx, chunks)");
+    if !matches!(
+        to.as_str(),
+        "md" | "markdown" | "json" | "dclx" | "chunks" | "images"
+    ) {
+        eprintln!("error: unknown --to '{to}' (expected: md, json, dclx, chunks, images)");
         return ExitCode::from(2);
     }
     let image_mode = match images.as_str() {
@@ -332,13 +352,14 @@ fn main() -> ExitCode {
             video_frames,
             pages,
             ocr_lang,
+            scale,
             vlm,
         };
         return run_batch(files, &base, Path::new(&outdir), jobs, &cfg);
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--use-web-browser] <input-file>");
+        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--use-web-browser] <input-file>");
         return ExitCode::from(2);
     };
 
@@ -360,6 +381,35 @@ fn main() -> ExitCode {
                     "warm conversion: {:.4}s/doc over {runs} runs (startup excluded)",
                     avg
                 );
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    // `--to images` (#243): rasterization is pdfium-only — no conversion, no
+    // models, no pipeline (a `--pipeline vlm` selection has nothing to do and
+    // is ignored). Files land in the CWD like `--to dclx`'s archive.
+    if to == "images" {
+        if !is_pdf {
+            eprintln!("error: --to images rasterizes PDF inputs only ('{path}' is not a PDF)");
+            return ExitCode::from(2);
+        }
+        let stem = Path::new(&path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "document".into());
+        return match write_page_images(&source.bytes, pages, scale, Path::new(""), &stem) {
+            Ok(written) => {
+                // Humans read stderr; stdout stays the bare paths for scripts
+                // (the dclx convention).
+                eprintln!("images: {} page(s) written", written.len());
+                for p in &written {
+                    println!("{}", p.display());
+                }
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -551,6 +601,8 @@ struct BatchCfg {
     video_frames: Option<usize>,
     pages: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    /// `--to images` render scale (pixels per PDF point, #243).
+    scale: f32,
     vlm: Option<docling::vlm::VlmOptions>,
 }
 
@@ -637,6 +689,7 @@ fn batch_out_path(file: &Path, base: &Path, output: &Path, to: &str) -> std::pat
         "json" => "json",
         "dclx" => "dclx",
         "chunks" => "chunks.json",
+        "images" => "png", // a stem carrier: pages land as `<stem>_page_NNNN.png`
         _ => "md",
     };
     output.join(rel).with_extension(ext)
@@ -712,6 +765,28 @@ fn batch_pipeline<'a>(
     Ok(slot.as_mut().expect("just filled"))
 }
 
+/// `--to images` (#243): rasterize a PDF to per-page PNGs,
+/// `<dir>/<stem>_page_NNNN.png` — absolute 1-based page numbers, so a
+/// `--pages` window keeps the source document's numbering. Returns the
+/// written paths in page order.
+fn write_page_images(
+    bytes: &[u8],
+    pages: Option<(usize, usize)>,
+    scale: f32,
+    dir: &Path,
+    stem: &str,
+) -> Result<Vec<std::path::PathBuf>, String> {
+    let rendered =
+        docling::render_pdf_pages(bytes, None, pages, scale).map_err(|e| e.to_string())?;
+    let mut written = Vec::with_capacity(rendered.len());
+    for page in &rendered {
+        let out = dir.join(format!("{stem}_page_{:04}.png", page.page_no));
+        std::fs::write(&out, &page.png).map_err(|e| format!("writing {}: {e}", out.display()))?;
+        written.push(out);
+    }
+    Ok(written)
+}
+
 /// Convert one batch file and write its output; returns the output path.
 fn batch_convert_one(
     file: &Path,
@@ -738,6 +813,30 @@ fn batch_convert_one(
         None => eprintln!("start: {}", file.display()),
     }
     let started = std::time::Instant::now();
+    if cfg.to == "images" {
+        // #243: rasterize instead of converting — PDF-only, like the serve
+        // endpoint. A non-PDF file fails its item, not the batch.
+        if source.format != InputFormat::Pdf {
+            return Err(format!(
+                "--to images rasterizes PDF inputs only ({} is not a PDF)",
+                file.display()
+            ));
+        }
+        let out = batch_out_path(file, base, output, &cfg.to);
+        let dir = out.parent().unwrap_or(Path::new("")).to_path_buf();
+        std::fs::create_dir_all(&dir).map_err(|e| format!("creating {}: {e}", dir.display()))?;
+        let stem = out
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "document".into());
+        // pdfium is not thread-safe: the shared pipeline mutex is this
+        // process's "who owns pdfium" lock, held here even though no models
+        // run — a render must not race a concurrent PDF conversion.
+        let _pdfium_owner = pipe.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let written = write_page_images(&source.bytes, cfg.pages, cfg.scale, &dir, &stem)?;
+        let shown = written.first().cloned().unwrap_or(out);
+        return Ok((shown, started.elapsed().as_secs_f64(), pages));
+    }
     let mut document = if let Some(vlm) = &cfg.vlm {
         docling::vlm::convert_vlm(&source, vlm).map_err(|e| e.to_string())?
     } else if matches!(source.format, InputFormat::Pdf | InputFormat::Image) {

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -107,6 +107,9 @@ pub use ocr::OcrLang;
 #[cfg(feature = "ml")]
 pub use pdfium_backend::PdfDocument;
 pub use pdfium_backend::{PdfPage, TextCell};
+// Plain page rasterization (#243) — pdfium only, no models.
+#[cfg(feature = "ml")]
+pub use pdfium_backend::{render_pages, RenderedPage};
 
 /// Errors from the PDF backend. Detailed and surfaced (never silently skipped).
 #[derive(Debug)]

--- a/crates/docling-pdf/src/pdfium_backend.rs
+++ b/crates/docling-pdf/src/pdfium_backend.rs
@@ -333,6 +333,90 @@ where
     Ok(())
 }
 
+/// One rasterized page from [`render_pages`] (#243): the absolute 1-based page
+/// number in the source document, the pixel dimensions, and the PNG bytes.
+#[cfg(feature = "ml")]
+#[derive(Debug, Clone)]
+pub struct RenderedPage {
+    pub page_no: usize,
+    pub width: u32,
+    pub height: u32,
+    pub png: Vec<u8>,
+}
+
+#[cfg(feature = "ml")]
+/// Rasterize a PDF's pages to PNG (#243) — the lean path behind serve's
+/// `to=images`: pdfium render only, no text extraction, no models, and only
+/// one page bitmap resident at a time (each is PNG-encoded and dropped before
+/// the next renders). `scale` is pixels per PDF point — 2.0 matches the
+/// pipeline's [`RENDER_SCALE`] (144 dpi). Unlike the pipeline's render there
+/// is no 1.5× supersample + downsample pass: that dance exists only because
+/// TableFormer is pixel-pinned to docling's bitmaps, and nothing downstream
+/// of this output is — a single render is nearly twice as fast.
+///
+/// `range` is a **1-based** inclusive page window (issue #80's `pages`
+/// semantics: the end clamps to the document, a start past the end errors).
+///
+/// pdfium is not thread-safe — callers must serialize this against any other
+/// pdfium use (docling-serve holds its pipeline mutex around this call for
+/// exactly that reason).
+pub fn render_pages(
+    bytes: &[u8],
+    password: Option<&str>,
+    range: Option<(usize, usize)>,
+    scale: f32,
+) -> Result<Vec<RenderedPage>, crate::PdfError> {
+    let pdfium = bind()?;
+    let doc = pdfium.load_pdf_from_byte_slice(bytes, password)?;
+    let pages = doc.pages();
+    let total = pages.len() as usize;
+    let (first, last) = match range {
+        None => (0, total.saturating_sub(1)),
+        Some((first, last)) => {
+            if first == 0 || last < first {
+                return Err(crate::PdfError::Pdfium(format!(
+                    "invalid page range {first}-{last} (pages are 1-based, first <= last)"
+                )));
+            }
+            if first > total {
+                return Err(crate::PdfError::Pdfium(format!(
+                    "page range {first}-{last} is outside the document ({total} page(s))"
+                )));
+            }
+            (first - 1, last.min(total) - 1)
+        }
+    };
+    let mut out = Vec::with_capacity(last.saturating_sub(first) + 1);
+    for (i, page) in pages.iter().enumerate() {
+        if i < first || i > last {
+            continue;
+        }
+        // pdfium applies /Rotate itself, so the bitmap is the page as a viewer
+        // shows it — no orientation handling needed (the pipeline's scanned-page
+        // un-rotation is an OCR-conformance concern, not a display one).
+        let tw = (page.width().value * scale).round().max(1.0) as i32;
+        let th = (page.height().value * scale).round().max(1.0) as i32;
+        let cfg = PdfRenderConfig::new()
+            .set_target_width(tw)
+            .set_target_height(th);
+        let bitmap = crate::timing::timed("pdfium.rasterize", || {
+            page.render_with_config(&cfg)
+                .map(|b| b.as_image().into_rgb8())
+        })?;
+        let mut png = Vec::new();
+        bitmap
+            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .map_err(|e| crate::PdfError::Pdfium(format!("PNG-encoding page {}: {e}", i + 1)))?;
+        out.push(RenderedPage {
+            page_no: i + 1,
+            width: bitmap.width(),
+            height: bitmap.height(),
+            png,
+        });
+    }
+    Ok(out)
+}
+
 #[cfg(feature = "ml")]
 fn extract_page(
     page: &pdfium_render::prelude::PdfPage<'_>,

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "calamine",
  "csv",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -98,6 +98,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
         <option value="json">docling JSON</option>
         <option value="chunks">chunk records</option>
         <option value="dclx">DocLang archive (.dclx)</option>
+        <option value="images">page images (PDF → PNG)</option>
       </select>
     </label>
     <label><input type="checkbox" id="strict"> strict Markdown</label>
@@ -152,8 +153,8 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
 <p>As query parameters, multipart text fields, or JSON keys (body wins over query):</p>
 <table>
   <tr><th>Option</th><th>Values</th><th>Description</th></tr>
-  <tr><td><code>to</code></td><td><code>md</code> (default) | <code>json</code> | <code>dclx</code> | <code>chunks</code></td>
-      <td>Markdown (streamed) · docling <code>DoclingDocument</code> JSON · DocLang OPC archive (download) · chunker records (hierarchical + hybrid when a tokenizer is installed).</td></tr>
+  <tr><td><code>to</code></td><td><code>md</code> (default) | <code>json</code> | <code>dclx</code> | <code>chunks</code> | <code>images</code></td>
+      <td>Markdown (streamed) · docling <code>DoclingDocument</code> JSON · DocLang OPC archive (download) · chunker records (hierarchical + hybrid when a tokenizer is installed) · per-page PNG renders of a PDF (no conversion; combines with <code>pages</code>, capped at 100 pages per request by default).</td></tr>
   <tr><td><code>strict</code></td><td><code>true</code>/<code>false</code></td><td>Cleaner strict Markdown dialect instead of byte-for-byte docling-legacy output.</td></tr>
   <tr><td><code>images</code></td><td><code>placeholder</code> (default) | <code>embedded</code></td><td>Markdown picture handling (embedded = base64 data URIs).</td></tr>
   <tr><td><code>no_ocr</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: skip layout/OCR/TableFormer entirely; emit the embedded text layer only.</td></tr>
@@ -161,6 +162,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
   <tr><td><code>no_text_panels</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: keep every detected picture as a picture — disable the demotion of uncaptioned dense-text "picture" regions into paragraphs.</td></tr>
   <tr><td><code>fetch_images</code></td><td><code>true</code>/<code>false</code></td><td>HTML/EPUB: resolve external <code>&lt;img src&gt;</code> and embed the bytes. Outbound fetch — honored only when the server runs with <code>--allow-url-fetch</code>, otherwise ignored.</td></tr>
   <tr><td><code>asr_lang</code></td><td><code>auto</code> (default) | a Whisper code (<code>en</code>, <code>de</code>, <code>zh</code>, …)</td><td>Audio/video: transcription language; <code>auto</code> detects it from the first 30 seconds. English-only presets always transcribe English.</td></tr>
+  <tr><td><code>scale</code></td><td><code>0.1</code>–<code>4.0</code> (default <code>2.0</code>)</td><td><code>to=images</code>: render scale in pixels per PDF point — 2.0 = 144&nbsp;dpi, the ML pipeline's own render scale.</td></tr>
 </table>
 
 <h2>Examples</h2>
@@ -330,6 +332,38 @@ $('go').addEventListener('click', async () => {
           `confidence: ${c.mean_grade} (mean ${Number(c.mean_score).toFixed(3)}, low ${c.low_grade})`;
         $('confidence').style.display = '';
       } catch { /* unparseable header — skip the banner */ }
+    }
+    if (to === 'images') {
+      // #243: per-page PNG renders — show them as the gallery instead of text.
+      const data = JSON.parse(await response.text());
+      const gallery = $('gallery');
+      let shown = 0;
+      const errors = [];
+      const addPages = (name, pages) => {
+        for (const p of pages || []) {
+          const figure = document.createElement('figure');
+          const img = document.createElement('img');
+          img.src = 'data:image/png;base64,' + p.png_base64;
+          img.alt = `page ${p.page}`;
+          const caption = document.createElement('figcaption');
+          caption.textContent =
+            `${name ? name + ' — ' : ''}page ${p.page} (${p.width}×${p.height})`;
+          figure.append(img, caption);
+          gallery.append(figure);
+          shown++;
+        }
+      };
+      if (data.results) { // batch: per-item status
+        for (const r of data.results) {
+          if (r.status === 'success') addPages(r.name, r.pages);
+          else errors.push(`${r.name}: ${r.error}`);
+        }
+      } else {
+        addPages('', data.pages);
+      }
+      out.textContent = `${shown} page(s) rendered.`
+        + (errors.length ? '\n' + errors.join('\n') : '');
+      return;
     }
     if (to === 'dclx') {
       const blob = await response.blob();

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -24,7 +24,13 @@
 //! Options ride along as multipart text parts, JSON fields, or query
 //! parameters (body wins over query):
 //!
-//! - `to` — `md` (default) | `json` | `dclx` | `chunks`
+//! - `to` — `md` (default) | `json` | `dclx` | `chunks` | `images` (#243:
+//!   rasterize a PDF's pages to PNG through pdfium — no conversion, no models;
+//!   the JSON response is `{"pages": [{"page", "width", "height",
+//!   "png_base64"}]}`, combines with `pages` for a window, capped at
+//!   `DOCLING_RS_MAX_RASTER_PAGES` pages per request, default 100)
+//! - `scale` — `to=images` render scale in pixels per PDF point:
+//!   0.1–4.0, default 2.0 (= 144 dpi, the ML pipeline's own render scale)
 //! - `strict` — cleaner Markdown instead of docling-legacy output
 //! - `images` — `placeholder` (default) | `embedded` (Markdown only)
 //! - `no_ocr`, `no_table_former`, `force_full_page_ocr`, `no_text_panels` — PDF/image pipeline switches
@@ -305,6 +311,9 @@ struct ConvertOptions {
     pages: Option<String>,
     /// OCR recognition language for scanned pages: `en` (default) | `ch`.
     ocr_lang: Option<String>,
+    /// `to=images` render scale in pixels per PDF point (#243): default 2.0
+    /// (144 dpi, the pipeline's own render scale), accepted range 0.1–4.0.
+    scale: Option<f32>,
 }
 
 impl ConvertOptions {
@@ -323,6 +332,7 @@ impl ConvertOptions {
             video_frames: self.video_frames.or(base.video_frames),
             pages: self.pages.or(base.pages),
             ocr_lang: self.ocr_lang.or(base.ocr_lang),
+            scale: self.scale.or(base.scale),
         }
     }
 }
@@ -421,9 +431,12 @@ async fn parse_convert_request(
 /// submission fails fast instead of parking a doomed job in the queue).
 fn validate_output(options: &ConvertOptions) -> Result<(String, ImageMode), ApiError> {
     let to = options.to.clone().unwrap_or_else(|| "md".into());
-    if !matches!(to.as_str(), "md" | "markdown" | "json" | "dclx" | "chunks") {
+    if !matches!(
+        to.as_str(),
+        "md" | "markdown" | "json" | "dclx" | "chunks" | "images"
+    ) {
         return Err(ApiError::Bad(format!(
-            "unknown to='{to}' (expected: md, json, dclx, chunks)"
+            "unknown to='{to}' (expected: md, json, dclx, chunks, images)"
         )));
     }
     let image_mode = match options.images.as_deref().unwrap_or("placeholder") {
@@ -722,6 +735,16 @@ fn run_conversion(
             .next()
             .expect("checked len")
             .map_err(|(_, e)| e)?;
+        if to == "images" {
+            let pages = rasterize_pages(state, &source, options)?;
+            return Ok(StoredResponse {
+                content_type: "application/json",
+                disposition: None,
+                confidence: None,
+                body: serde_json::to_vec_pretty(&json!({ "pages": pages }))
+                    .expect("page JSON serializes"),
+            });
+        }
         let name = source.name.clone();
         let document = convert_document(state, source, options)?;
         return Ok(render_stored(
@@ -742,6 +765,20 @@ fn run_conversion(
                 }
             };
             let name = source.name.clone();
+            if to == "images" {
+                return match rasterize_pages(state, &source, options) {
+                    Ok(pages) => json!({
+                        "name": name,
+                        "status": "success",
+                        "pages": pages,
+                    }),
+                    Err(e) => json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    }),
+                };
+            }
             match convert_document(state, source, options) {
                 Ok(document) => batch_item(state, to, image_mode, &name, &document, options),
                 Err(e) => json!({
@@ -759,6 +796,83 @@ fn run_conversion(
         body: serde_json::to_vec_pretty(&json!({ "results": items }))
             .expect("batch JSON serializes"),
     })
+}
+
+/// Server-side cap on pages rasterized per `to=images` request (#243). A small
+/// upload can be a 1000-page PDF, and every rendered page is hundreds of KB of
+/// PNG held in the response (or an async job's stored result) — without a cap
+/// one request could balloon memory far past the body limit. Override with
+/// `DOCLING_RS_MAX_RASTER_PAGES`.
+fn max_raster_pages() -> usize {
+    docling_core::env::parse("DOCLING_RS_MAX_RASTER_PAGES").unwrap_or(100)
+}
+
+/// `to=images` (#243): rasterize a PDF's pages to PNG through pdfium — no
+/// models, no OCR — honoring the request's `pages` window and `scale`. Returns
+/// the response's `pages` array; base64 in JSON mirrors the batch `dclx_base64`
+/// precedent (and survives async job storage unchanged).
+fn rasterize_pages(
+    state: &AppState,
+    source: &SourceDocument,
+    options: &ConvertOptions,
+) -> Result<Vec<serde_json::Value>, ApiError> {
+    if source.format != InputFormat::Pdf {
+        return Err(ApiError::Unsupported(format!(
+            "to=images rasterizes PDF inputs only ('{}' is not a PDF); \
+             other formats convert with to=md|json|dclx|chunks",
+            source.name
+        )));
+    }
+    let scale = options.scale.unwrap_or(2.0);
+    if !(0.1..=4.0).contains(&scale) {
+        return Err(ApiError::Bad(format!(
+            "scale {scale} out of range (0.1–4.0 pixels per PDF point; 2.0 = 144 dpi)"
+        )));
+    }
+    let range = options
+        .pages
+        .as_deref()
+        .map(docling::parse_page_range)
+        .transpose()
+        .map_err(|e| ApiError::Bad(format!("pages: {e}")))?;
+    // Enforce the page cap before rendering anything. Count with the window
+    // applied — pages=A-B is exactly the documented way to rasterize a slice
+    // of a document that exceeds the cap.
+    let total = docling::pdf_page_count(&source.bytes, None)
+        .map_err(|e| ApiError::Unsupported(e.to_string()))?;
+    let selected = match range {
+        Some((first, last)) if first <= total => last.min(total) - first + 1,
+        Some(_) => 0, // out-of-document start — render_pages reports the error
+        None => total,
+    };
+    let cap = max_raster_pages();
+    if selected > cap {
+        return Err(ApiError::Bad(format!(
+            "{selected} pages exceed the rasterization cap of {cap}; narrow the request \
+             with pages=A-B (or raise DOCLING_RS_MAX_RASTER_PAGES on the server)"
+        )));
+    }
+    // pdfium is not thread-safe, and the warm pipeline's mutex is this
+    // process's "who owns pdfium" lock — hold it for the render even though no
+    // models run here, so a rasterization can't race a concurrent PDF/image
+    // conversion inside pdfium.
+    let _pdfium_owner = state
+        .pipeline
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let pages = docling::render_pdf_pages(&source.bytes, None, range, scale)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(pages
+        .iter()
+        .map(|p| {
+            json!({
+                "page": p.page_no,
+                "width": p.width,
+                "height": p.height,
+                "png_base64": docling::base64::encode(&p.png),
+            })
+        })
+        .collect())
 }
 
 /// Serialize a converted document for a buffered (non-streaming) response.
@@ -931,6 +1045,13 @@ async fn read_multipart(
             "asr_lang" => body_opts.asr_lang = Some(text_field(field).await?),
             "pages" => body_opts.pages = Some(text_field(field).await?),
             "ocr_lang" => body_opts.ocr_lang = Some(text_field(field).await?),
+            "scale" => {
+                let v = text_field(field).await?;
+                body_opts.scale =
+                    Some(v.parse().map_err(|_| {
+                        ApiError::Bad(format!("scale must be a number, got {v:?}"))
+                    })?);
+            }
             "video_frames" => {
                 let v = text_field(field).await?;
                 body_opts.video_frames = Some(v.parse().map_err(|_| {

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -34,7 +34,9 @@ paths:
         segment of the URL path.
 
         `to=md` streams the Markdown as it converts (chunked response);
-        `to=dclx` returns the archive as a download.
+        `to=dclx` returns the archive as a download; `to=images` skips
+        conversion entirely and rasterizes a PDF's pages to PNG (base64 in
+        JSON), honoring `pages` and `scale`.
 
         **Batch**: several `file` parts in one multipart request convert as a
         batch — the response is then `{"results": [...]}` with per-item
@@ -57,6 +59,7 @@ paths:
         - { $ref: "#/components/parameters/no_text_panels" }
         - { $ref: "#/components/parameters/fetch_images" }
         - { $ref: "#/components/parameters/pages" }
+        - { $ref: "#/components/parameters/scale" }
         - { $ref: "#/components/parameters/ocr_lang" }
         - { $ref: "#/components/parameters/asr_model" }
         - { $ref: "#/components/parameters/asr_lang" }
@@ -310,13 +313,17 @@ components:
   schemas:
     To:
       type: string
-      enum: [md, json, dclx, chunks]
+      enum: [md, json, dclx, chunks, images]
       default: md
       description: |
         `md` — Markdown, streamed as it converts.
         `json` — docling `DoclingDocument` JSON.
         `dclx` — DocLang OPC archive, returned as a download.
         `chunks` — chunker records (hierarchical, plus hybrid when a tokenizer is installed).
+        `images` — PDF only: per-page PNG renders as
+        `{"pages": [{"page", "width", "height", "png_base64"}]}` (no
+        conversion, no models; capped at `DOCLING_RS_MAX_RASTER_PAGES`
+        pages per request, default 100 — narrow with `pages=A-B`).
     Images:
       type: string
       enum: [placeholder, embedded]
@@ -327,6 +334,14 @@ components:
       enum: [en, ch]
       default: en
       description: OCR recognition language for scanned pages.
+    Scale:
+      type: number
+      minimum: 0.1
+      maximum: 4.0
+      default: 2.0
+      description: >-
+        `to=images` render scale in pixels per PDF point — 2.0 = 144 dpi,
+        the ML pipeline's own render scale.
     Options:
       type: object
       description: Conversion options, shared by every transport.
@@ -368,6 +383,7 @@ components:
           description: PDF page window, `A-B` or a single `N` (1-based, inclusive).
           examples: ["2-5", "3"]
         ocr_lang: { $ref: "#/components/schemas/OcrLang" }
+        scale: { $ref: "#/components/schemas/Scale" }
         asr_model:
           type: string
           description: Audio/video — Whisper preset directory under `.models/asr/`.
@@ -463,6 +479,8 @@ components:
       { name: fetch_images, in: query, schema: { type: boolean } }
     pages:
       { name: pages, in: query, schema: { type: string }, example: "2-5" }
+    scale:
+      { name: scale, in: query, schema: { $ref: "#/components/schemas/Scale" } }
     ocr_lang:
       { name: ocr_lang, in: query, schema: { $ref: "#/components/schemas/OcrLang" } }
     asr_model:

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -47,6 +47,28 @@ fn convert_request(content_type: &str, body: Vec<u8>, query: &str) -> Request<Bo
         .unwrap()
 }
 
+/// Shared fixtures live at the repo root (see CLAUDE.md); tests run with CWD =
+/// the crate dir.
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Skip-gate for tests that render PDFs: point pdfium resolution at the
+/// repo-root `.pdfium/lib` when present (same pattern as
+/// `crates/docling/tests/pages.rs`) — CI without the runtime assets stays
+/// green.
+fn pdfium_ready() -> bool {
+    let lib = repo_root().join(".pdfium/lib");
+    if lib.join("libpdfium.so").exists()
+        || lib.join("libpdfium.dylib").exists()
+        || lib.join("pdfium.dll").exists()
+    {
+        std::env::set_var("PDFIUM_DYNAMIC_LIB_PATH", &lib);
+        return true;
+    }
+    std::env::var("PDFIUM_DYNAMIC_LIB_PATH").is_ok()
+}
+
 #[tokio::test]
 async fn health_is_ok() {
     let response = app()
@@ -110,6 +132,7 @@ async fn serves_its_logo_and_openapi_description() {
         "fetch_images:",
         "pages:",
         "ocr_lang:",
+        "scale:",
         "asr_model:",
         "video_frames:",
     ] {
@@ -205,6 +228,53 @@ async fn bad_to_value_is_400() {
     let (ct, body) = multipart("x.md", b"x", &[("to", "pdf")]);
     let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// `to=images` (#243) is PDF-only — a non-PDF upload answers 422 before any
+/// pdfium work, so this runs in plain CI.
+#[tokio::test]
+async fn images_output_requires_a_pdf_input() {
+    let (ct, body) = multipart("x.md", b"# hi", &[("to", "images")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(body_string(response).await.contains("PDF inputs only"));
+}
+
+/// A `scale` outside 0.1–4.0 is rejected before pdfium is touched.
+#[tokio::test]
+async fn images_scale_is_validated() {
+    let (ct, body) = multipart("x.pdf", b"%PDF-1.4", &[("to", "images"), ("scale", "9")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("scale"));
+}
+
+/// End-to-end rasterization over a real one-page fixture — runs only where
+/// `.pdfium/lib` is installed (`pdfium_ready` gate).
+#[tokio::test]
+async fn rasterizes_pdf_pages_to_png() {
+    if !pdfium_ready() {
+        eprintln!("skipping: pdfium not installed");
+        return;
+    }
+    let pdf = std::fs::read(repo_root().join("tests/data/pdf/sources/base14_fonts.pdf")).unwrap();
+    let (ct, body) = multipart(
+        "base14_fonts.pdf",
+        &pdf,
+        &[("to", "images"), ("scale", "1")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    let pages = json["pages"].as_array().expect("pages array");
+    assert_eq!(pages.len(), 1);
+    assert_eq!(pages[0]["page"], 1);
+    assert!(pages[0]["width"].as_u64().unwrap() > 0);
+    assert!(pages[0]["height"].as_u64().unwrap() > 0);
+    // The payload decodes to a real PNG (magic bytes).
+    let b64 = pages[0]["png_base64"].as_str().unwrap();
+    let bytes = docling::base64::decode(b64).expect("valid base64");
+    assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
 }
 
 #[tokio::test]

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -59,7 +59,8 @@ pub use docling_core::{
 // for callers that convert many files or want a warm, startup-excluded measurement.
 #[cfg(feature = "pdf")]
 pub use docling_pdf::{
-    model_inventory, page_count as pdf_page_count, EnrichmentOptions, ModelEntry, OcrLang, Pipeline,
+    model_inventory, page_count as pdf_page_count, render_pages as render_pdf_pages,
+    EnrichmentOptions, ModelEntry, OcrLang, Pipeline, RenderedPage,
 };
 // The pure-Rust text-layer extraction (no pdfium, no models) — compiled with
 // either PDF feature. The CLI uses it as the `--no-ocr` fallback when the

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -369,6 +369,13 @@ These are deliberate or unavoidable divergences, not bugs.
    its 0-based internal page index. Unset scores serialize as `null`, not
    `NaN`.
 
+10. **Page rasterization over HTTP** (#243). `to=images` on docling-serve's
+    `/v1/convert` (sync, async, batch) renders a PDF's pages to PNG through
+    pdfium without running any conversion — the per-page base64 JSON covers
+    the PDF-to-image use case Python docling-serve served; `pages=A-B`
+    windows and `scale` (pixels per PDF point, default 2.0 = 144 dpi) apply,
+    capped at `DOCLING_RS_MAX_RASTER_PAGES` (100) pages per request.
+
 ---
 
 ## 5. Not migrated / out of scope

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -374,7 +374,9 @@ These are deliberate or unavoidable divergences, not bugs.
     pdfium without running any conversion — the per-page base64 JSON covers
     the PDF-to-image use case Python docling-serve served; `pages=A-B`
     windows and `scale` (pixels per PDF point, default 2.0 = 144 dpi) apply,
-    capped at `DOCLING_RS_MAX_RASTER_PAGES` (100) pages per request.
+    capped at `DOCLING_RS_MAX_RASTER_PAGES` (100) pages per request. The CLI
+    counterpart is `--to images` + `--scale`, writing `<stem>_page_NNNN.png`
+    files (no cap — the pages land on the caller's own disk).
 
 ---
 


### PR DESCRIPTION
Exposes docling-pdf's pdfium rendering through docling-serve without running any conversion: to=images on /v1/convert (sync, async and batch alike) answers {"pages": [{"page", "width", "height", "png_base64"}]} — the PDF-to-image use case Python docling-serve covered, now one request against the same server that converts.

The render path is deliberately lean: docling_pdf::render_pages binds pdfium, renders each page at scale pixels per point and PNG-encodes it with one bitmap resident at a time — no text extraction, no models, and no 1.5x supersample+downsample pass (that dance exists only because TableFormer is pixel-pinned to docling's bitmaps; nothing downstream of this output is, and a single render is nearly twice as fast). pdfium is not thread-safe, so serve holds its warm-pipeline mutex — the process's one pdfium owner — around the render even though no models run.

Request surface: pages=A-B (#80 semantics) windows the render; new scale option (0.1-4.0 px per PDF point, default 2.0 = 144 dpi, the pipeline's own RENDER_SCALE) rides as query param, multipart field and JSON key like every other option. Non-PDF inputs 422 before pdfium is touched. A server-side cap (DOCLING_RS_MAX_RASTER_PAGES, default 100) bounds the response/stored-result memory a single request can demand — a small upload can be a 1000-page PDF — with pages=A-B as the documented slice-it-yourself escape.

The playground renders the pages as its existing gallery; openapi.yaml describes the format, option and cap (pinned by the spec-drift test). Serve tests cover the 422/400 validation paths in plain CI and gate the end-to-end PNG assertion on .pdfium presence, mirroring pages.rs::pdfium_ready.

Closes docling-project/docling.rs#243



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT