### PR TITLE
fix(serve,pdf): container-aware resource tuning — CPU quota budget, arena-off default, memory-ceiling admission control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,10 @@ cargo check -p docling --no-default-features --features pdf-text \
 - Resolution is CWD-relative with exe-dir fallback; env overrides:
   `PDFIUM_DYNAMIC_LIB_PATH`, `DOCLING_ASR_{ENCODER,DECODER,VOCAB}`,
   `DOCLING_FFMPEG` (video frames — ffmpeg is a runtime binary, never a build
-  dep), `DOCLING_RS_PDF_WORKERS/_THREADS/_INTRA`, `DOCLING_RS_FP32`,
+  dep), `DOCLING_RS_PDF_WORKERS/_THREADS/_INTRA`, `DOCLING_RS_TF_INTRA` (#262),
+  `DOCLING_RS_NO_ARENA` (#263; serve defaults it on),
+  `DOCLING_RS_MAX_MEMORY_MB` + `DOCLING_RS_MEMORY_WATERMARK_PCT` (serve
+  admission control), `DOCLING_RS_FP32`,
   `DOCLING_RS_EP` (GPU execution providers), `DOCLING_RS_ASR_LANG`,
   `DOCLING_RS_OCR_LANG` (en default; `ch` = the docling-conformance OCR
   model, which conformance scripts pin themselves),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "docling",
  "docling-core",
  "http-body-util",
+ "libc",
  "serde",
  "serde_json",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -196,7 +196,16 @@ Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placehol
 `ocr_lang`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
-`--allow-url-fetch`, `--no-url-fetch`, `--strict`. A container image
+`--allow-url-fetch`, `--no-url-fetch`, `--strict`, `--max-memory-mb` (#263:
+memory ceiling for admission control — explicit, or `DOCLING_RS_MAX_MEMORY_MB`,
+else the container's cgroup limit; once RSS crosses 85% of it — tunable via
+`DOCLING_RS_MEMORY_WATERMARK_PCT` — new conversions get 503 + Retry-After
+instead of OOM-killing the process; `0` disables). Thread pools are
+**cgroup-quota-aware** (#262; `DOCLING_RS_TF_INTRA` further narrows the shared
+TableFormer session — the reporter's 4-CPU case dropped ~40% peak memory), and
+the server defaults `DOCLING_RS_NO_ARENA=1`: with the ONNX CPU arena off plus
+heap trimming, warm retained RSS measured ~3× lower (2.0 GB → 0.7 GB) at no
+latency cost — set `DOCLING_RS_NO_ARENA=0` to restore the arena. A container image
 builds from [`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfile)
 (models + pdfium baked in, or mounted with `--build-arg FETCH_ASSETS=0`).
 URL inputs are **off by default** (SSRF surface): pass `--allow-url-fetch` to

--- a/crates/docling-asr/src/whisper.rs
+++ b/crates/docling-asr/src/whisper.rs
@@ -198,9 +198,8 @@ impl Transcriber {
             Session::builder()
                 .map_err(|e| format!("asr: builder: {e}"))?
                 .with_intra_threads(
-                    std::thread::available_parallelism()
-                        .map(|n| n.get())
-                        .unwrap_or(1),
+                    // Quota-aware (#262): a cgroup CPU limit clamps the pool.
+                    docling_core::env::cpu_budget(),
                 )
                 .map_err(|e| format!("asr: threads: {e}"))?
                 .commit_from_file(&path)

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -117,6 +117,16 @@ fn main() -> ExitCode {
     {
         let mut args = std::env::args().skip(1);
         if args.next().as_deref() == Some("serve") {
+            // #263: a long-lived server defaults the ONNX CPU arena OFF — measured
+            // here, a warm server's retained RSS drops ~3x (2.0 GB -> 0.7 GB after
+            // large-PDF requests) at no measurable latency cost, and stops ratcheting
+            // with every new page shape. Explicit DOCLING_RS_NO_ARENA=0 restores the
+            // arena. Set before any session loads; the process is single-threaded
+            // this early.
+            if std::env::var_os("DOCLING_RS_NO_ARENA").is_none() {
+                std::env::set_var("DOCLING_RS_NO_ARENA", "1");
+            }
+
             return run_serve(args.collect());
         }
     }
@@ -1122,6 +1132,12 @@ fn run_serve(args: Vec<String>) -> ExitCode {
             "--result-ttl" => match it.next().and_then(|v| v.parse().ok()) {
                 Some(v) if v >= 1 => cfg.result_ttl_secs = v,
                 _ => return serve_usage("--result-ttl needs a positive number of seconds"),
+            },
+            // #263: memory ceiling for admission control. 0 disables; unset =
+            // auto-detect the container's cgroup limit.
+            "--max-memory-mb" => match it.next().and_then(|v| v.parse().ok()) {
+                Some(v) => cfg.max_memory_mb = Some(v),
+                None => return serve_usage("--max-memory-mb needs a number (0 disables)"),
             },
             "--warmup" => cfg.warmup = true,
             "--allow-url-fetch" => cfg.allow_url_fetch = true,

--- a/crates/docling-core/src/env.rs
+++ b/crates/docling-core/src/env.rs
@@ -74,6 +74,103 @@ macro_rules! debug_log {
     };
 }
 
+/// The CPU budget thread-pool sizing should derive from: host parallelism
+/// clamped by the container's cgroup CPU quota (#262).
+/// `available_parallelism` is quota-aware on common setups, but container
+/// runtimes exist where it still reports the host cores (docling.rs#262's
+/// 8 threads under a 4-CPU limit), so the quota files are read directly as an
+/// extra clamp — a limited container must never size pools past its throttle
+/// ceiling. On non-Linux (and wasm) the quota reads simply fail and the host
+/// count stands.
+pub fn cpu_budget() -> usize {
+    let host = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    match cgroup_cpu_quota() {
+        Some(q) => host.min(q).max(1),
+        None => host,
+    }
+}
+
+/// CPUs allowed by the cgroup CPU quota, rounded up (a 2.5-CPU limit gets 3
+/// threads); `None` when unlimited or undeterminable. Reads cgroup v2
+/// (`cpu.max`) and cgroup v1 (`cpu.cfs_quota_us` / `cpu.cfs_period_us`).
+fn cgroup_cpu_quota() -> Option<usize> {
+    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/cpu.max") {
+        return parse_cpu_max(&s);
+    }
+    for dir in ["/sys/fs/cgroup/cpu", "/sys/fs/cgroup/cpu,cpuacct"] {
+        if let (Ok(quota), Ok(period)) = (
+            std::fs::read_to_string(format!("{dir}/cpu.cfs_quota_us")),
+            std::fs::read_to_string(format!("{dir}/cpu.cfs_period_us")),
+        ) {
+            return parse_cfs(&quota, &period);
+        }
+    }
+    None
+}
+
+/// cgroup v2 `cpu.max` ("max 100000" = unlimited, "400000 100000" = 4 CPUs).
+fn parse_cpu_max(s: &str) -> Option<usize> {
+    let mut it = s.split_whitespace();
+    let quota = it.next()?;
+    if quota == "max" {
+        return None;
+    }
+    let quota: u64 = quota.parse().ok()?;
+    let period: u64 = it.next()?.parse().ok()?;
+    if period == 0 || quota == 0 {
+        return None;
+    }
+    Some(quota.div_ceil(period) as usize)
+}
+
+/// cgroup v1 CFS quota/period (quota -1 = unlimited).
+fn parse_cfs(quota: &str, period: &str) -> Option<usize> {
+    let quota: i64 = quota.trim().parse().ok()?;
+    if quota <= 0 {
+        return None;
+    }
+    let period: i64 = period.trim().parse().ok()?;
+    if period <= 0 {
+        return None;
+    }
+    Some((quota as u64).div_ceil(period as u64) as usize)
+}
+
+/// The container's memory limit in MB from the cgroup files (v2 `memory.max`,
+/// v1 `memory.limit_in_bytes`), `None` when unlimited — both spell "no limit"
+/// as either the literal `max` or an enormous sentinel (>= 2^60 bytes).
+pub fn cgroup_memory_limit_mb() -> Option<u64> {
+    for path in [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ] {
+        if let Ok(s) = std::fs::read_to_string(path) {
+            let s = s.trim();
+            if s == "max" {
+                return None;
+            }
+            let bytes: u64 = s.parse().ok()?;
+            if bytes >= 1 << 60 {
+                return None;
+            }
+            return Some(bytes / (1024 * 1024));
+        }
+    }
+    None
+}
+
+/// This process's resident set size in MB (`/proc/self/status` `VmRSS`);
+/// `None` off Linux. The number admission control (#263) compares against the
+/// memory ceiling.
+pub fn rss_mb() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let line = status.lines().find(|l| l.starts_with("VmRSS:"))?;
+    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kb / 1024)
+}
+
 #[cfg(test)]
 mod tests {
     // Env mutation is process-global and the test harness is parallel, so
@@ -100,6 +197,27 @@ mod tests {
         std::env::set_var("DOCLING_TEST_NONEMPTY_BLANK", "   ");
         assert_eq!(nonempty("DOCLING_TEST_NONEMPTY_BLANK"), None);
         assert_eq!(nonempty("DOCLING_TEST_NONEMPTY_UNSET"), None);
+    }
+
+    #[test]
+    fn cpu_quota_parsers_cover_both_cgroup_versions() {
+        // v2: unlimited, exact, and fractional (rounds up).
+        assert_eq!(super::parse_cpu_max("max 100000\n"), None);
+        assert_eq!(super::parse_cpu_max("400000 100000"), Some(4));
+        assert_eq!(super::parse_cpu_max("250000 100000"), Some(3));
+        assert_eq!(super::parse_cpu_max("garbage"), None);
+        // v1: -1 = unlimited; fractional rounds up.
+        assert_eq!(super::parse_cfs("-1\n", "100000\n"), None);
+        assert_eq!(super::parse_cfs("400000", "100000"), Some(4));
+        assert_eq!(super::parse_cfs("150000", "100000"), Some(2));
+        assert_eq!(super::parse_cfs("x", "100000"), None);
+    }
+
+    #[test]
+    fn rss_reads_on_linux() {
+        // A running test process certainly has a nonzero RSS on Linux.
+        #[cfg(target_os = "linux")]
+        assert!(super::rss_mb().unwrap() > 0);
     }
 
     #[test]

--- a/crates/docling-pdf/src/ep.rs
+++ b/crates/docling-pdf/src/ep.rs
@@ -188,9 +188,34 @@ fn dispatches() -> Option<Vec<ExecutionProviderDispatch>> {
 /// Register the selected execution providers on a session builder. Called by
 /// every session in this crate; a no-op (and infallible) in the default
 /// CPU configuration.
+/// Session memory options (#263): with `DOCLING_RS_NO_ARENA` set, the CPU
+/// execution provider registers with its memory arena disabled
+/// (`DisableCpuMemArena`) and initializers stay out of arena allocations.
+/// ONNX Runtime's CPU arena grows a slab for every new tensor shape it sees
+/// — a PDF's pages all differ, so a warm server's arena ratchets up with the
+/// largest documents it ever served and never returns a byte; without it,
+/// activations free after each run (and `malloc_trim` hands them back to the
+/// OS) at a few percent inference cost. Off by default — batch CLI runs
+/// prefer the arena's speed. Called at the *end* of [`apply`], so an explicit
+/// GPU execution provider (registered first) keeps priority.
+fn memory_opts(builder: SessionBuilder) -> Result<SessionBuilder, String> {
+    if !docling_core::env::flag("DOCLING_RS_NO_ARENA") {
+        return Ok(builder);
+    }
+    use ort::ep::{cpu::CPU, ExecutionProvider as _};
+    let cpu = CPU::default().with_arena_allocator(false);
+    let mut builder = builder
+        .with_config_entry("session.use_device_allocator_for_initializers", "1")
+        .map_err(|e| format!("allocator config: {e}"))?;
+    cpu.register(&mut builder)
+        .map_err(|e| format!("cpu ep: {e}"))?;
+    Ok(builder)
+}
+
 pub fn apply(builder: SessionBuilder) -> Result<SessionBuilder, String> {
     let Some(eps) = dispatches() else {
-        return Ok(builder);
+        // No GPU EP selected: the CPU fallback still honors the arena knob.
+        return memory_opts(builder);
     };
     static LOGGED: OnceLock<()> = OnceLock::new();
     LOGGED.get_or_init(|| {
@@ -198,9 +223,11 @@ pub fn apply(builder: SessionBuilder) -> Result<SessionBuilder, String> {
             eprintln!("docling-pdf: execution providers: {eps:?}");
         }
     });
-    builder
+    let builder = builder
         .with_execution_providers(eps)
-        .map_err(|e| format!("execution provider registration: {e}"))
+        .map_err(|e| format!("execution provider registration: {e}"))?;
+    // After the GPU EPs, so they keep registration priority.
+    memory_opts(builder)
 }
 
 #[cfg(test)]

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -236,9 +236,22 @@ pub(crate) fn intra_threads() -> usize {
     if let Some(n) = env::parse::<usize>("DOCLING_RS_PDF_THREADS").filter(|&n| n > 0) {
         return n;
     }
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
+    env::cpu_budget()
+}
+
+#[cfg(feature = "ml")]
+/// TableFormer's intra-op width (#262): `DOCLING_RS_TF_INTRA` explicitly,
+/// else the shared [`intra_threads`] budget. The shared TF session used to
+/// take the raw host width on top of the already-sized worker pools —
+/// under a cgroup CPU limit that oversubscription showed up as constant
+/// throttling and ~66% higher peak memory (each intra thread carries its own
+/// arena slab); the reporter's 4-CPU/8-core case dropped from 2.2 GB to
+/// 1.3 GB peak by capping this pool.
+pub(crate) fn tf_intra() -> usize {
+    if let Some(n) = env::parse::<usize>("DOCLING_RS_TF_INTRA").filter(|&n| n > 0) {
+        return n;
+    }
+    intra_threads()
 }
 
 #[cfg(feature = "ml")]
@@ -1034,9 +1047,12 @@ impl Worker {
                 timing::timed("tableformer", || {
                     let mut guard = slot.lock().unwrap();
                     if matches!(*guard, TfSlot::Unloaded) {
-                        // Full intra-op width: tables serialise on this mutex, so
-                        // the one instance gets the whole thread budget.
-                        *guard = match tableformer::TableFormer::load_with(intra_threads()) {
+                        // Tables serialise on this mutex, so the one instance
+                        // gets the shared thread budget (quota-aware, #262) —
+                        // DOCLING_RS_TF_INTRA narrows it further where the
+                        // memory-per-thread tradeoff matters more than table
+                        // latency.
+                        *guard = match tableformer::TableFormer::load_with(tf_intra()) {
                             Some(tf) => TfSlot::Ready(tf),
                             None => TfSlot::Missing,
                         };

--- a/crates/docling-serve/Cargo.toml
+++ b/crates/docling-serve/Cargo.toml
@@ -25,6 +25,9 @@ coreml = ["docling/coreml"]
 axum = { version = "0.8", features = ["multipart"] }
 docling = { path = "../docling", version = "1.11.0" }
 docling-core = { path = "../docling-core", version = "1.11.0" }
+# malloc_trim after conversions (#263): glibc's allocator otherwise keeps
+# freed page-bitmap heap mapped forever, ratcheting a warm server's RSS.
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "signal"] }

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -72,6 +72,20 @@
 //! concurrently. A semaphore bounds total in-flight conversions
 //! (`--concurrency`); excess requests queue.
 //!
+//! Resource controls (#262/#263): thread pools size to the **cgroup-aware**
+//! CPU budget (a container's CPU quota clamps them; `DOCLING_RS_TF_INTRA`
+//! additionally narrows the shared TableFormer session). The server binary
+//! defaults `DOCLING_RS_NO_ARENA=1` — ONNX Runtime's CPU arena grows with
+//! every new page shape and never returns memory; without it (plus a
+//! `malloc_trim` after each conversion) a warm server's retained RSS measured
+//! ~3× lower and stopped ratcheting, at no observed latency cost. A memory
+//! **ceiling** (`--max-memory-mb` / `DOCLING_RS_MAX_MEMORY_MB`, else the
+//! container's cgroup limit; `0` disables) drives admission control: once
+//! process RSS crosses the watermark (85%, `DOCLING_RS_MEMORY_WATERMARK_PCT`)
+//! new conversions answer **503 + Retry-After** instead of being accepted and
+//! OOM-killing the whole server; `/v1/config` reports `max_memory_mb` and the
+//! live `rss_mb`.
+//!
 //! Security: URL fetching makes the server issue outbound requests (SSRF
 //! surface), so it is **off by default** — enable with `--allow-url-fetch`.
 //! Even when enabled, targets that resolve to a private/loopback/link-local
@@ -123,6 +137,13 @@ pub struct ServeConfig {
     /// How long a finished async job's result stays fetchable before it is
     /// evicted (idle results are the other thing holding memory).
     pub result_ttl_secs: u64,
+    /// Memory ceiling in MB for admission control (#263). `None` = detect the
+    /// container's cgroup limit at startup; `Some(0)` disables the ceiling.
+    /// Once the process RSS crosses the watermark (85% of the ceiling by
+    /// default; `DOCLING_RS_MEMORY_WATERMARK_PCT` overrides), new conversions
+    /// answer 503 instead of being accepted and OOM-killing the whole server
+    /// (exit 137 takes every in-flight request with it).
+    pub max_memory_mb: Option<u64>,
 }
 
 impl Default for ServeConfig {
@@ -136,6 +157,7 @@ impl Default for ServeConfig {
             strict: false,
             queue_size: 16,
             result_ttl_secs: 600,
+            max_memory_mb: None,
         }
     }
 }
@@ -150,16 +172,52 @@ struct AppState {
     /// Async conversion jobs (#182), keyed by task id.
     jobs: Mutex<std::collections::HashMap<String, Job>>,
     ready: AtomicBool,
+    /// The resolved memory ceiling (#263): the configured value, else the
+    /// container's cgroup limit, else none. `0` disables.
+    memory_ceiling_mb: Option<u64>,
     cfg: ServeConfig,
+}
+
+impl AppState {
+    /// Admission control (#263): `Some(refusal)` when the process RSS sits
+    /// above the watermark of the memory ceiling — the request should get a
+    /// 503 *now* rather than push the whole server into the kernel's OOM
+    /// killer. In-flight conversions keep running; the server recovers as
+    /// soon as memory is released (or, with the ONNX arena retaining it, as
+    /// soon as `DOCLING_RS_NO_ARENA` deployments free theirs).
+    fn overloaded(&self) -> Option<String> {
+        let ceiling = self.memory_ceiling_mb.filter(|&c| c > 0)?;
+        let rss = docling_core::env::rss_mb()?;
+        let pct = docling_core::env::parse::<u64>("DOCLING_RS_MEMORY_WATERMARK_PCT")
+            .filter(|p| (1..=100).contains(p))
+            .unwrap_or(85);
+        let watermark = ceiling * pct / 100;
+        (rss >= watermark).then(|| {
+            format!(
+                "server memory is at {rss} MB of the {ceiling} MB ceiling \
+                 (watermark {watermark} MB) — retry once in-flight conversions finish"
+            )
+        })
+    }
 }
 
 /// Build the router (exposed separately from [`serve`] for tests).
 pub fn router(cfg: ServeConfig) -> Router {
+    // Ceiling resolution (#263): explicit flag > DOCLING_RS_MAX_MEMORY_MB >
+    // the container's own cgroup limit > none. 0 anywhere disables.
+    let memory_ceiling_mb = cfg
+        .max_memory_mb
+        .or_else(|| docling_core::env::parse::<u64>("DOCLING_RS_MAX_MEMORY_MB"))
+        .or_else(docling_core::env::cgroup_memory_limit_mb);
+    if let Some(c) = memory_ceiling_mb.filter(|&c| c > 0) {
+        eprintln!("docling-serve: memory ceiling {c} MB (admission control, #263)");
+    }
     let state = Arc::new(AppState {
         pipeline: Mutex::new(None),
         permits: Arc::new(Semaphore::new(cfg.concurrency.max(1))),
         jobs: Mutex::new(std::collections::HashMap::new()),
         ready: AtomicBool::new(!cfg.warmup),
+        memory_ceiling_mb,
         cfg: cfg.clone(),
     });
     if cfg.warmup {
@@ -267,6 +325,10 @@ async fn shutdown_signal() {
 async fn config(State(state): State<Arc<AppState>>) -> Response {
     Json(json!({
         "allow_url_fetch": state.cfg.allow_url_fetch,
+        // #263: the resolved memory ceiling (0/absent = none) and live RSS —
+        // what admission control compares.
+        "max_memory_mb": state.memory_ceiling_mb,
+        "rss_mb": docling_core::env::rss_mb(),
         // Which model file each pipeline stage would load right now (resolved
         // per request — CWD-relative with env overrides, so this is the truth,
         // not a startup snapshot). "Two servers convert the same PDF
@@ -374,6 +436,8 @@ enum ApiError {
     Internal(String),
     /// The async job queue is full (#182) — retry later.
     Busy(String),
+    /// The memory ceiling's watermark is crossed (#263) — 503, retry later.
+    Overloaded(String),
 }
 
 /// The HTTP status + message an [`ApiError`] answers with (also stored on a
@@ -384,13 +448,22 @@ fn api_error_parts(e: ApiError) -> (StatusCode, String) {
         ApiError::Unsupported(m) => (StatusCode::UNPROCESSABLE_ENTITY, m),
         ApiError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
         ApiError::Busy(m) => (StatusCode::TOO_MANY_REQUESTS, m),
+        ApiError::Overloaded(m) => (StatusCode::SERVICE_UNAVAILABLE, m),
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        let overloaded = matches!(self, ApiError::Overloaded(_));
         let (status, msg) = api_error_parts(self);
-        (status, Json(json!({"error": msg}))).into_response()
+        let mut response = (status, Json(json!({"error": msg}))).into_response();
+        if overloaded {
+            // A hint for well-behaved clients; conversions run seconds, not ms.
+            response
+                .headers_mut()
+                .insert("retry-after", header::HeaderValue::from_static("5"));
+        }
+        response
     }
 }
 
@@ -479,6 +552,10 @@ async fn convert(
 ) -> Result<Response, ApiError> {
     let (sources, options) = parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    // Admission control (#263): shed load before taking a conversion slot.
+    if let Some(msg) = state.overloaded() {
+        return Err(ApiError::Overloaded(msg));
+    }
 
     // Bound total in-flight conversions; excess requests queue here. The
     // permit is owned so the streaming path can hold it until the response
@@ -504,7 +581,9 @@ async fn convert(
 
     let st = state.clone();
     let stored = tokio::task::spawn_blocking(move || {
-        run_conversion(&st, sources, &options, &to, image_mode)
+        let out = run_conversion(&st, sources, &options, &to, image_mode);
+        trim_heap();
+        out
     })
     .await
     .map_err(|e| ApiError::Internal(format!("convert task: {e}")))?;
@@ -575,6 +654,11 @@ async fn convert_async(
 ) -> Result<Response, ApiError> {
     let (mut sources, options) = parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    // Admission control (#263) applies to async submissions too — a queued
+    // job holds its upload bytes and will run into the same ceiling.
+    if let Some(msg) = state.overloaded() {
+        return Err(ApiError::Overloaded(msg));
+    }
     // A single unconvertible upload fails the submission itself (a batch
     // converts around bad items) — same surface as the sync endpoint, and no
     // doomed job occupies the queue.
@@ -622,7 +706,9 @@ async fn convert_async(
         let stx = st.clone();
         let opts = options;
         let outcome = tokio::task::spawn_blocking(move || {
-            run_conversion(&stx, sources, &opts, &to, image_mode)
+            let out = run_conversion(&stx, sources, &opts, &to, image_mode);
+            trim_heap();
+            out
         })
         .await
         .map_err(|e| ApiError::Internal(format!("convert task: {e}")))
@@ -816,6 +902,21 @@ fn run_conversion(
         body: serde_json::to_vec_pretty(&json!({ "results": items }))
             .expect("batch JSON serializes"),
     })
+}
+
+/// Return freed heap to the OS after a conversion (#263). A PDF conversion
+/// churns hundreds of MB of page bitmaps through glibc's allocator, which
+/// keeps the freed arenas mapped — measured here, a warm server sat at
+/// ~2 GB RSS after one big conversion with the actual live data a fraction
+/// of that. `malloc_trim` walks the arenas and gives the free pages back;
+/// admission control (and the operator's dashboards) then see the truth.
+/// glibc-Linux only — a no-op elsewhere (musl/mac allocators don't have the
+/// retention pattern to the same degree, and no trim call to offer).
+fn trim_heap() {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    unsafe {
+        libc::malloc_trim(0);
+    }
 }
 
 /// Server-side cap on pages rasterized per `to=images` request (#243). A small
@@ -1494,6 +1595,14 @@ async fn stream_markdown(
     tokio::task::spawn_blocking(move || {
         // Held until this worker (and thus the response body) is done.
         let _permit = permit;
+        // Freed page bitmaps go back to the OS when this worker finishes.
+        struct TrimOnDrop;
+        impl Drop for TrimOnDrop {
+            fn drop(&mut self) {
+                trim_heap();
+            }
+        }
+        let _trim = TrimOnDrop;
         let send = |item: Result<Chunk, String>| {
             // The receiver disappearing means the client went away — stop.
             tx.blocking_send(item).is_ok()

--- a/crates/docling-serve/src/main.rs
+++ b/crates/docling-serve/src/main.rs
@@ -1,7 +1,7 @@
 //! `docling-serve` — standalone binary for the HTTP conversion API.
 //!
 //! Usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N]
-//!                      [--queue-size N] [--result-ttl SECS]
+//!                      [--queue-size N] [--result-ttl SECS] [--max-memory-mb N]
 //!                      [--warmup] [--allow-url-fetch] [--strict]
 //!
 //!   --addr HOST:PORT  bind address (default: 127.0.0.1:5001). Bind 0.0.0.0
@@ -27,6 +27,16 @@ use std::process::ExitCode;
 use docling_serve::{serve, ServeConfig};
 
 fn main() -> ExitCode {
+    // #263: a long-lived server defaults the ONNX CPU arena OFF — measured
+    // here, a warm server's retained RSS drops ~3x (2.0 GB -> 0.7 GB after
+    // large-PDF requests) at no measurable latency cost, and stops ratcheting
+    // with every new page shape. Explicit DOCLING_RS_NO_ARENA=0 restores the
+    // arena. Set before any session loads; the process is single-threaded
+    // this early.
+    if std::env::var_os("DOCLING_RS_NO_ARENA").is_none() {
+        std::env::set_var("DOCLING_RS_NO_ARENA", "1");
+    }
+
     let mut cfg = ServeConfig::default();
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -50,6 +60,12 @@ fn main() -> ExitCode {
             "--result-ttl" => match args.next().and_then(|v| v.parse().ok()) {
                 Some(v) if v >= 1 => cfg.result_ttl_secs = v,
                 _ => return usage("--result-ttl needs a positive number of seconds"),
+            },
+            // #263: memory ceiling for admission control. 0 disables; unset =
+            // auto-detect the container's cgroup limit.
+            "--max-memory-mb" => match args.next().and_then(|v| v.parse().ok()) {
+                Some(v) => cfg.max_memory_mb = Some(v),
+                None => return usage("--max-memory-mb needs a number (0 disables)"),
             },
             "--warmup" => cfg.warmup = true,
             "--allow-url-fetch" => cfg.allow_url_fetch = true,
@@ -83,7 +99,7 @@ fn usage(err: &str) -> ExitCode {
         eprintln!("error: {err}");
     }
     eprintln!(
-        "usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--queue-size N] [--result-ttl SECS] [--warmup] [--allow-url-fetch] [--strict]"
+        "usage: docling-serve [--addr HOST:PORT] [--concurrency N] [--max-body-mb N] [--queue-size N] [--result-ttl SECS] [--max-memory-mb N] [--warmup] [--allow-url-fetch] [--strict]"
     );
     if err.is_empty() {
         ExitCode::SUCCESS

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -354,6 +354,63 @@ async fn no_ocr_request_does_not_stick_to_the_warm_pipeline() {
     );
 }
 
+/// #263: with the RSS already past the watermark of a tiny ceiling, both
+/// endpoints shed the request with 503 + Retry-After instead of accepting
+/// work that would push the process into the OOM killer. (The test process's
+/// real RSS is far above a 1 MB ceiling on any platform where rss_mb()
+/// reads, so no mocking is needed; off-Linux the check is inert and the
+/// request converts — skip there.)
+#[tokio::test]
+async fn memory_ceiling_sheds_requests_with_503() {
+    if docling_core::env::rss_mb().is_none() {
+        eprintln!("skipping: no RSS reading on this platform");
+        return;
+    }
+    let cfg = ServeConfig {
+        max_memory_mb: Some(1),
+        ..ServeConfig::default()
+    };
+    let app = router(cfg);
+    let (ct, body) = multipart("x.md", b"# hi", &[]);
+    let response = app
+        .clone()
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.headers()["retry-after"], "5");
+    assert!(body_string(response).await.contains("ceiling"));
+    // Async submissions are shed the same way.
+    let (ct, body) = multipart("x.md", b"# hi", &[]);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/convert/async")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// A ceiling of 0 (explicitly disabled) admits everything.
+#[tokio::test]
+async fn memory_ceiling_zero_disables_admission_control() {
+    let cfg = ServeConfig {
+        max_memory_mb: Some(0),
+        ..ServeConfig::default()
+    };
+    let (ct, body) = multipart("note.md", b"# T", &[]);
+    let response = router(cfg)
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn url_fetch_can_be_disabled() {
     let cfg = ServeConfig {


### PR DESCRIPTION
Two production reports from constrained deployments, one PR.

#262 — thread pools vs cgroup CPU limits. Every pool now sizes from a cgroup-aware budget (docling_core::env::cpu_budget): host parallelism clamped by the container quota, read straight from cpu.max (v2) and cfs_quota_us/period_us (v1) as a belt-and-braces clamp for runtimes where available_parallelism still reports the host cores — the issue's 8 threads under a 4-CPU limit. The shared TableFormer session, which used to take the raw host width on top of the already-sized worker pools (the oversubscription behind 128 throttled periods and ~66% higher peak memory in the report), now takes the shared budget, and DOCLING_RS_TF_INTRA narrows it further for memory-first deployments (the reporter's 2-thread config: 2.2 GB -> 1.3 GB peak). The ASR session sizes from the same budget. Quota parsers are unit-tested; arena on/off output is bit-identical on the PDF corpus, and the unconstrained-host default budget is unchanged, so snapshots hold.

#263 — memory ceiling + the arena ratchet. Measured on this 8-core box with redp5110_sampled.pdf: a warm server retained ~2.0 GB RSS after one conversion and kept GROWING per request — ONNX Runtime's CPU arena grows a slab for every new tensor shape (every PDF page differs) and never returns a byte, and glibc keeps freed bitmap heap mapped on top. Two levers, both measured:
- DOCLING_RS_NO_ARENA registers the CPU EP with DisableCpuMemArena (+ initializers off-arena) at the end of ep::apply, so explicit GPU EPs keep priority. The serve binaries default it ON (explicit =0 restores): retained RSS 2031 MB and climbing -> ~700 MB and flat across large-PDF requests, at no measurable warm latency cost (33.5s vs 33.3s). Library and CLI batch use keep the arena.
- malloc_trim(0) after every conversion (sync, streaming, async; glibc-Linux only) returns the freed page-bitmap heap.

Admission control: --max-memory-mb / DOCLING_RS_MAX_MEMORY_MB, else the container's own cgroup memory limit (v2 memory.max, v1 limit_in_bytes; 0 disables). Once process RSS (VmRSS) crosses the watermark — 85%, DOCLING_RS_MEMORY_WATERMARK_PCT overrides — sync and async submissions answer 503 + Retry-After with a message naming the numbers, instead of being accepted and OOM-killing the whole server (exit 137 takes every in-flight request with it). In-flight work finishes; /v1/config reports max_memory_mb and live rss_mb, which is also how the retention measurements above were taken. Router tests pin the 503 path, the Retry-After header, async shedding, and 0-disables.

Closes docling-project/docling.rs#262
Closes docling-project/docling.rs#263



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT