### PR TITLE
feat: skip_ocr — layout + TableFormer without OCR, and OCR-model degr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ honoring `pages=A-B` and a `scale` of 0.1–4.0 pixels per PDF point (default
 (`DOCLING_RS_MAX_RASTER_PAGES`); narrow big documents with `pages`.
 
 Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placeholder|embedded`,
-`no_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
+`no_ocr`, `skip_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
 `ocr_lang`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
@@ -500,7 +500,17 @@ all, only the PDF's embedded text cells grouped into flat paragraphs by
 reading order (no headings/lists/tables/pictures). It's the fastest PDF path
 by a wide margin, but a scanned/image-only PDF (no embedded text layer) comes
 back empty rather than erroring, so a caller can detect that and re-convert
-without the flag. `--force-full-page-ocr` is the opposite escape hatch
+without the flag. `--skip-ocr` (#244) sits between the two: it keeps layout
+detection and TableFormer but never runs (or loads) OCR — docling's
+independent `do_ocr=False`, the counterpart of `--no-table-former`. Structured
+output — headings, tables, pictures, reading order — survives; only text that
+exists solely as pixels is lost (scanned pages come back with empty regions,
+and the speculative OCR of large embedded images never runs). Independently of
+the flag, a *missing* OCR model now warns and degrades to the same behavior
+instead of failing the conversion (`skip_ocr` in serve/Node,
+`do_ocr=False` in Python — which now matches docling exactly; the old
+skip-everything meaning moved to the Python-only `text_layer_only=True`).
+`--force-full-page-ocr` is the opposite escape hatch
 (docling's `force_full_page_ocr`): OCR every page from its rendered image
 even when it carries a text layer — for layers that exist but lie (broken
 encodings, subset fonts with garbage mappings, a scanned form with a few

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -3,7 +3,11 @@
 //! The docling.rs counterpart of `docling.cli.main`; `docling-rs serve`
 //! (with `--features serve`) starts the HTTP conversion API.
 //!
-//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! `--skip-ocr` (#244) keeps layout + TableFormer but never runs OCR
+//! (docling's independent `do_ocr=False`); `--no-ocr` remains the
+//! skip-everything fast path.
+//!
+//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
 //!                      shell doesn't expand it) instead of one positional file.
@@ -124,6 +128,7 @@ fn main() -> ExitCode {
     let mut no_stream = false;
     let mut no_table_former = false;
     let mut no_ocr = false;
+    let mut skip_ocr = false;
     let mut force_full_page_ocr = false;
     let mut no_text_panels = false;
     let mut use_web_browser = false;
@@ -152,6 +157,10 @@ fn main() -> ExitCode {
             "--no-stream" => no_stream = true,
             "--no-table-former" => no_table_former = true,
             "--no-ocr" => no_ocr = true,
+            // #244: keep layout + TableFormer, never OCR (docling's
+            // independent do_ocr=False) — unlike --no-ocr, which skips the
+            // whole ML stack.
+            "--skip-ocr" => skip_ocr = true,
             "--force-full-page-ocr" => force_full_page_ocr = true,
             "--no-text-panels" => no_text_panels = true,
             "--use-web-browser" => use_web_browser = true,
@@ -341,6 +350,7 @@ fn main() -> ExitCode {
             fetch_images,
             no_table_former,
             no_ocr,
+            skip_ocr,
             force_full_page_ocr,
             no_text_panels,
             use_web_browser,
@@ -359,7 +369,7 @@ fn main() -> ExitCode {
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--use-web-browser] <input-file>");
+        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--use-web-browser] <input-file>");
         return ExitCode::from(2);
     };
 
@@ -448,6 +458,7 @@ fn main() -> ExitCode {
         .asr_lang(asr_lang.clone())
         .fetch_images(fetch_images)
         .no_table_former(no_table_former)
+        .skip_ocr(skip_ocr)
         .no_ocr(no_ocr)
         .force_full_page_ocr(force_full_page_ocr)
         .no_text_panels(no_text_panels)
@@ -590,6 +601,7 @@ struct BatchCfg {
     fetch_images: bool,
     no_table_former: bool,
     no_ocr: bool,
+    skip_ocr: bool,
     force_full_page_ocr: bool,
     no_text_panels: bool,
     use_web_browser: bool,
@@ -735,6 +747,7 @@ fn batch_pipeline<'a>(
             .map_err(|e| e.to_string())?
             .no_table_former(cfg.no_table_former)
             .no_ocr(cfg.no_ocr)
+            .skip_ocr(cfg.skip_ocr)
             .force_full_page_ocr(cfg.force_full_page_ocr)
             .no_text_panels(cfg.no_text_panels)
             .enrichments(docling::EnrichmentOptions {

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -47,6 +47,11 @@ pub struct ConverterOptions {
     /// proper Latin word spacing) or `"ch"` (the multilingual
     /// docling-conformance model). Formats that never OCR ignore it.
     pub ocr_lang: Option<String>,
+    /// Keep layout + TableFormer, never OCR (#244) — docling's independent
+    /// `do_ocr=False`. Structured output survives; text that exists only as
+    /// pixels (scanned pages, text inside images) comes back empty.
+    /// Default `false`.
+    pub skip_ocr: Option<bool>,
     /// OCR every PDF page even when it carries an embedded text layer
     /// (docling's `force_full_page_ocr`) — for text layers that exist but lie.
     /// Default `false`.
@@ -100,6 +105,11 @@ pub struct ConvertOptions {
     pub pages: Option<String>,
     /// OCR recognition language for scanned pages: `"en"` (default) | `"ch"`.
     pub ocr_lang: Option<String>,
+    /// Keep layout + TableFormer, never OCR (#244) — docling's independent
+    /// `do_ocr=False`. Structured output survives; text that exists only as
+    /// pixels (scanned pages, text inside images) comes back empty.
+    /// Default `false`.
+    pub skip_ocr: Option<bool>,
     /// OCR every PDF page even when it carries a text layer (docling's
     /// `force_full_page_ocr`). Default `false`.
     pub force_full_page_ocr: Option<bool>,
@@ -163,6 +173,7 @@ struct ConvertConfig {
     video_frames: Option<usize>,
     page_range: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    skip_ocr: bool,
     force_full_page_ocr: bool,
     no_text_panels: bool,
     allowed_formats: Option<Vec<InputFormat>>,
@@ -225,6 +236,7 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         video_frames: o.video_frames.map(|n| n as usize),
         page_range: parse_pages(o.pages.as_deref())?,
         ocr_lang: parse_ocr_lang(o.ocr_lang)?,
+        skip_ocr: o.skip_ocr.unwrap_or(false),
         force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
         no_text_panels: o.no_text_panels.unwrap_or(false),
         allowed_formats: allowed,
@@ -257,6 +269,7 @@ fn build_converter(cfg: &ConvertConfig) -> RsConverter {
     let base = base
         .strict(cfg.strict)
         .fetch_images(cfg.fetch_images)
+        .skip_ocr(cfg.skip_ocr)
         .force_full_page_ocr(cfg.force_full_page_ocr)
         .no_text_panels(cfg.no_text_panels)
         .asr_model(cfg.asr_model.clone())
@@ -446,6 +459,7 @@ pub struct DocumentConverter {
     video_frames: Option<usize>,
     page_range: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    skip_ocr: bool,
     force_full_page_ocr: bool,
     no_text_panels: bool,
     allowed_formats: Option<Vec<InputFormat>>,
@@ -472,6 +486,7 @@ impl DocumentConverter {
             video_frames: o.video_frames.map(|n| n as usize),
             page_range: parse_pages(o.pages.as_deref())?,
             ocr_lang: parse_ocr_lang(o.ocr_lang.clone())?,
+            skip_ocr: o.skip_ocr.unwrap_or(false),
             force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
             no_text_panels: o.no_text_panels.unwrap_or(false),
             allowed_formats: allowed,
@@ -488,6 +503,7 @@ impl DocumentConverter {
             video_frames: self.video_frames,
             page_range: self.page_range,
             ocr_lang: self.ocr_lang.clone(),
+            skip_ocr: self.skip_ocr,
             force_full_page_ocr: self.force_full_page_ocr,
             no_text_panels: self.no_text_panels,
             allowed_formats: self.allowed_formats.clone(),
@@ -904,6 +920,7 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
         asr_lang: None,
         video_frames: None,
         page_range: None,
+        skip_ocr: false,
         force_full_page_ocr: false,
         no_text_panels: false,
         ocr_lang: None,

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -101,7 +101,7 @@ use docling_core::Node;
 use docling_core::{debug_log, env};
 
 #[cfg(feature = "ml")]
-pub use mets::{convert_mets_gbs, convert_mets_gbs_with_options};
+pub use mets::{convert_mets_gbs, convert_mets_gbs_with_options, convert_mets_gbs_with_pipeline};
 #[cfg(feature = "ml")]
 pub use ocr::OcrLang;
 #[cfg(feature = "ml")]
@@ -529,7 +529,7 @@ pub fn layout_src(page: &PdfPage) -> layout::LayoutSrc<'_> {
 struct Worker {
     /// `None` when `no_ocr` skips layout entirely — no model load, no inference.
     layout: Option<layout::LayoutModel>,
-    ocr: Option<ocr::OcrModel>,
+    ocr: OcrSlot,
     /// Shared TableFormer slot; `None` when `no_table_former`/`no_ocr` skip it.
     tables: Option<SharedTables>,
     /// Shared enrichment slots; `None` unless the corresponding flag is on.
@@ -545,8 +545,22 @@ struct Worker {
     /// Keep text-panel pictures as pictures instead of demoting them to
     /// paragraphs. See [`Pipeline::no_text_panels`].
     no_text_panels: bool,
+    /// Never run OCR, but keep layout + TableFormer (#244) — docling's
+    /// `do_ocr=False`. See [`Pipeline::skip_ocr`].
+    skip_ocr: bool,
     /// Which recognition model [`Self::ocr`] loads. See [`Pipeline::ocr_lang`].
     ocr_lang: ocr::OcrLang,
+}
+
+#[cfg(feature = "ml")]
+/// The worker's lazily-loaded OCR recognition model. `Missing` records a
+/// failed load (#244: degradation over failure — a deployment without the OCR
+/// model still gets layout + TableFormer, and OCR-dependent regions stay
+/// empty) so the load isn't retried per page.
+enum OcrSlot {
+    Unloaded,
+    Ready(ocr::OcrModel),
+    Missing,
 }
 
 #[cfg(feature = "ml")]
@@ -558,6 +572,7 @@ impl Worker {
         enrich_slots: (Option<SharedClassifier>, Option<SharedCodeFormula>),
         enrich: EnrichmentOptions,
         no_ocr: bool,
+        skip_ocr: bool,
         force_full_page_ocr: bool,
         no_text_panels: bool,
         ocr_lang: ocr::OcrLang,
@@ -568,15 +583,49 @@ impl Worker {
             } else {
                 Some(layout::LayoutModel::load_with(intra).map_err(PdfError::Layout)?)
             },
-            ocr: None,
+            ocr: OcrSlot::Unloaded,
             tables,
             classifier: enrich_slots.0,
             code_formula: enrich_slots.1,
             enrich,
             no_ocr,
+            skip_ocr,
             force_full_page_ocr,
             no_text_panels,
             ocr_lang,
+        })
+    }
+
+    /// The OCR model, or `None` when this conversion must not (or cannot) OCR:
+    /// `skip_ocr` short-circuits, and a failed model load degrades to `None`
+    /// with a one-time warning instead of failing the conversion (#244) —
+    /// unless `force_full_page_ocr` demanded OCR explicitly, where a missing
+    /// model stays a hard error (the text layer was deliberately discarded, so
+    /// degrading would silently emit an empty document).
+    fn ocr_model(&mut self) -> Result<Option<&mut ocr::OcrModel>, PdfError> {
+        if self.skip_ocr {
+            return Ok(None);
+        }
+        if matches!(self.ocr, OcrSlot::Unloaded) {
+            match ocr::OcrModel::load(self.ocr_lang) {
+                Ok(model) => self.ocr = OcrSlot::Ready(model),
+                Err(e) if self.force_full_page_ocr => return Err(PdfError::Ocr(e)),
+                Err(e) => {
+                    static WARNED: std::sync::Once = std::sync::Once::new();
+                    WARNED.call_once(|| {
+                        eprintln!(
+                            "warning: OCR model unavailable ({e}); continuing without OCR — \
+                             scanned pages and text inside images will come back empty \
+                             (run scripts/install/download_dependencies.sh for the model)"
+                        );
+                    });
+                    self.ocr = OcrSlot::Missing;
+                }
+            }
+        }
+        Ok(match &mut self.ocr {
+            OcrSlot::Ready(model) => Some(model),
+            _ => None,
         })
     }
 
@@ -625,15 +674,16 @@ impl Worker {
     fn normalize_orientation(&mut self, n: usize, page: &mut PdfPage) -> Result<(), PdfError> {
         let scanned =
             page.cells.is_empty() && page.word_cells.is_empty() && page.code_cells.is_empty();
-        if self.no_ocr || !scanned || page.image.width() <= 1 || !orient::enabled() {
+        if self.no_ocr || self.skip_ocr || !scanned || page.image.width() <= 1 || !orient::enabled()
+        {
             return Ok(());
         }
-        if self.ocr.is_none() {
-            self.ocr = Some(ocr::OcrModel::load(self.ocr_lang).map_err(PdfError::Ocr)?);
-        }
-        let deg = timing::timed("orient.detect", || {
-            orient::detect(&page.image, self.ocr.as_mut().unwrap())
-        });
+        // The probe reads text through the OCR model; without one (missing —
+        // #244 degradation) the page stays as rendered.
+        let Some(ocr) = self.ocr_model()? else {
+            return Ok(());
+        };
+        let deg = timing::timed("orient.detect", || orient::detect(&page.image, ocr));
         if deg != 0 {
             debug_log!(
                 "docling-pdf: page {}: content rotated {deg}° in the raster; \
@@ -799,37 +849,33 @@ impl Worker {
         // No text layer → recognise text from the page image via OCR.
         let ocred = page.cells.is_empty();
         if ocred {
-            if self.ocr.is_none() {
-                self.ocr = Some(ocr::OcrModel::load(self.ocr_lang).map_err(PdfError::Ocr)?);
-            }
-            let cells = timing::timed("ocr.page", || {
-                self.ocr
-                    .as_mut()
-                    .unwrap()
-                    .ocr_page(&page.image, &regions, page.scale)
-            })
-            .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
-            ocr_confs.extend(cells.iter().map(|(_, conf)| conf));
-            page.cells = cells.into_iter().map(|(cell, _)| cell).collect();
-            // Table interiors carry no words yet: region-scoped OCR skips
-            // table labels, and a scanned page has no pdfium text layer — so
-            // TableFormer's cell matcher got an empty word list and the table
-            // dissolved (#173). Recognize the table regions' word crops
-            // (mirroring the browser scanned path): `word_cells` feeds the
-            // matcher, and the same cells join `cells` so the geometric
-            // fallback and the table's region text see them too.
-            if regions.iter().any(|r| assemble::is_table_like(r.label)) {
-                let words = timing::timed("ocr.table_words", || {
-                    self.ocr
-                        .as_mut()
-                        .unwrap()
-                        .ocr_table_words(&page.image, &regions, page.scale)
+            // `None` = `skip_ocr` or a missing model (#244): the page keeps
+            // its layout regions (and TableFormer structure below) with no
+            // recognized text, instead of failing the conversion.
+            if let Some(ocr) = self.ocr_model()? {
+                let cells = timing::timed("ocr.page", || {
+                    ocr.ocr_page(&page.image, &regions, page.scale)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
-                ocr_confs.extend(words.iter().map(|(_, conf)| conf));
-                let words: Vec<_> = words.into_iter().map(|(cell, _)| cell).collect();
-                page.cells.extend(words.iter().cloned());
-                page.word_cells = words;
+                ocr_confs.extend(cells.iter().map(|(_, conf)| conf));
+                page.cells = cells.into_iter().map(|(cell, _)| cell).collect();
+                // Table interiors carry no words yet: region-scoped OCR skips
+                // table labels, and a scanned page has no pdfium text layer — so
+                // TableFormer's cell matcher got an empty word list and the table
+                // dissolved (#173). Recognize the table regions' word crops
+                // (mirroring the browser scanned path): `word_cells` feeds the
+                // matcher, and the same cells join `cells` so the geometric
+                // fallback and the table's region text see them too.
+                if regions.iter().any(|r| assemble::is_table_like(r.label)) {
+                    let words = timing::timed("ocr.table_words", || {
+                        ocr.ocr_table_words(&page.image, &regions, page.scale)
+                    })
+                    .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+                    ocr_confs.extend(words.iter().map(|(_, conf)| conf));
+                    let words: Vec<_> = words.into_iter().map(|(cell, _)| cell).collect();
+                    page.cells.extend(words.iter().cloned());
+                    page.word_cells = words;
+                }
             }
         }
         // Region-scoped OCR skips `picture` interiors, and a digital page's
@@ -874,15 +920,11 @@ impl Worker {
                     ..r.clone()
                 })
                 .collect();
-            if !bare.is_empty() {
-                if self.ocr.is_none() {
-                    self.ocr = Some(ocr::OcrModel::load(self.ocr_lang).map_err(PdfError::Ocr)?);
-                }
+            // Speculative OCR (#244): with `skip_ocr` or no model, big bare
+            // pictures simply stay pictures.
+            if let (false, Some(ocr)) = (bare.is_empty(), self.ocr_model()?) {
                 let scored = timing::timed("ocr.pictures", || {
-                    self.ocr
-                        .as_mut()
-                        .unwrap()
-                        .ocr_page(&page.image, &bare, page.scale)
+                    ocr.ocr_page(&page.image, &bare, page.scale)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                 // Speculative in-picture OCR counts toward ocr_score only on
@@ -970,15 +1012,11 @@ impl Worker {
                 .filter(|t| assemble::is_table_like(t.label) && !has_text(t) && in_picture(t))
                 .cloned()
                 .collect();
-            if !pic_tables.is_empty() {
-                if self.ocr.is_none() {
-                    self.ocr = Some(ocr::OcrModel::load(self.ocr_lang).map_err(PdfError::Ocr)?);
-                }
+            // Same degradation as above: without OCR the in-picture table
+            // keeps its structure (TableFormer is geometry-driven) minus text.
+            if let (false, Some(ocr)) = (pic_tables.is_empty(), self.ocr_model()?) {
                 let words = timing::timed("ocr.table_words", || {
-                    self.ocr
-                        .as_mut()
-                        .unwrap()
-                        .ocr_table_words(&page.image, &pic_tables, page.scale)
+                    ocr.ocr_table_words(&page.image, &pic_tables, page.scale)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                 ocr_confs.extend(words.iter().map(|(_, conf)| conf));
@@ -1233,6 +1271,8 @@ pub struct Pipeline {
     no_table_former: bool,
     /// Skip layout, OCR, and TableFormer entirely. See [`Pipeline::no_ocr`].
     no_ocr: bool,
+    /// Keep layout + TableFormer, never OCR (#244). See [`Pipeline::skip_ocr`].
+    skip_ocr: bool,
     /// OCR every page even when it carries a text layer. See
     /// [`Pipeline::force_full_page_ocr`].
     force_full_page_ocr: bool,
@@ -1266,6 +1306,7 @@ impl Pipeline {
             parallel_min: pdf_parallel_min(),
             no_table_former: false,
             no_ocr: false,
+            skip_ocr: false,
             force_full_page_ocr: false,
             no_text_panels: false,
             enrich: EnrichmentOptions::default(),
@@ -1323,7 +1364,7 @@ impl Pipeline {
         for worker in self.primary.iter_mut().chain(self.pool.iter_mut()) {
             if worker.ocr_lang != lang {
                 worker.ocr_lang = lang;
-                worker.ocr = None;
+                worker.ocr = OcrSlot::Unloaded;
             }
         }
     }
@@ -1394,6 +1435,22 @@ impl Pipeline {
         self
     }
 
+    /// Never run OCR, but keep layout detection and TableFormer — docling's
+    /// independent `do_ocr=False` (#244), the counterpart of
+    /// [`no_table_former`](Self::no_table_former). Unlike
+    /// [`no_ocr`](Self::no_ocr) (which skips the whole ML stack), structured
+    /// output — headings, tables, pictures, reading order — is preserved;
+    /// only text that exists solely as pixels is lost: scanned pages come
+    /// back with their regions empty, and the speculative OCR of large
+    /// embedded images never runs. The OCR model is never loaded. Ignored
+    /// when `no_ocr` is set (there is no OCR to skip);
+    /// takes precedence over [`force_full_page_ocr`](Self::force_full_page_ocr),
+    /// mirroring docling where forcing is a sub-option of `do_ocr`.
+    pub fn skip_ocr(mut self, disable: bool) -> Self {
+        self.skip_ocr = disable;
+        self
+    }
+
     /// OCR every page from its rendered image even when the page carries an
     /// embedded text layer — docling's `force_full_page_ocr`. The escape hatch
     /// for text layers that exist but lie: broken encodings, subset fonts with
@@ -1448,6 +1505,7 @@ impl Pipeline {
                 self.enrich_slots(),
                 self.enrich,
                 self.no_ocr,
+                self.skip_ocr,
                 self.force_full_page_ocr,
                 self.no_text_panels,
                 self.ocr_lang,
@@ -1846,6 +1904,7 @@ impl Pipeline {
         }
         let intra = pdf_intra();
         let no_ocr = self.no_ocr;
+        let skip_ocr = self.skip_ocr;
         let force = self.force_full_page_ocr;
         let ntp = self.no_text_panels;
         let ocr_lang = self.ocr_lang;
@@ -1864,6 +1923,7 @@ impl Pipeline {
                             enrich_slots,
                             enrich,
                             no_ocr,
+                            skip_ocr,
                             force,
                             ntp,
                             ocr_lang,
@@ -1905,7 +1965,9 @@ impl Pipeline {
 
     /// Run layout (+ OCR for cell-less pages) and assemble each already-rendered
     /// page (image / METS inputs, which are small and already materialised).
-    fn process_pages(
+    /// Public so [`mets::convert_mets_gbs_with_pipeline`] can drive a
+    /// caller-configured pipeline (#244).
+    pub fn process_pages(
         &mut self,
         mut pages: Vec<PdfPage>,
         name: &str,

--- a/crates/docling-pdf/src/mets.rs
+++ b/crates/docling-pdf/src/mets.rs
@@ -42,6 +42,30 @@ pub fn convert_mets_gbs_with_options(
     no_text_panels: bool,
     enrich: crate::EnrichmentOptions,
 ) -> Result<DoclingDocument, PdfError> {
+    convert_pages_with_options(
+        mets_pages(bytes)?,
+        name,
+        no_table_former,
+        no_ocr,
+        no_text_panels,
+        enrich,
+    )
+}
+
+/// Like [`convert_mets_gbs_with_options`], but driving a caller-configured
+/// [`crate::Pipeline`] — the growth path for pipeline options (#244's
+/// `skip_ocr` and whatever comes next) without another signature change.
+pub fn convert_mets_gbs_with_pipeline(
+    bytes: &[u8],
+    name: &str,
+    pipeline: &mut crate::Pipeline,
+) -> Result<DoclingDocument, PdfError> {
+    pipeline.process_pages(mets_pages(bytes)?, name)
+}
+
+/// Parse a METS-GBS archive (tar.gz of per-page hOCR + TIFF) into pipeline
+/// pages, in page order.
+fn mets_pages(bytes: &[u8]) -> Result<Vec<PdfPage>, PdfError> {
     let mut html: BTreeMap<String, String> = BTreeMap::new();
     let mut tiff: BTreeMap<String, Vec<u8>> = BTreeMap::new();
 
@@ -103,7 +127,7 @@ pub fn convert_mets_gbs_with_options(
             "mets: no hOCR/TIFF page pairs found in archive".into(),
         ));
     }
-    convert_pages_with_options(pages, name, no_table_former, no_ocr, no_text_panels, enrich)
+    Ok(pages)
 }
 
 /// Parse an hOCR page: the `ocr_page` bbox gives the page geometry (cells are in

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "calamine",
  "csv",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -81,6 +81,7 @@ struct PyDocumentConverter {
     /// the interruptible worker threads can own a handle to it.
     pdf_pipeline: std::sync::Arc<std::sync::Mutex<Option<docling::Pipeline>>>,
     no_ocr: bool,
+    skip_ocr: bool,
     no_table_former: bool,
     no_text_panels: bool,
     enrich: docling::EnrichmentOptions,
@@ -92,6 +93,10 @@ impl PyDocumentConverter {
     /// Python side:
     /// * `fetch_images` — resolve remote/local `<img src>` for HTML/EPUB.
     /// * `do_ocr` — run OCR on scanned PDF/image pages (docling's `do_ocr`).
+    ///   `do_ocr=False` now matches docling exactly (#244): layout detection
+    ///   and TableFormer still run, only OCR is skipped — previously it
+    ///   disabled the whole ML stack (that fast path is the docling.rs-only
+    ///   `text_layer_only=True`).
     /// * `force_full_page_ocr` — OCR every PDF page even when it carries a
     ///   text layer (docling's `force_full_page_ocr`); ignored when
     ///   `do_ocr=False`.
@@ -136,6 +141,7 @@ impl PyDocumentConverter {
         page_range = None,
         ocr_lang = None,
         allowed_formats = None,
+        text_layer_only = false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -154,6 +160,7 @@ impl PyDocumentConverter {
         page_range: Option<(usize, usize)>,
         ocr_lang: Option<String>,
         allowed_formats: Option<Vec<String>>,
+        text_layer_only: bool,
     ) -> PyResult<Self> {
         // `allowed_formats` (docling's converter arg) restricts which input
         // formats convert; an unknown name is an error so typos surface early.
@@ -203,7 +210,8 @@ impl PyDocumentConverter {
                 .fetch_images(fetch_images)
                 .asr_model(asr_model)
                 .asr_lang(asr_lang)
-                .no_ocr(!do_ocr)
+                .no_ocr(text_layer_only)
+                .skip_ocr(!do_ocr)
                 .force_full_page_ocr(force_full_page_ocr)
                 .no_table_former(!do_table_structure)
                 .no_text_panels(no_text_panels)
@@ -212,7 +220,8 @@ impl PyDocumentConverter {
                 .do_code_enrichment(do_code_enrichment)
                 .do_formula_enrichment(do_formula_enrichment),
             pdf_pipeline: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            no_ocr: !do_ocr,
+            no_ocr: text_layer_only,
+            skip_ocr: !do_ocr,
             no_table_former: !do_table_structure,
             no_text_panels,
             enrich,
@@ -236,6 +245,7 @@ impl PyDocumentConverter {
         let slot = std::sync::Arc::clone(&self.pdf_pipeline);
         let no_table_former = self.no_table_former;
         let no_ocr = self.no_ocr;
+        let skip_ocr = self.skip_ocr;
         let no_text_panels = self.no_text_panels;
         let enrich = self.enrich;
         run_interruptible(py, move || {
@@ -245,6 +255,7 @@ impl PyDocumentConverter {
                     .map_err(|e| ConversionError::new_err(e.to_string()))?
                     .no_table_former(no_table_former)
                     .no_ocr(no_ocr)
+                    .skip_ocr(skip_ocr)
                     .no_text_panels(no_text_panels)
                     .enrichments(enrich);
                 pipeline

--- a/crates/docling-serve/Dockerfile
+++ b/crates/docling-serve/Dockerfile
@@ -13,7 +13,12 @@
 # network policy); URL fetching is enabled — front with a policy proxy or add
 # --no-url-fetch to CMD if the service should accept uploads only.
 
-FROM rust:1.96-bookworm AS build
+# trixie, not bookworm (#246): ort's prebuilt static onnxruntime is built
+# with GCC 13 and references GLIBCXX_3.4.31 — bookworm's libstdc++ (GCC 12)
+# tops out at 3.4.30, so the release link fails with undefined references.
+# The runtime stage below must stay on the same Debian release: the binary
+# links that libstdc++ (and trixie's glibc) dynamically.
+FROM rust:1.96-trixie AS build
 WORKDIR /src
 COPY . .
 ARG FETCH_ASSETS=1
@@ -21,7 +26,7 @@ RUN cargo build --release -p docling-serve --locked
 RUN if [ "$FETCH_ASSETS" = "1" ]; then sh scripts/install/download_dependencies.sh; \
     else mkdir -p .models .pdfium; fi
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 # ffmpeg powers video frame sampling (#138 Phase 2); without it a video input
 # still converts, transcript-only.
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg \

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -105,6 +105,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
     <label><input type="checkbox" id="embed" checked> embed images</label>
     <label id="fetch-images-label" title="HTML/EPUB: resolve external <img src> and embed the bytes (outbound fetch)"><input type="checkbox" id="fetch_images"> fetch images</label>
     <label><input type="checkbox" id="no_ocr"> no OCR</label>
+    <label title="Keep layout + TableFormer, never OCR (docling's do_ocr=False): structure survives, pixel-only text comes back empty"><input type="checkbox" id="skip_ocr"> skip OCR</label>
     <label><input type="checkbox" id="no_table_former"> no TableFormer</label>
     <label title="Keep every detected picture as a picture (disable text-panel demotion)"><input type="checkbox" id="no_text_panels"> keep pictures</label>
     <button id="go">Convert</button>
@@ -158,6 +159,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
   <tr><td><code>strict</code></td><td><code>true</code>/<code>false</code></td><td>Cleaner strict Markdown dialect instead of byte-for-byte docling-legacy output.</td></tr>
   <tr><td><code>images</code></td><td><code>placeholder</code> (default) | <code>embedded</code></td><td>Markdown picture handling (embedded = base64 data URIs).</td></tr>
   <tr><td><code>no_ocr</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: skip layout/OCR/TableFormer entirely; emit the embedded text layer only.</td></tr>
+  <tr><td><code>skip_ocr</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: keep layout + TableFormer, never OCR (docling's independent <code>do_ocr=False</code>, #244) — structure survives, pixel-only text comes back empty. A missing OCR model now degrades to this instead of erroring.</td></tr>
   <tr><td><code>no_table_former</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: geometric table reconstruction instead of the TableFormer model.</td></tr>
   <tr><td><code>no_text_panels</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: keep every detected picture as a picture — disable the demotion of uncaptioned dense-text "picture" regions into paragraphs.</td></tr>
   <tr><td><code>fetch_images</code></td><td><code>true</code>/<code>false</code></td><td>HTML/EPUB: resolve external <code>&lt;img src&gt;</code> and embed the bytes. Outbound fetch — honored only when the server runs with <code>--allow-url-fetch</code>, otherwise ignored.</td></tr>
@@ -291,6 +293,7 @@ $('go').addEventListener('click', async () => {
     images: $('embed').checked ? 'embedded' : 'placeholder',
     fetch_images: $('fetch_images').checked,
     no_ocr: $('no_ocr').checked,
+    skip_ocr: $('skip_ocr').checked,
     no_table_former: $('no_table_former').checked,
     no_text_panels: $('no_text_panels').checked,
   };

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -138,7 +138,7 @@ impl Default for ServeConfig {
 struct AppState {
     /// Warm ML pipeline (mutable ONNX sessions) — one PDF/image conversion at
     /// a time, but the models stay loaded across requests.
-    pipeline: Mutex<Option<Pipeline>>,
+    pipeline: Mutex<Option<(PipelineFlags, Pipeline)>>,
     /// Bounds total in-flight conversions (`Arc` so a permit can move into
     /// a streaming response's worker and outlive the handler).
     permits: Arc<Semaphore>,
@@ -162,7 +162,7 @@ pub fn router(cfg: ServeConfig) -> Router {
         // Blocking model load off the runtime; readiness flips when done.
         tokio::task::spawn_blocking(move || {
             match Pipeline::new() {
-                Ok(p) => *st.pipeline.lock().unwrap() = Some(p),
+                Ok(p) => *st.pipeline.lock().unwrap() = Some((PipelineFlags::default(), p)),
                 Err(e) => eprintln!("warmup: pipeline load failed: {e}"),
             }
             st.ready.store(true, Ordering::Release);
@@ -1362,30 +1362,53 @@ fn convert_document(
     }
 }
 
-/// The lazily-loaded warm pipeline. Pipeline switches (`no_ocr`,
-/// `no_table_former`) are per-instance, so a request that changes them
-/// rebuilds the pipeline (model sessions reload); steady-state traffic with
-/// stable options keeps the warm one.
+/// The pipeline switches a warm instance was built with, remembered alongside
+/// it (#246): the switches are per-instance state a [`Pipeline`] doesn't
+/// expose back, and without the record a flagged request permanently degraded
+/// the cached instance — a later default request found the slot filled and
+/// reused the reduced pipeline, silently returning flat no-OCR output until
+/// the server restarted.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct PipelineFlags {
+    no_ocr: bool,
+    skip_ocr: bool,
+    no_table_former: bool,
+    no_text_panels: bool,
+}
+
+impl PipelineFlags {
+    fn of(options: &ConvertOptions) -> Self {
+        Self {
+            no_ocr: options.no_ocr.unwrap_or(false),
+            skip_ocr: options.skip_ocr.unwrap_or(false),
+            no_table_former: options.no_table_former.unwrap_or(false),
+            no_text_panels: options.no_text_panels.unwrap_or(false),
+        }
+    }
+}
+
+/// The lazily-loaded warm pipeline. Pipeline switches (`no_ocr`, `skip_ocr`,
+/// `no_table_former`, `no_text_panels`) are per-instance, so the pipeline is
+/// rebuilt exactly when the request's switches differ from the cached
+/// instance's — including back to the default (#246; the old code only
+/// rebuilt *toward* reduced configurations, so a degraded instance stuck).
+/// Steady-state traffic with stable options — flagged or not — keeps the warm
+/// one.
 fn warm_pipeline<'a>(
-    slot: &'a mut Option<Pipeline>,
+    slot: &'a mut Option<(PipelineFlags, Pipeline)>,
     options: &ConvertOptions,
 ) -> Result<&'a mut Pipeline, ApiError> {
-    let no_ocr = options.no_ocr.unwrap_or(false);
-    let skip_ocr = options.skip_ocr.unwrap_or(false);
-    let no_tf = options.no_table_former.unwrap_or(false);
-    let ntp = options.no_text_panels.unwrap_or(false);
-    if no_ocr || skip_ocr || no_tf || ntp {
+    let flags = PipelineFlags::of(options);
+    if slot.as_ref().map(|(built, _)| *built) != Some(flags) {
         let p = Pipeline::new()
             .map_err(|e| ApiError::Internal(e.to_string()))?
-            .no_ocr(no_ocr)
-            .skip_ocr(skip_ocr)
-            .no_table_former(no_tf)
-            .no_text_panels(ntp);
-        *slot = Some(p);
-    } else if slot.is_none() {
-        *slot = Some(Pipeline::new().map_err(|e| ApiError::Internal(e.to_string()))?);
+            .no_ocr(flags.no_ocr)
+            .skip_ocr(flags.skip_ocr)
+            .no_table_former(flags.no_table_former)
+            .no_text_panels(flags.no_text_panels);
+        *slot = Some((flags, p));
     }
-    Ok(slot.as_mut().expect("just filled"))
+    Ok(&mut slot.as_mut().expect("just filled").1)
 }
 
 /// Per-request declarative converter (construction is cheap — it's
@@ -1553,6 +1576,37 @@ async fn stream_markdown(
 
 fn api_error_message(e: ApiError) -> String {
     api_error_parts(e).1
+}
+
+#[cfg(test)]
+mod pipeline_flag_tests {
+    use super::{warm_pipeline, ConvertOptions, PipelineFlags};
+
+    /// #246: the cached pipeline must be rebuilt whenever the request's
+    /// switches differ from the ones it was built with — in BOTH directions.
+    /// The old code only rebuilt toward reduced configurations, so a
+    /// `no_ocr=true` request permanently degraded the shared instance for
+    /// every later default request. (`Pipeline::new()` loads no models —
+    /// they're lazy — so this runs in plain CI.)
+    #[test]
+    fn warm_pipeline_rebuilds_in_both_directions() {
+        let mut slot = None;
+        let default_opts = ConvertOptions::default();
+        let no_ocr_opts = ConvertOptions {
+            no_ocr: Some(true),
+            ..ConvertOptions::default()
+        };
+        assert!(warm_pipeline(&mut slot, &no_ocr_opts).is_ok());
+        assert_eq!(slot.as_ref().unwrap().0, PipelineFlags::of(&no_ocr_opts));
+        // Back to default: the degraded instance must not be reused.
+        assert!(warm_pipeline(&mut slot, &default_opts).is_ok());
+        assert_eq!(slot.as_ref().unwrap().0, PipelineFlags::default());
+        // And a repeat with unchanged flags keeps the warm instance (no
+        // needless model reload): the stored flags stay identical, which is
+        // the rebuild guard itself.
+        assert!(warm_pipeline(&mut slot, &default_opts).is_ok());
+        assert_eq!(slot.as_ref().unwrap().0, PipelineFlags::default());
+    }
 }
 
 #[cfg(test)]

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -33,7 +33,10 @@
 //!   0.1–4.0, default 2.0 (= 144 dpi, the ML pipeline's own render scale)
 //! - `strict` — cleaner Markdown instead of docling-legacy output
 //! - `images` — `placeholder` (default) | `embedded` (Markdown only)
-//! - `no_ocr`, `no_table_former`, `force_full_page_ocr`, `no_text_panels` — PDF/image pipeline switches
+//! - `no_ocr`, `skip_ocr`, `no_table_former`, `force_full_page_ocr`,
+//!   `no_text_panels` — PDF/image pipeline switches (`skip_ocr`, #244: keep
+//!   layout + TableFormer, never OCR — docling's independent `do_ocr=False`;
+//!   `no_ocr` skips the whole ML stack)
 //! - `pages` — PDF page window `A-B` / `N` (1-based inclusive, #80)
 //! - `ocr_lang` — OCR recognition language for scanned pages: `en` (default)
 //!   | `ch` (the multilingual docling-conformance model)
@@ -293,6 +296,9 @@ struct ConvertOptions {
     strict: Option<bool>,
     images: Option<String>,
     no_ocr: Option<bool>,
+    /// Keep layout + TableFormer, never OCR (#244) — docling's independent
+    /// `do_ocr=False`. `no_ocr` (the whole-stack skip) wins when both are set.
+    skip_ocr: Option<bool>,
     force_full_page_ocr: Option<bool>,
     no_table_former: Option<bool>,
     /// Keep text-panel pictures as pictures (#173): disable the #157 demotion
@@ -323,6 +329,7 @@ impl ConvertOptions {
             strict: self.strict.or(base.strict),
             images: self.images.or(base.images),
             no_ocr: self.no_ocr.or(base.no_ocr),
+            skip_ocr: self.skip_ocr.or(base.skip_ocr),
             force_full_page_ocr: self.force_full_page_ocr.or(base.force_full_page_ocr),
             no_table_former: self.no_table_former.or(base.no_table_former),
             no_text_panels: self.no_text_panels.or(base.no_text_panels),
@@ -1062,6 +1069,7 @@ async fn read_multipart(
             }
             "strict"
             | "no_ocr"
+            | "skip_ocr"
             | "no_table_former"
             | "force_full_page_ocr"
             | "no_text_panels"
@@ -1071,6 +1079,7 @@ async fn read_multipart(
                 match name.as_str() {
                     "strict" => body_opts.strict = Some(b),
                     "no_ocr" => body_opts.no_ocr = Some(b),
+                    "skip_ocr" => body_opts.skip_ocr = Some(b),
                     "force_full_page_ocr" => body_opts.force_full_page_ocr = Some(b),
                     "no_table_former" => body_opts.no_table_former = Some(b),
                     "no_text_panels" => body_opts.no_text_panels = Some(b),
@@ -1362,12 +1371,14 @@ fn warm_pipeline<'a>(
     options: &ConvertOptions,
 ) -> Result<&'a mut Pipeline, ApiError> {
     let no_ocr = options.no_ocr.unwrap_or(false);
+    let skip_ocr = options.skip_ocr.unwrap_or(false);
     let no_tf = options.no_table_former.unwrap_or(false);
     let ntp = options.no_text_panels.unwrap_or(false);
-    if no_ocr || no_tf || ntp {
+    if no_ocr || skip_ocr || no_tf || ntp {
         let p = Pipeline::new()
             .map_err(|e| ApiError::Internal(e.to_string()))?
             .no_ocr(no_ocr)
+            .skip_ocr(skip_ocr)
             .no_table_former(no_tf)
             .no_text_panels(ntp);
         *slot = Some(p);
@@ -1399,6 +1410,7 @@ fn request_converter(
                 .unwrap_or(docling::DEFAULT_VIDEO_FRAMES),
         )
         .no_ocr(options.no_ocr.unwrap_or(false))
+        .skip_ocr(options.skip_ocr.unwrap_or(false))
         .force_full_page_ocr(options.force_full_page_ocr.unwrap_or(false))
         .no_table_former(options.no_table_former.unwrap_or(false))
         .no_text_panels(options.no_text_panels.unwrap_or(false));

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -54,6 +54,7 @@ paths:
         - { $ref: "#/components/parameters/strict" }
         - { $ref: "#/components/parameters/images" }
         - { $ref: "#/components/parameters/no_ocr" }
+        - { $ref: "#/components/parameters/skip_ocr" }
         - { $ref: "#/components/parameters/force_full_page_ocr" }
         - { $ref: "#/components/parameters/no_table_former" }
         - { $ref: "#/components/parameters/no_text_panels" }
@@ -352,6 +353,14 @@ components:
           default: false
           description: Cleaner strict Markdown dialect instead of byte-for-byte docling-legacy output.
         images: { $ref: "#/components/schemas/Images" }
+        skip_ocr:
+          type: boolean
+          default: false
+          description: >
+            PDF/image — keep layout detection and TableFormer but never run OCR
+            (docling's independent `do_ocr=False`, #244): structure survives,
+            text that exists only as pixels comes back empty. `no_ocr` (the
+            whole-stack skip) wins when both are set.
         no_ocr:
           type: boolean
           default: false
@@ -469,6 +478,8 @@ components:
       { name: images, in: query, schema: { $ref: "#/components/schemas/Images" } }
     no_ocr:
       { name: no_ocr, in: query, schema: { type: boolean } }
+    skip_ocr:
+      { name: skip_ocr, in: query, schema: { type: boolean } }
     force_full_page_ocr:
       { name: force_full_page_ocr, in: query, schema: { type: boolean } }
     no_table_former:

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -127,6 +127,7 @@ async fn serves_its_logo_and_openapi_description() {
         "strict:",
         "images:",
         "no_ocr:",
+        "skip_ocr:",
         "force_full_page_ocr:",
         "no_table_former:",
         "fetch_images:",

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -69,6 +69,45 @@ fn pdfium_ready() -> bool {
     std::env::var("PDFIUM_DYNAMIC_LIB_PATH").is_ok()
 }
 
+/// The layout/OCR/TableFormer model files, resolved from the repo-root
+/// `.models` into the env overrides (tests run with CWD = the crate dir, so
+/// CWD-relative resolution can't find them) — same pattern as
+/// `crates/docling/tests/pages.rs`.
+fn ml_models_ready() -> bool {
+    let m = repo_root().join(".models");
+    let layout = ["layout_heron_int8.onnx", "layout_heron.onnx"]
+        .iter()
+        .map(|f| m.join(f))
+        .find(|p| p.exists());
+    let rec = ["ocr_rec_en.onnx", "ocr_rec.onnx"]
+        .iter()
+        .map(|f| m.join(f))
+        .find(|p| p.exists());
+    let dict = ["en_dict.txt", "ppocr_keys_v1.txt"]
+        .iter()
+        .map(|f| m.join(f))
+        .find(|p| p.exists());
+    let tf = m.join("tableformer");
+    let dec = ["decoder_kv.onnx", "decoder_int8.onnx", "decoder.onnx"]
+        .iter()
+        .map(|f| tf.join(f))
+        .find(|p| p.exists());
+    match (layout, rec, dict, dec) {
+        (Some(l), Some(r), Some(di), Some(de))
+            if tf.join("encoder.onnx").exists() && tf.join("bbox.onnx").exists() =>
+        {
+            std::env::set_var("DOCLING_LAYOUT_ONNX", l);
+            std::env::set_var("DOCLING_OCR_REC_ONNX", r);
+            std::env::set_var("DOCLING_OCR_DICT", di);
+            std::env::set_var("DOCLING_TABLEFORMER_ENCODER", tf.join("encoder.onnx"));
+            std::env::set_var("DOCLING_TABLEFORMER_DECODER", de);
+            std::env::set_var("DOCLING_TABLEFORMER_BBOX", tf.join("bbox.onnx"));
+            true
+        }
+        _ => false,
+    }
+}
+
 #[tokio::test]
 async fn health_is_ok() {
     let response = app()
@@ -276,6 +315,41 @@ async fn rasterizes_pdf_pages_to_png() {
     let b64 = pages[0]["png_base64"].as_str().unwrap();
     let bytes = docling::base64::decode(b64).expect("valid base64");
     assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+}
+
+/// #246 end-to-end: a `no_ocr=true` request must not degrade the shared warm
+/// pipeline for later default requests. The table fixture makes the difference
+/// decisive — the full pipeline emits a Markdown table (pipes), the no-OCR
+/// text-layer path emits flat paragraphs. Needs pdfium + the layout/OCR/
+/// TableFormer models, so it gates like the rasterization test.
+#[tokio::test]
+async fn no_ocr_request_does_not_stick_to_the_warm_pipeline() {
+    if !pdfium_ready() || !ml_models_ready() {
+        eprintln!("skipping: pdfium or the ML models are not present");
+        return;
+    }
+    let pdf =
+        std::fs::read(repo_root().join("tests/data/pdf/sources/2305.03393v1-pg9.pdf")).unwrap();
+    let app = app();
+    let run = |no_ocr: &'static str, app: axum::Router| {
+        let (ct, body) = multipart("t.pdf", &pdf, &[("to", "md"), ("no_ocr", no_ocr)]);
+        async move {
+            let response = app.oneshot(convert_request(&ct, body, "")).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            body_string(response).await
+        }
+    };
+    let full1 = run("false", app.clone()).await;
+    assert!(full1.contains('|'), "full pipeline must emit the table");
+    let reduced = run("true", app.clone()).await;
+    assert!(!reduced.contains('|'), "no_ocr path has no TableFormer");
+    // The bug: this third request reused the degraded pipeline and returned
+    // the flat no_ocr output until the server restarted.
+    let full2 = run("false", app).await;
+    assert_eq!(
+        full1, full2,
+        "default request after no_ocr must fully recover"
+    );
 }
 
 #[tokio::test]

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -77,6 +77,7 @@ pub struct DocumentConverter {
     no_table_former: bool,
     no_text_panels: bool,
     no_ocr: bool,
+    skip_ocr: bool,
     force_full_page_ocr: bool,
     use_web_browser: bool,
     /// Named Whisper model preset for audio sources (docling's ASR model
@@ -142,6 +143,7 @@ impl Default for DocumentConverter {
             no_table_former: false,
             no_text_panels: false,
             no_ocr: false,
+            skip_ocr: false,
             force_full_page_ocr: false,
             use_web_browser: false,
             asr_model: None,
@@ -190,6 +192,21 @@ impl DocumentConverter {
     pub fn ocr_lang(mut self, lang: impl Into<String>) -> Self {
         self.ocr_lang = Some(lang.into());
         self
+    }
+
+    /// The configured ML pipeline for one conversion (models load per call —
+    /// callers that convert many files hold a warm [`docling_pdf::Pipeline`]
+    /// themselves). Grew out of docling-pdf's `convert_with_options` free
+    /// functions, whose fixed signatures couldn't take #244's `skip_ocr`.
+    #[cfg(feature = "pdf")]
+    fn ml_pipeline(&self) -> Result<docling_pdf::Pipeline, docling_pdf::PdfError> {
+        Ok(docling_pdf::Pipeline::new()?
+            .no_table_former(self.no_table_former)
+            .no_ocr(self.no_ocr)
+            .skip_ocr(self.skip_ocr)
+            .no_text_panels(self.no_text_panels)
+            .enrichments(self.enrich)
+            .ocr_lang(self.ocr_lang_choice()))
     }
 
     /// The parsed [`Self::ocr_lang`] choice for the ML call sites; a value
@@ -308,6 +325,23 @@ impl DocumentConverter {
     /// without this flag. Implies [`no_table_former`](Self::no_table_former).
     pub fn no_ocr(mut self, disable: bool) -> Self {
         self.no_ocr = disable;
+        self
+    }
+
+    /// Never run OCR, but keep layout detection and TableFormer — docling's
+    /// independent `do_ocr=False` (#244), the counterpart of
+    /// [`no_table_former`](Self::no_table_former). Unlike
+    /// [`no_ocr`](Self::no_ocr) (the skip-everything fast path), structured
+    /// output — headings, tables, pictures, reading order — is preserved; only
+    /// text that exists solely as pixels is lost (scanned pages come back with
+    /// empty regions, and the speculative OCR of large embedded images never
+    /// runs). The OCR model is never loaded, and independently of this flag a
+    /// *missing* OCR model now degrades to the same behavior with a warning
+    /// instead of failing the conversion. SVG inputs route to direct
+    /// `<text>` extraction (their text is native — skipping OCR must not lose
+    /// it), like `no_ocr`.
+    pub fn skip_ocr(mut self, disable: bool) -> Self {
+        self.skip_ocr = disable;
         self
     }
 
@@ -444,6 +478,7 @@ impl DocumentConverter {
             no_table_former: self.no_table_former,
             no_text_panels: self.no_text_panels,
             no_ocr: self.no_ocr,
+            skip_ocr: self.skip_ocr,
             force_full_page_ocr: self.force_full_page_ocr,
             enrich: self.enrich,
             page_range: self.page_range,
@@ -564,66 +599,47 @@ impl DocumentConverter {
                 doc
             }
             #[cfg(feature = "pdf")]
-            InputFormat::Pdf => docling_pdf::convert_with_options(
-                &source.bytes,
-                None,
-                &source.name,
-                self.no_table_former,
-                self.no_ocr,
-                self.force_full_page_ocr,
-                self.no_text_panels,
-                self.enrich,
-                self.page_range,
-                self.ocr_lang_choice(),
-            )
-            .map_err(|e| ConversionError::with_source("pdf", e))?,
+            InputFormat::Pdf => self
+                .ml_pipeline()
+                .map(|p| {
+                    p.force_full_page_ocr(self.force_full_page_ocr)
+                        .pages(self.page_range)
+                })
+                .and_then(|mut p| p.convert(&source.bytes, None, &source.name))
+                .map_err(|e| ConversionError::with_source("pdf", e))?,
             // SVG (#212), the ML route: rasterize (resvg, white-backed PNG at
             // ~2048px long side) and ride the image pipeline. `--no-ocr` short-
             // circuits to direct <text> extraction instead — the SVG carries
             // its text natively, so skipping OCR must not mean losing it.
             #[cfg(feature = "pdf")]
-            InputFormat::Svg if !self.no_ocr => {
+            InputFormat::Svg if !self.no_ocr && !self.skip_ocr => {
                 let png = crate::backend::svg::rasterize_png(&source.bytes)?;
-                docling_pdf::convert_image_with_options(
-                    &png,
-                    &source.name,
-                    self.no_table_former,
-                    false,
-                    self.no_text_panels,
-                    self.enrich,
-                    self.ocr_lang_choice(),
-                )
-                .map_err(|e| ConversionError::with_source("svg", e))?
+                self.ml_pipeline()
+                    .and_then(|mut p| p.convert_image(&png, &source.name))
+                    .map_err(|e| ConversionError::with_source("svg", e))?
             }
             // SVG without the ML pipeline (pdf-text / wasm builds) or with
-            // --no-ocr: pure-Rust <text> extraction, flat paragraphs in
-            // reading order (the pdf / pdf-text split, applied to SVG).
+            // --no-ocr / --skip-ocr: pure-Rust <text> extraction, flat
+            // paragraphs in reading order (the pdf / pdf-text split, applied
+            // to SVG) — the SVG carries its text natively, so skipping OCR
+            // must not mean losing it.
             InputFormat::Svg => crate::backend::SvgBackend.convert(&source)?,
             // Apple iWork (#213): pure-Rust IWA text extraction, all builds.
             InputFormat::Pages | InputFormat::Numbers | InputFormat::Keynote => {
                 crate::backend::IworkBackend.convert(&source)?
             }
             #[cfg(feature = "pdf")]
-            InputFormat::Image => docling_pdf::convert_image_with_options(
-                &source.bytes,
-                &source.name,
-                self.no_table_former,
-                self.no_ocr,
-                self.no_text_panels,
-                self.enrich,
-                self.ocr_lang_choice(),
-            )
-            .map_err(|e| ConversionError::with_source("image", e))?,
+            InputFormat::Image => self
+                .ml_pipeline()
+                .and_then(|mut p| p.convert_image(&source.bytes, &source.name))
+                .map_err(|e| ConversionError::with_source("image", e))?,
             #[cfg(feature = "pdf")]
-            InputFormat::MetsGbs => docling_pdf::convert_mets_gbs_with_options(
-                &source.bytes,
-                &source.name,
-                self.no_table_former,
-                self.no_ocr,
-                self.no_text_panels,
-                self.enrich,
-            )
-            .map_err(|e| ConversionError::with_source("mets-gbs", e))?,
+            InputFormat::MetsGbs => self
+                .ml_pipeline()
+                .and_then(|mut p| {
+                    docling_pdf::convert_mets_gbs_with_pipeline(&source.bytes, &source.name, &mut p)
+                })
+                .map_err(|e| ConversionError::with_source("mets-gbs", e))?,
             // Audio → Whisper ASR (symphonia decode + ONNX inference); each
             // transcribed segment becomes a `[time: start-end] text` paragraph.
             #[cfg(feature = "asr")]

--- a/crates/docling/src/stream.rs
+++ b/crates/docling/src/stream.rs
@@ -74,6 +74,7 @@ pub(crate) struct StreamSettings {
     pub no_table_former: bool,
     pub no_text_panels: bool,
     pub no_ocr: bool,
+    pub skip_ocr: bool,
     pub force_full_page_ocr: bool,
     pub enrich: docling_pdf::EnrichmentOptions,
     pub page_range: Option<(usize, usize)>,
@@ -142,6 +143,7 @@ fn run_pdf(
         p.no_table_former(settings.no_table_former)
             .no_text_panels(settings.no_text_panels)
             .no_ocr(settings.no_ocr)
+            .skip_ocr(settings.skip_ocr)
             .force_full_page_ocr(settings.force_full_page_ocr)
             .ocr_lang(settings.ocr_lang)
             .enrichments(settings.enrich)

--- a/crates/docling/tests/skip_ocr.rs
+++ b/crates/docling/tests/skip_ocr.rs
@@ -1,0 +1,124 @@
+//! #244: `skip_ocr` — layout + TableFormer without OCR (docling's independent
+//! `do_ocr=False`) — and the missing-OCR-model degradation.
+//!
+//! A **separate integration-test file on purpose**: these tests point
+//! `DOCLING_OCR_REC_ONNX` at a nonexistent path to prove the recognition
+//! model is never loaded (or degrades when it can't be), and env vars are
+//! process-global — `pages.rs` sets the same vars to *real* paths for its OCR
+//! tests. Each tests/ file is its own binary and process, so the sabotage
+//! can't race a sibling suite.
+
+use std::path::{Path, PathBuf};
+
+use docling::{DocumentConverter, SourceDocument};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn pdfium_ready() -> bool {
+    let lib = repo_root().join(".pdfium/lib");
+    if lib.join("libpdfium.so").exists()
+        || lib.join("libpdfium.dylib").exists()
+        || lib.join("pdfium.dll").exists()
+    {
+        std::env::set_var("PDFIUM_DYNAMIC_LIB_PATH", &lib);
+        return true;
+    }
+    std::env::var("PDFIUM_DYNAMIC_LIB_PATH").is_ok()
+}
+
+/// Layout (+ TableFormer) models, with the OCR recognition model deliberately
+/// pointed into the void — every test in this binary must work without it.
+fn layout_ready_ocr_sabotaged() -> bool {
+    let m = repo_root().join(".models");
+    let layout = ["layout_heron_int8.onnx", "layout_heron.onnx"]
+        .iter()
+        .map(|f| m.join(f))
+        .find(|p| p.exists());
+    let Some(layout) = layout else {
+        return false;
+    };
+    std::env::set_var("DOCLING_LAYOUT_ONNX", layout);
+    std::env::set_var(
+        "DOCLING_OCR_REC_ONNX",
+        m.join("definitely-not-a-model.onnx"),
+    );
+    let tf = m.join("tableformer");
+    let dec = ["decoder_kv.onnx", "decoder_int8.onnx", "decoder.onnx"]
+        .iter()
+        .map(|f| tf.join(f))
+        .find(|p| p.exists());
+    if let Some(dec) = dec {
+        if tf.join("encoder.onnx").exists() && tf.join("bbox.onnx").exists() {
+            std::env::set_var("DOCLING_TABLEFORMER_ENCODER", tf.join("encoder.onnx"));
+            std::env::set_var("DOCLING_TABLEFORMER_DECODER", dec);
+            std::env::set_var("DOCLING_TABLEFORMER_BBOX", tf.join("bbox.onnx"));
+        }
+    }
+    true
+}
+
+/// A digital page with a real table: `skip_ocr` must keep the layout + table
+/// structure that `no_ocr` throws away — with the OCR model unloadable, which
+/// also proves `skip_ocr` never touches it.
+#[test]
+fn skip_ocr_keeps_layout_and_tables() {
+    if !pdfium_ready() || !layout_ready_ocr_sabotaged() {
+        eprintln!("skipping: pdfium or the layout model is not present");
+        return;
+    }
+    let path = repo_root().join("tests/data/pdf/sources/2305.03393v1-pg9.pdf");
+    let src = SourceDocument::from_file(&path).expect("table fixture");
+    let doc = DocumentConverter::new()
+        .skip_ocr(true)
+        .convert(src)
+        .expect("skip_ocr conversion succeeds")
+        .document;
+    let md = doc.export_to_markdown();
+    // Structure survived: the fixture's table serializes as a Markdown grid
+    // (the no_ocr path yields flat paragraphs — no pipes).
+    assert!(
+        md.contains('|'),
+        "expected a Markdown table from layout + TableFormer, got:\n{md}"
+    );
+    // ...and its digital text layer still reads out.
+    assert!(!md.trim().is_empty());
+}
+
+/// A scanned page (no text layer) with `skip_ocr`: converts cleanly to a
+/// document whose regions are empty of text — not an error.
+#[test]
+fn skip_ocr_scanned_page_converts_empty() {
+    if !pdfium_ready() || !layout_ready_ocr_sabotaged() {
+        eprintln!("skipping: pdfium or the layout model is not present");
+        return;
+    }
+    let path = repo_root().join("tests/data/scanned/sources/ocr_test_raster.pdf");
+    let src = SourceDocument::from_file(&path).expect("scanned fixture");
+    let doc = DocumentConverter::new()
+        .skip_ocr(true)
+        .convert(src)
+        .expect("skip_ocr on a scanned page must not error")
+        .document;
+    // The page's only text exists as pixels; without OCR nothing reads out.
+    assert!(doc.export_to_markdown().trim().is_empty());
+}
+
+/// The degradation half of #244: OCR *wanted* (no flag) but the model is
+/// missing — the conversion warns and completes instead of erroring (the
+/// pre-#244 behavior surfaced as a 422 through docling-serve).
+#[test]
+fn missing_ocr_model_degrades_instead_of_erroring() {
+    if !pdfium_ready() || !layout_ready_ocr_sabotaged() {
+        eprintln!("skipping: pdfium or the layout model is not present");
+        return;
+    }
+    let path = repo_root().join("tests/data/scanned/sources/ocr_test_raster.pdf");
+    let src = SourceDocument::from_file(&path).expect("scanned fixture");
+    let doc = DocumentConverter::new()
+        .convert(src)
+        .expect("a missing OCR model must degrade, not fail the conversion")
+        .document;
+    assert!(doc.export_to_markdown().trim().is_empty());
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -378,6 +378,17 @@ These are deliberate or unavoidable divergences, not bugs.
     counterpart is `--to images` + `--scale`, writing `<stem>_page_NNNN.png`
     files (no cap — the pages land on the caller's own disk).
 
+11. **`do_ocr` and `do_table_structure` are independent** (#244), as in
+    docling: `skip_ocr` (`--skip-ocr`, serve/Node `skip_ocr`, Python
+    `do_ocr=False`) keeps layout detection and TableFormer but never loads or
+    runs OCR — pixel-only text comes back empty instead of erroring. The
+    Python binding's `do_ocr=False` previously skipped the whole ML stack
+    (layout and tables included), which docling's `do_ocr` never meant; that
+    fast path is now the docling.rs-only `text_layer_only=True` kwarg
+    (`--no-ocr` / `no_ocr` elsewhere). A missing OCR model also degrades to
+    the `skip_ocr` behavior with a one-time warning — docling errors there —
+    matching the repo-wide degradation-over-failure convention.
+
 ---
 
 ## 5. Not migrated / out of scope


### PR DESCRIPTION
…adation (#244)

docling's do_ocr and do_table_structure are independent pipeline options; docling.rs's no_ocr conflated them — disabling OCR threw away layout and tables too, and a deployment without the OCR model 422'd instead of degrading. Two changes, both requested in #244:

skip_ocr (docling's do_ocr=False, the counterpart of no_table_former): layout detection and TableFormer run as usual, OCR never loads or runs — structured output (headings, tables, pictures, reading order) survives, and only text that exists solely as pixels comes back empty: scanned pages yield their regions without text, the #225 orientation probe is skipped, and the speculative OCR of large embedded images (the ~5% bitmap-area pass) never fires. no_ocr keeps its meaning as the skip-everything fast path; skip_ocr wins over force_full_page_ocr, mirroring docling where forcing is a sub-option of do_ocr. SVG inputs route to direct <text> extraction like no_ocr — their text is native, skipping OCR must not lose it.

Missing-model degradation: the worker's OCR slot now records a failed load (Unloaded/Ready/Missing, the TfSlot pattern) and converts on with a one-time warning instead of failing — the repo-wide degradation-over-failure convention applied to OCR. The exception is force_full_page_ocr, where the text layer was deliberately discarded: degrading would silently emit an empty document, so a missing model stays a hard error there.

Plumbed through every surface: Pipeline::skip_ocr + DocumentConverter::skip_ocr (converter now builds its pipeline via one ml_pipeline() helper instead of docling-pdf's fixed-signature convert_with_options free functions — those stay for compatibility; METS gained convert_mets_gbs_with_pipeline and a public Pipeline::process_pages), the streaming path, CLI --skip-ocr, serve skip_ocr (query/multipart/JSON + warm-pipeline rebuild + playground checkbox + OpenAPI), Node skipOcr. The Python binding's do_ocr=False now matches docling exactly — it previously mapped to no_ocr and silently disabled layout and tables, which docling's do_ocr never meant; that fast path moved to the new text_layer_only=True kwarg (appended last, so positional callers are unaffected).

Tests live in their own integration binary (tests/skip_ocr.rs) so they can point DOCLING_OCR_REC_ONNX into the void without racing pages.rs's real-model env setup: table structure survives skip_ocr with the OCR model unloadable, a scanned page converts to empty instead of erroring, and a missing model degrades on the default path. All three run against real models where present and skip cleanly in CI.

Closes #244
Closes #246 



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT