### PR TITLE
fix(dclx): docling-core 2.88/2.89 serializer robustness — illegal chars, CDATA splits, heading clamp

### DIFF
--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -69,6 +69,27 @@ impl Out {
 
 /// Reverse the Markdown-oriented escaping backends bake into node text
 /// (`&amp;`/`&lt;`/`&gt;` and `\_`), recovering the raw text DocLang serializes:
+/// XML-1.0-illegal characters (C0 controls minus tab/LF/CR, U+FFFE/U+FFFF)
+/// replaced with a visible `[U+XXXX]` marker, docling-core#687's rendering.
+/// Surrogates cannot occur in a Rust `str`, so the Python pattern's surrogate
+/// range has no counterpart here. Borrows when nothing needs replacing (the
+/// overwhelmingly common case).
+fn sanitize_xml_illegal(text: &str) -> std::borrow::Cow<'_, str> {
+    let illegal = |c: char| matches!(c, '\u{00}'..='\u{08}' | '\u{0B}' | '\u{0C}' | '\u{0E}'..='\u{1F}' | '\u{FFFE}' | '\u{FFFF}');
+    if !text.contains(illegal) {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len() + 8);
+    for c in text.chars() {
+        if illegal(c) {
+            out.push_str(&format!("[U+{:04X}]", c as u32));
+        } else {
+            out.push(c);
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 /// `<`/`>`/`&` go into a CDATA section verbatim, `_` stays literal.
 fn unescape_stored(text: &str) -> Cow<'_, str> {
     if !text.contains('&') && !text.contains('\\') {
@@ -84,13 +105,20 @@ fn unescape_stored(text: &str) -> Cow<'_, str> {
 
 /// AUTO escape: any of `"' &<>` in the text → CDATA; leading/trailing
 /// whitespace or a newline → additionally wrapped in `<content>`.
+/// Robustness (docling-core 2.88/2.89 parity, #253): XML-1.0-illegal
+/// characters are replaced with a visible `[U+XXXX]` marker before anything
+/// else (docling-core#687 — a stray control byte must not make the archive
+/// unparseable), and a literal `]]>` inside the text splits across adjacent
+/// CDATA sections (docling-core#689 — a CDATA section cannot contain its own
+/// closing delimiter).
 fn escape_text(text: &str) -> String {
     let raw = unescape_stored(text);
-    let text = raw.as_ref();
+    let text = sanitize_xml_illegal(raw.as_ref());
+    let text = text.as_ref();
     let needs_cdata = text.contains(['"', '\'', '&', '<', '>']);
     let needs_content = text != text.trim() || text.contains('\n');
     let mut t = if needs_cdata {
-        format!("<![CDATA[{text}]]>")
+        format!("<![CDATA[{}]]>", text.replace("]]>", "]]]]><![CDATA[>"))
     } else {
         text.to_string()
     };
@@ -758,7 +786,9 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
                 let open = if *level <= 1 {
                     "heading".to_string()
                 } else {
-                    format!("heading level=\"{level}\"")
+                    // Clamp to the heading vocabulary (docling-core#688): deep
+                    // section headers serialize as level 6 instead of raising.
+                    format!("heading level=\"{}\"", (*level).min(6))
                 };
                 emit_text_element(out, depth, &open, "heading", text, None);
                 *i += 1;
@@ -1274,7 +1304,9 @@ fn emit_furniture(out: &mut Out, depth: i32, layer: ContentLayer, inner: &Node) 
             let open = if *level <= 1 {
                 "heading".to_string()
             } else {
-                format!("heading level=\"{level}\"")
+                // Clamp to the heading vocabulary (docling-core#688): deep
+                // section headers serialize as level 6 instead of raising.
+                format!("heading level=\"{}\"", (*level).min(6))
             };
             out.push(depth, format!("<{open}>"));
             out.push(depth + 1, token);
@@ -1459,7 +1491,9 @@ fn emit_located(out: &mut Out, depth: i32, location: &[u16; 4], inner: &Node) {
             let open = if *level <= 1 {
                 "heading".to_string()
             } else {
-                format!("heading level=\"{level}\"")
+                // Clamp to the heading vocabulary (docling-core#688): deep
+                // section headers serialize as level 6 instead of raising.
+                format!("heading level=\"{}\"", (*level).min(6))
             };
             emit_text_element(out, depth, &open, "heading", text, Some(location));
         }
@@ -1761,6 +1795,55 @@ fn emit_field_region(out: &mut Out, depth: i32, items: &[FieldItem]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// docling-core#687 (#253): XML-1.0-illegal characters render as visible
+    /// `[U+XXXX]` markers so the archive stays parseable; tab/LF/CR are legal
+    /// and pass through.
+    #[test]
+    fn xml_illegal_characters_become_visible_markers() {
+        let doclang = export_to_doclang(&[Node::Paragraph {
+            text: "Before break\u{0B}After\u{FFFF} tab\tok".into(),
+        }]);
+        assert!(
+            doclang.contains("Before break[U+000B]After[U+FFFF] tab\tok"),
+            "got:\n{doclang}"
+        );
+    }
+
+    /// docling-core#689 (#253): a literal `]]>` inside CDATA-escaped text
+    /// splits across adjacent CDATA sections, preserving the exact characters
+    /// instead of producing unparseable XML.
+    #[test]
+    fn cdata_closing_delimiter_splits_sections() {
+        let doclang = export_to_doclang(&[Node::Paragraph {
+            text: "a]]>b & c".into(),
+        }]);
+        assert!(
+            doclang.contains("<![CDATA[a]]]]><![CDATA[>b & c]]>"),
+            "got:\n{doclang}"
+        );
+    }
+
+    /// docling-core#688 (#253): heading levels past the vocabulary clamp to 6
+    /// instead of emitting an out-of-range token.
+    #[test]
+    fn deep_heading_levels_clamp_to_six() {
+        let doclang = export_to_doclang(&[
+            Node::Heading {
+                level: 6,
+                text: "Deep".into(),
+            },
+            Node::Heading {
+                level: 42,
+                text: "Deeper".into(),
+            },
+        ]);
+        assert!(doclang.contains("<heading level=\"6\">Deep</heading>"));
+        assert!(
+            doclang.contains("<heading level=\"6\">Deeper</heading>"),
+            "got:\n{doclang}"
+        );
+    }
 
     #[test]
     fn located_heading_emits_location_tokens_in_block_form() {

--- a/crates/docling/tests/dclx_roundtrip.rs
+++ b/crates/docling/tests/dclx_roundtrip.rs
@@ -1,0 +1,86 @@
+//! #253 (docling-core 2.88/2.89 parity): DCLX round-trip robustness. The
+//! writer-side fixes (XML-illegal markers, CDATA splitting, heading clamp)
+//! are unit-tested in docling-core; these tests pin the full write → read
+//! loop through the archive, including the reader behaviors docling fixed in
+//! docling-core#689/#695 — our single-pass roxmltree reader never re-parses
+//! text fragments as XML, so tag-shaped literals must survive as text.
+
+use docling::{DocumentConverter, SourceDocument};
+use docling_core::{DoclingDocument, Node, Table};
+
+fn roundtrip(doc: &DoclingDocument) -> DoclingDocument {
+    let bytes = docling::dclx::to_dclx_bytes(doc);
+    let src = SourceDocument::from_bytes("t", docling::InputFormat::Dclx, bytes);
+    DocumentConverter::new()
+        .convert(src)
+        .expect("dclx round-trip")
+        .document
+}
+
+/// A literal `]]>` in body text survives the CDATA-section split
+/// (docling-core#689's writer half) and reads back verbatim.
+#[test]
+fn cdata_delimiter_text_round_trips() {
+    let mut doc = DoclingDocument::new("t");
+    doc.push(Node::Paragraph {
+        text: "a]]>b & c <t>".into(),
+    });
+    let back = roundtrip(&doc);
+    assert_eq!(back.export_to_markdown(), doc.export_to_markdown());
+}
+
+/// Cell text that merely looks like DocLang/OTSL markup — docling-core#695's
+/// literal `<fcel>`, plus a `<location .../>`-shaped string — stays text
+/// through the archive instead of being interpreted as structure.
+#[test]
+fn tag_shaped_cell_text_round_trips() {
+    let mut doc = DoclingDocument::new("t");
+    doc.push(Node::Table(Table {
+        rows: vec![
+            vec!["h1".into(), "h2".into()],
+            vec!["<fcel>".into(), "<location value=\"3\"/> x".into()],
+        ],
+        location: None,
+        structure: None,
+        cell_blocks: None,
+        cells: None,
+        caption: None,
+    }));
+    let back = roundtrip(&doc);
+    let md = back.export_to_markdown();
+    assert!(md.contains("&lt;fcel&gt;") || md.contains("<fcel>"), "{md}");
+    assert_eq!(back.export_to_markdown(), doc.export_to_markdown());
+}
+
+/// XML-illegal control characters render as visible `[U+XXXX]` markers
+/// (docling-core#687) — and, crucially, the archive stays parseable: the
+/// round-trip must succeed rather than fail on invalid XML.
+#[test]
+fn xml_illegal_characters_round_trip_as_markers() {
+    let mut doc = DoclingDocument::new("t");
+    doc.push(Node::Paragraph {
+        text: "break\u{0B}here".into(),
+    });
+    let back = roundtrip(&doc);
+    assert!(
+        back.export_to_markdown().contains("break[U+000B]here"),
+        "{}",
+        back.export_to_markdown()
+    );
+}
+
+/// Deep headings clamp to level 6 (docling-core#688) and read back at 6.
+#[test]
+fn deep_headings_round_trip_clamped() {
+    let mut doc = DoclingDocument::new("t");
+    doc.push(Node::Heading {
+        level: 42,
+        text: "Deeper".into(),
+    });
+    let back = roundtrip(&doc);
+    assert!(
+        back.export_to_markdown().contains("###### Deeper"),
+        "{}",
+        back.export_to_markdown()
+    );
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -170,7 +170,14 @@ close — see `PDF_CONFORMANCE.md`. A deterministic snapshot baseline
 The `.dclx` DocLang output (§3) is scored against docling's own `.dclx` archives
 with `scripts/conformance/dclx_conformance.sh` — the extracted `document.xml`
 line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈94% mean over the
-136-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format:
+136-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format.
+Robustness tracks docling-core 2.88/2.89 (#253): XML-illegal control
+characters serialize as visible `[U+XXXX]` markers, a literal `]]>` splits
+across CDATA sections, and deep section headers clamp to heading level 6
+instead of emitting out-of-range tokens — all round-trip pinned; the reader
+side of docling-core#689/#695 (tag-shaped literals in OTSL cells) never
+applied here, since the single-pass roxmltree reader doesn't re-parse text
+fragments as XML.
 
 | Format | `.dclx` similarity | Format | `.dclx` similarity |
 |---|---|---|---|


### PR DESCRIPTION
Ports the DocLang edge-case fixes from the docling-core 2.88/2.89 window; each is the difference between an odd document and an unparseable (or panicking) archive:

- docling-core#687: XML-1.0-illegal characters (C0 controls minus tab/LF/CR, U+FFFE/U+FFFF) in document text serialize as visible [U+XXXX] markers, so one stray control byte can't make document.xml invalid. The Python pattern's surrogate range has no Rust counterpart — surrogates can't occur in a str.

- docling-core#689 (writer half): a literal ']]>' inside CDATA-escaped text splits across adjacent CDATA sections, preserving the exact characters instead of terminating the section early.

- docling-core#688: section headers deeper than the heading vocabulary clamp to level 6 — docling's own heading inference emits level-6 headings, which the +1 title shift used to push out of range; our Markdown serializer already clamped, the DocLang one now agrees at all three emission sites.

The reader halves of docling-core#689/#695 (entity re-escaping and tag-shaped literals in OTSL cells) turn out to need no port: docling's deserializer re-parsed stringified fragments as XML, our reader is a single roxmltree pass that never re-serializes — cell text that merely looks like '<fcel>' or '<location .../>' stays text. A new dclx_roundtrip integration suite pins all four behaviors through the full write → archive → read loop, and the regression corpus is untouched — the fixes are edge-case-only by construction.

Closes docling-project/docling.rs#253



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT