### PR TITLE
feat(ocr): OCR mode + render scale options across every surface (docl…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ cargo check -p docling --no-default-features --features pdf-text \
   `DOCLING_RS_EP` (GPU execution providers), `DOCLING_RS_ASR_LANG`,
   `DOCLING_RS_OCR_LANG` (en default; `ch` = the docling-conformance OCR
   model, which conformance scripts pin themselves),
+  `DOCLING_RS_OCR_MODE` (#254; docling's `OcrMode` —
+  `full_page`/`layout_regions` force-discard the text layer),
+  `DOCLING_RS_OCR_SCALE` (#254; OCR input px/pt — resampled from the 2.0
+  render; docling's default is 3),
   `DOCLING_RS_OCR_ORIENTATION` (auto default; `off` disables content-based
   un-rotation of raster-rotated scans, #225), `DOCLING_CHUNK_TOKENIZER`,
   `DOCLING_RS_DEBUG` (re-enables quiet pipeline diagnostics, e.g. the

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ honoring `pages=A-B` and a `scale` of 0.1–4.0 pixels per PDF point (default
 
 Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placeholder|embedded`,
 `no_ocr`, `skip_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
-`ocr_lang`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
+`ocr_lang`, `ocr_mode`, `ocr_scale`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
 `--allow-url-fetch`, `--no-url-fetch`, `--strict`, `--max-memory-mb` (#263:
@@ -552,6 +552,26 @@ generated with the multilingual `ch_` model — if you're comparing output
 against Python docling byte-for-byte, run with `--ocr-lang ch`
 (`DOCLING_RS_OCR_LANG=ch`). On ordinary scans `en` reads better; on the
 conformance fixtures `ch` matches the groundtruth exactly.
+
+Two more OCR knobs mirror docling 2.116+ options (#254), on every surface
+(CLI flag, `DocumentConverter`/`Pipeline` builder, serve option, Python
+kwarg, Node option):
+
+- `--ocr-mode default|full_page|layout_regions|pdf_aware_layout_regions`
+  (`DOCLING_RS_OCR_MODE`) — docling's `OcrMode`, i.e. which regions feed the
+  OCR. The default (= `pdf_aware_layout_regions`) is the text-layer-aware
+  behavior this pipeline has always had; `full_page` and `layout_regions`
+  both discard the embedded text layer, exactly like `--force-full-page-ocr`
+  (the upstream distinction between them — whole-page vs per-region
+  *detector* input — has no analogue here, since the PP-OCR recognizer
+  always reads per-region line crops).
+- `--ocr-scale X` (`DOCLING_RS_OCR_SCALE`) — docling's `OcrOptions.scale`:
+  the resolution OCR reads, in pixels per PDF point. Unset, OCR reads the
+  pipeline's own 2.0 px/pt (144 dpi) page render — the pinned conformance
+  baseline; a different value resamples that render for the OCR input only
+  (layout and TableFormer pixels are untouched). docling's default is 3
+  (216 dpi); lower it when the source raster is already high-resolution and
+  upscaling degrades recognition.
 Turn it on for image-extraction workflows over scanned documents whose
 uncaptioned figures carry enough label text to look panel-like. Available on
 every surface: `no_text_panels(bool)` on the library builder, a

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -7,7 +7,7 @@
 //! (docling's independent `do_ocr=False`); `--no-ocr` remains the
 //! skip-everything fast path.
 //!
-//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
 //!                      shell doesn't expand it) instead of one positional file.
@@ -154,6 +154,8 @@ fn main() -> ExitCode {
     let mut pages: Option<(usize, usize)> = None;
     let mut scale: f32 = 2.0;
     let mut ocr_lang: Option<String> = None;
+    let mut ocr_mode: Option<String> = None;
+    let mut ocr_scale: Option<f32> = None;
     let mut pipeline: Option<String> = None;
     let mut vlm_endpoint: Option<String> = None;
     let mut vlm_model: Option<String> = None;
@@ -260,6 +262,45 @@ fn main() -> ExitCode {
                 }
                 None => {
                     eprintln!("error: --ocr-lang needs a value (en|ch)");
+                    return ExitCode::from(2);
+                }
+            },
+            // Which regions feed the OCR (docling's OcrMode, #254):
+            // full_page/layout_regions discard the text layer like
+            // --force-full-page-ocr; pdf_aware_layout_regions (= default) is
+            // the standard text-layer-aware behavior.
+            "--ocr-mode" => match args.next() {
+                Some(v)
+                    if matches!(
+                        v.trim(),
+                        "default" | "full_page" | "layout_regions" | "pdf_aware_layout_regions"
+                    ) =>
+                {
+                    ocr_mode = Some(v)
+                }
+                Some(v) => {
+                    eprintln!(
+                        "error: --ocr-mode {v:?} is not \
+                         default|full_page|layout_regions|pdf_aware_layout_regions"
+                    );
+                    return ExitCode::from(2);
+                }
+                None => {
+                    eprintln!("error: --ocr-mode needs a value");
+                    return ExitCode::from(2);
+                }
+            },
+            // OCR render scale in px per PDF point (docling's
+            // OcrOptions.scale, #254): unset reads the pipeline's own 2.0
+            // px/pt render; docling's default is 3 (216 dpi).
+            "--ocr-scale" => match args.next().map(|v| v.trim().parse::<f32>()) {
+                Some(Ok(s)) if s > 0.0 && s.is_finite() => ocr_scale = Some(s),
+                Some(_) => {
+                    eprintln!("error: --ocr-scale needs a positive number");
+                    return ExitCode::from(2);
+                }
+                None => {
+                    eprintln!("error: --ocr-scale needs a value");
                     return ExitCode::from(2);
                 }
             },
@@ -388,6 +429,8 @@ fn main() -> ExitCode {
             video_frames,
             pages,
             ocr_lang,
+            ocr_mode,
+            ocr_scale,
             scale,
             vlm,
         };
@@ -395,7 +438,7 @@ fn main() -> ExitCode {
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--use-web-browser] <input-file>");
+        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--use-web-browser] <input-file>");
         return ExitCode::from(2);
     };
 
@@ -502,6 +545,12 @@ fn main() -> ExitCode {
     }
     if let Some(lang) = &ocr_lang {
         converter = converter.ocr_lang(lang.clone());
+    }
+    if let Some(mode) = &ocr_mode {
+        converter = converter.ocr_mode(mode.clone());
+    }
+    if let Some(s) = ocr_scale {
+        converter = converter.ocr_scale(s);
     }
 
     // Stream Markdown by default: print each chunk as the converter produces it
@@ -643,6 +692,10 @@ struct BatchCfg {
     video_frames: Option<usize>,
     pages: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    /// Which regions feed the OCR (docling's `OcrMode`, #254).
+    ocr_mode: Option<String>,
+    /// OCR render scale in px/pt (docling's `OcrOptions.scale`, #254).
+    ocr_scale: Option<f32>,
     /// `--to images` render scale (pixels per PDF point, #243).
     scale: f32,
     vlm: Option<docling::vlm::VlmOptions>,
@@ -763,6 +816,12 @@ fn batch_converter(cfg: &BatchCfg) -> DocumentConverter {
     if let Some(lang) = &cfg.ocr_lang {
         converter = converter.ocr_lang(lang.clone());
     }
+    if let Some(mode) = &cfg.ocr_mode {
+        converter = converter.ocr_mode(mode.clone());
+    }
+    if let Some(s) = cfg.ocr_scale {
+        converter = converter.ocr_scale(s);
+    }
     converter
 }
 
@@ -782,6 +841,8 @@ fn batch_pipeline<'a>(
             .skip_ocr(cfg.skip_ocr)
             .force_full_page_ocr(cfg.force_full_page_ocr)
             .no_text_panels(cfg.no_text_panels)
+            .ocr_mode(cfg.ocr_mode.as_deref().and_then(docling::OcrMode::parse))
+            .ocr_scale(cfg.ocr_scale)
             .enrichments(docling::EnrichmentOptions {
                 picture_classification: cfg.enrich_picture_classes,
                 code: cfg.enrich_code,

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -47,6 +47,15 @@ pub struct ConverterOptions {
     /// proper Latin word spacing) or `"ch"` (the multilingual
     /// docling-conformance model). Formats that never OCR ignore it.
     pub ocr_lang: Option<String>,
+    /// Which regions feed the OCR (docling's `OcrMode`, #254): `"default"` |
+    /// `"full_page"` | `"layout_regions"` | `"pdf_aware_layout_regions"`.
+    /// `full_page`/`layout_regions` discard the text layer like
+    /// `forceFullPageOcr`.
+    pub ocr_mode: Option<String>,
+    /// OCR render scale in px per PDF point (docling's `OcrOptions.scale`,
+    /// #254); unset reads the pipeline's own 2.0 px/pt render (docling's
+    /// default is 3 = 216 dpi).
+    pub ocr_scale: Option<f64>,
     /// Email (.eml/.msg): append an Attachments section — names and content
     /// types only, never the payload (#251). Default `false`.
     pub list_attachments: Option<bool>,
@@ -111,6 +120,12 @@ pub struct ConvertOptions {
     pub pages: Option<String>,
     /// OCR recognition language for scanned pages: `"en"` (default) | `"ch"`.
     pub ocr_lang: Option<String>,
+    /// Which regions feed the OCR (docling's `OcrMode`, #254): `"default"` |
+    /// `"full_page"` | `"layout_regions"` | `"pdf_aware_layout_regions"`.
+    pub ocr_mode: Option<String>,
+    /// OCR render scale in px per PDF point (docling's `OcrOptions.scale`,
+    /// #254); unset reads the pipeline's own 2.0 px/pt render.
+    pub ocr_scale: Option<f64>,
     /// Email (.eml/.msg): append an Attachments section — names and content
     /// types only, never the payload (#251). Default `false`.
     pub list_attachments: Option<bool>,
@@ -185,6 +200,8 @@ struct ConvertConfig {
     video_frames: Option<usize>,
     page_range: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    ocr_mode: Option<String>,
+    ocr_scale: Option<f32>,
     list_attachments: bool,
     ebcdic_layout: Option<String>,
     skip_ocr: bool,
@@ -250,6 +267,8 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         video_frames: o.video_frames.map(|n| n as usize),
         page_range: parse_pages(o.pages.as_deref())?,
         ocr_lang: parse_ocr_lang(o.ocr_lang)?,
+        ocr_mode: parse_ocr_mode(o.ocr_mode)?,
+        ocr_scale: parse_ocr_scale(o.ocr_scale)?,
         list_attachments: o.list_attachments.unwrap_or(false),
         ebcdic_layout: o.ebcdic_layout,
         skip_ocr: o.skip_ocr.unwrap_or(false),
@@ -267,6 +286,28 @@ fn parse_ocr_lang(s: Option<String>) -> Result<Option<String>> {
     match s {
         Some(v) if docling::OcrLang::parse(&v).is_some() => Ok(Some(v)),
         Some(v) => Err(Error::from_reason(format!("ocrLang {v:?} is not en|ch"))),
+        None => Ok(None),
+    }
+}
+
+/// Validate an `ocrMode` option (#254); an unknown id is an error.
+fn parse_ocr_mode(s: Option<String>) -> Result<Option<String>> {
+    match s {
+        Some(v) if docling::OcrMode::parse(&v).is_some() => Ok(Some(v)),
+        Some(v) => Err(Error::from_reason(format!(
+            "ocrMode {v:?} is not default|full_page|layout_regions|pdf_aware_layout_regions"
+        ))),
+        None => Ok(None),
+    }
+}
+
+/// Validate an `ocrScale` option (#254); non-positive values are an error.
+fn parse_ocr_scale(s: Option<f64>) -> Result<Option<f32>> {
+    match s {
+        Some(v) if v.is_finite() && v > 0.0 => Ok(Some(v as f32)),
+        Some(v) => Err(Error::from_reason(format!(
+            "ocrScale must be a positive number, got {v}"
+        ))),
         None => Ok(None),
     }
 }
@@ -300,8 +341,16 @@ fn build_converter(cfg: &ConvertConfig) -> RsConverter {
         Some((first, last)) => base.page_range(first, last),
         None => base,
     };
-    match &cfg.ocr_lang {
+    let base = match &cfg.ocr_lang {
         Some(lang) => base.ocr_lang(lang.clone()),
+        None => base,
+    };
+    let base = match &cfg.ocr_mode {
+        Some(mode) => base.ocr_mode(mode.clone()),
+        None => base,
+    };
+    match cfg.ocr_scale {
+        Some(s) => base.ocr_scale(s),
         None => base,
     }
 }
@@ -477,6 +526,8 @@ pub struct DocumentConverter {
     video_frames: Option<usize>,
     page_range: Option<(usize, usize)>,
     ocr_lang: Option<String>,
+    ocr_mode: Option<String>,
+    ocr_scale: Option<f32>,
     list_attachments: bool,
     ebcdic_layout: Option<String>,
     skip_ocr: bool,
@@ -506,6 +557,8 @@ impl DocumentConverter {
             video_frames: o.video_frames.map(|n| n as usize),
             page_range: parse_pages(o.pages.as_deref())?,
             ocr_lang: parse_ocr_lang(o.ocr_lang.clone())?,
+            ocr_mode: parse_ocr_mode(o.ocr_mode.clone())?,
+            ocr_scale: parse_ocr_scale(o.ocr_scale)?,
             list_attachments: o.list_attachments.unwrap_or(false),
             ebcdic_layout: o.ebcdic_layout.clone(),
             skip_ocr: o.skip_ocr.unwrap_or(false),
@@ -525,6 +578,8 @@ impl DocumentConverter {
             video_frames: self.video_frames,
             page_range: self.page_range,
             ocr_lang: self.ocr_lang.clone(),
+            ocr_mode: self.ocr_mode.clone(),
+            ocr_scale: self.ocr_scale,
             list_attachments: self.list_attachments,
             ebcdic_layout: self.ebcdic_layout.clone(),
             skip_ocr: self.skip_ocr,
@@ -950,6 +1005,8 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
         force_full_page_ocr: false,
         no_text_panels: false,
         ocr_lang: None,
+        ocr_mode: None,
+        ocr_scale: None,
         allowed_formats: None,
         to: parse_output_kind(out.to.as_deref())?,
         image_mode: parse_image_mode(out.image_mode.as_deref())?,

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -103,7 +103,7 @@ use docling_core::{debug_log, env};
 #[cfg(feature = "ml")]
 pub use mets::{convert_mets_gbs, convert_mets_gbs_with_options, convert_mets_gbs_with_pipeline};
 #[cfg(feature = "ml")]
-pub use ocr::OcrLang;
+pub use ocr::{OcrLang, OcrMode};
 #[cfg(feature = "ml")]
 pub use pdfium_backend::PdfDocument;
 pub use pdfium_backend::{PdfPage, TextCell};
@@ -535,6 +535,36 @@ pub fn layout_src(page: &PdfPage) -> layout::LayoutSrc<'_> {
 }
 
 #[cfg(feature = "ml")]
+/// The bitmap + px/pt scale the OCR reads (#254, docling#3877's
+/// `OcrOptions.scale`): the page's own render unless `ocr_scale` asks for a
+/// different resolution, where a PIL-bicubic resample of that render is built
+/// once per page (cached in `cache`) and shared by every OCR pass. Resampling
+/// — rather than a second native pdfium render — keeps one code path across
+/// PDF, image, and hOCR inputs and leaves the layout/TableFormer pixels (and
+/// with them the conformance baseline) untouched; the 144-dpi base render is
+/// itself supersampled down from 216 dpi, so an upscaled OCR view loses
+/// little against a native render.
+fn ocr_input<'a>(
+    cache: &'a mut Option<image::RgbImage>,
+    image: &'a image::RgbImage,
+    scale: f32,
+    ocr_scale: Option<f32>,
+) -> (&'a image::RgbImage, f32) {
+    match ocr_scale {
+        Some(s) if (s - scale).abs() > 1e-3 && image.width() > 1 => {
+            let f = s / scale;
+            let img = cache.get_or_insert_with(|| {
+                let dw = ((image.width() as f32 * f).round() as u32).max(1);
+                let dh = ((image.height() as f32 * f).round() as u32).max(1);
+                resample::pil_resize(image, dw, dh, resample::PilFilter::Bicubic)
+            });
+            (img, s)
+        }
+        _ => (image, scale),
+    }
+}
+
+#[cfg(feature = "ml")]
 /// A self-contained set of the per-page models (layout, OCR). Each parallel
 /// page-worker owns its own `Worker` so inference runs concurrently without
 /// sharing an ONNX session (`ort`'s `Session::run` is `&mut self`); only the
@@ -563,6 +593,8 @@ struct Worker {
     skip_ocr: bool,
     /// Which recognition model [`Self::ocr`] loads. See [`Pipeline::ocr_lang`].
     ocr_lang: ocr::OcrLang,
+    /// OCR render scale override (px/pt, #254). See [`Pipeline::ocr_scale`].
+    ocr_scale: Option<f32>,
 }
 
 #[cfg(feature = "ml")]
@@ -589,6 +621,7 @@ impl Worker {
         force_full_page_ocr: bool,
         no_text_panels: bool,
         ocr_lang: ocr::OcrLang,
+        ocr_scale: Option<f32>,
     ) -> Result<Self, PdfError> {
         Ok(Self {
             layout: if no_ocr {
@@ -606,6 +639,7 @@ impl Worker {
             force_full_page_ocr,
             no_text_panels,
             ocr_lang,
+            ocr_scale,
         })
     }
 
@@ -783,6 +817,12 @@ impl Worker {
         let parse = quality::parse_score(&page.cells);
         // Recognition confidences of every OCR'd cell on this page → ocr_score.
         let mut ocr_confs: Vec<f32> = Vec::new();
+        // The bitmap the OCR reads (#254): with `ocr_scale` set, a resample of
+        // the page render at the requested px/pt, built lazily on the first
+        // OCR use so non-OCR pages never pay for it. Copied out of `self` up
+        // front — the OCR sites hold `self.ocr_model()`'s mutable borrow.
+        let ocr_scale = self.ocr_scale;
+        let mut ocr_view: Option<image::RgbImage> = None;
         if self.force_full_page_ocr {
             page.cells.clear();
             page.code_cells.clear();
@@ -866,10 +906,9 @@ impl Worker {
             // its layout regions (and TableFormer structure below) with no
             // recognized text, instead of failing the conversion.
             if let Some(ocr) = self.ocr_model()? {
-                let cells = timing::timed("ocr.page", || {
-                    ocr.ocr_page(&page.image, &regions, page.scale)
-                })
-                .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+                let (img, scl) = ocr_input(&mut ocr_view, &page.image, page.scale, ocr_scale);
+                let cells = timing::timed("ocr.page", || ocr.ocr_page(img, &regions, scl))
+                    .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                 ocr_confs.extend(cells.iter().map(|(_, conf)| conf));
                 page.cells = cells.into_iter().map(|(cell, _)| cell).collect();
                 // Table interiors carry no words yet: region-scoped OCR skips
@@ -880,8 +919,9 @@ impl Worker {
                 // matcher, and the same cells join `cells` so the geometric
                 // fallback and the table's region text see them too.
                 if regions.iter().any(|r| assemble::is_table_like(r.label)) {
+                    let (img, scl) = ocr_input(&mut ocr_view, &page.image, page.scale, ocr_scale);
                     let words = timing::timed("ocr.table_words", || {
-                        ocr.ocr_table_words(&page.image, &regions, page.scale)
+                        ocr.ocr_table_words(img, &regions, scl)
                     })
                     .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                     ocr_confs.extend(words.iter().map(|(_, conf)| conf));
@@ -936,10 +976,9 @@ impl Worker {
             // Speculative OCR (#244): with `skip_ocr` or no model, big bare
             // pictures simply stay pictures.
             if let (false, Some(ocr)) = (bare.is_empty(), self.ocr_model()?) {
-                let scored = timing::timed("ocr.pictures", || {
-                    ocr.ocr_page(&page.image, &bare, page.scale)
-                })
-                .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
+                let (img, scl) = ocr_input(&mut ocr_view, &page.image, page.scale, ocr_scale);
+                let scored = timing::timed("ocr.pictures", || ocr.ocr_page(img, &bare, scl))
+                    .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                 // Speculative in-picture OCR counts toward ocr_score only on
                 // OCR'd pages, where the recognized lines actually join the
                 // output; on a digital page they may be discarded below.
@@ -1028,8 +1067,9 @@ impl Worker {
             // Same degradation as above: without OCR the in-picture table
             // keeps its structure (TableFormer is geometry-driven) minus text.
             if let (false, Some(ocr)) = (pic_tables.is_empty(), self.ocr_model()?) {
+                let (img, scl) = ocr_input(&mut ocr_view, &page.image, page.scale, ocr_scale);
                 let words = timing::timed("ocr.table_words", || {
-                    ocr.ocr_table_words(&page.image, &pic_tables, page.scale)
+                    ocr.ocr_table_words(img, &pic_tables, scl)
                 })
                 .map_err(|e| PdfError::Ocr(format!("page {}: {e}", n + 1)))?;
                 ocr_confs.extend(words.iter().map(|(_, conf)| conf));
@@ -1300,6 +1340,10 @@ pub struct Pipeline {
     page_range: Option<(usize, usize)>,
     /// OCR recognition language. See [`Pipeline::ocr_lang`].
     ocr_lang: ocr::OcrLang,
+    /// Which regions feed the OCR (#254). See [`Pipeline::ocr_mode`].
+    ocr_mode: ocr::OcrMode,
+    /// OCR render scale override in px/pt (#254). See [`Pipeline::ocr_scale`].
+    ocr_scale: Option<f32>,
     /// Optional per-page progress hook `(done, selected_total)`, invoked after
     /// each page finishes on both the serial and parallel buffered paths. Set
     /// by the CLI batch mode for dot-progress; `None` costs nothing.
@@ -1328,6 +1372,8 @@ impl Pipeline {
             enrich: EnrichmentOptions::default(),
             page_range: None,
             ocr_lang: ocr::OcrLang::from_env(),
+            ocr_mode: ocr::OcrMode::from_env(),
+            ocr_scale: ocr::scale_from_env(),
             progress: None,
         })
     }
@@ -1478,6 +1524,71 @@ impl Pipeline {
         self
     }
 
+    /// Which document regions feed the OCR — docling's `OcrMode` (#254). The
+    /// default (`default` = `pdf_aware_layout_regions`) is the standard
+    /// text-layer-aware behavior; `full_page`/`layout_regions` discard the
+    /// text layer like [`force_full_page_ocr`](Self::force_full_page_ocr)
+    /// (see [`ocr::OcrMode`] for why both map onto it). Whichever of the flag
+    /// and the mode demands forcing wins, mirroring docling's
+    /// `force_full_page_ocr` → `mode=full_page` bridge. `None` keeps the
+    /// process default (`DOCLING_RS_OCR_MODE`, else `default`).
+    pub fn ocr_mode(mut self, mode: Option<ocr::OcrMode>) -> Self {
+        self.ocr_mode = mode.unwrap_or_else(ocr::OcrMode::from_env);
+        self
+    }
+
+    /// In-place variants of [`force_full_page_ocr`](Self::force_full_page_ocr),
+    /// [`ocr_mode`](Self::ocr_mode) and [`ocr_scale`](Self::ocr_scale) for a
+    /// long-lived pipeline (docling-serve's warm instance): all three are pure
+    /// per-worker configuration — no model reloads — so they apply per request
+    /// like [`set_pages`](Self::set_pages). Set them before every conversion so
+    /// no request inherits a previous one's choice.
+    pub fn set_force_full_page_ocr(&mut self, force: bool) {
+        self.force_full_page_ocr = force;
+        self.sync_ocr_config();
+    }
+
+    /// See [`set_force_full_page_ocr`](Self::set_force_full_page_ocr).
+    pub fn set_ocr_mode(&mut self, mode: Option<ocr::OcrMode>) {
+        self.ocr_mode = mode.unwrap_or_else(ocr::OcrMode::from_env);
+        self.sync_ocr_config();
+    }
+
+    /// See [`set_force_full_page_ocr`](Self::set_force_full_page_ocr).
+    pub fn set_ocr_scale(&mut self, scale: Option<f32>) {
+        self.ocr_scale = scale
+            .filter(|s| s.is_finite() && *s > 0.0)
+            .or_else(ocr::scale_from_env);
+        self.sync_ocr_config();
+    }
+
+    /// Push the current OCR forcing/scale choice onto already-loaded workers
+    /// (new workers read it at [`Worker::load`]).
+    fn sync_ocr_config(&mut self) {
+        let force = self.force_full_page_ocr || self.ocr_mode.forces_full_page();
+        let scale = self.ocr_scale;
+        for worker in self.primary.iter_mut().chain(self.pool.iter_mut()) {
+            worker.force_full_page_ocr = force;
+            worker.ocr_scale = scale;
+        }
+    }
+
+    /// OCR render scale in pixels per PDF point — docling's `OcrOptions.scale`
+    /// (#254, upstream docling#3877; their default 3 = 216 dpi). `None`
+    /// (default: `DOCLING_RS_OCR_SCALE`, else unset) feeds the recognizer the
+    /// pipeline's own page render (2.0 px/pt = 144 dpi); a different value
+    /// resamples that render for the OCR input only — layout and TableFormer
+    /// keep their pinned-resolution pixels, so the conformance baseline never
+    /// moves. Lower it when the source raster is already high-resolution and
+    /// upscaling degrades recognition; raise it toward docling's 216 dpi for
+    /// parity experiments. Non-positive values are ignored.
+    pub fn ocr_scale(mut self, scale: Option<f32>) -> Self {
+        self.ocr_scale = scale
+            .filter(|s| s.is_finite() && *s > 0.0)
+            .or_else(ocr::scale_from_env);
+        self
+    }
+
     /// The shared TableFormer slot handed to each worker, or `None` when the
     /// pipeline options skip TableFormer entirely.
     fn tables_slot(&self) -> Option<SharedTables> {
@@ -1522,9 +1633,13 @@ impl Pipeline {
                 self.enrich,
                 self.no_ocr,
                 self.skip_ocr,
-                self.force_full_page_ocr,
+                // The mode-shaped spelling (#254) and the flag are one engine
+                // truth: whichever demands forcing wins, mirroring docling's
+                // `force_full_page_ocr` → `mode=full_page` bridge.
+                self.force_full_page_ocr || self.ocr_mode.forces_full_page(),
                 self.no_text_panels,
                 self.ocr_lang,
+                self.ocr_scale,
             )?);
         }
         Ok(self.primary.as_mut().unwrap())
@@ -1921,9 +2036,10 @@ impl Pipeline {
         let intra = pdf_intra();
         let no_ocr = self.no_ocr;
         let skip_ocr = self.skip_ocr;
-        let force = self.force_full_page_ocr;
+        let force = self.force_full_page_ocr || self.ocr_mode.forces_full_page();
         let ntp = self.no_text_panels;
         let ocr_lang = self.ocr_lang;
+        let ocr_scale = self.ocr_scale;
         let enrich = self.enrich;
         let tables = self.tables_slot();
         let enrich_slots = self.enrich_slots();
@@ -1943,6 +2059,7 @@ impl Pipeline {
                             force,
                             ntp,
                             ocr_lang,
+                            ocr_scale,
                         )
                     })
                 })
@@ -2194,5 +2311,36 @@ mod send_check {
     #[test]
     fn pipeline_is_send() {
         assert_send::<super::Pipeline>();
+    }
+}
+
+#[cfg(all(test, feature = "ml"))]
+mod ocr_input_tests {
+    /// #254: without an `ocr_scale` (or with one equal to the render scale)
+    /// the OCR reads the page render untouched and the cache stays cold; a
+    /// different scale builds one resampled view, reuses it across calls, and
+    /// reports the requested px/pt so cell geometry divides back to points.
+    #[test]
+    fn ocr_input_resamples_only_on_a_real_scale_change() {
+        let img = image::RgbImage::new(200, 100);
+        let mut cache = None;
+        let (v, s) = super::ocr_input(&mut cache, &img, 2.0, None);
+        assert!(std::ptr::eq(v, &img) && s == 2.0 && cache.is_none());
+        let (v, s) = super::ocr_input(&mut cache, &img, 2.0, Some(2.0));
+        assert!(std::ptr::eq(v, &img) && s == 2.0 && cache.is_none());
+
+        let (v, s) = super::ocr_input(&mut cache, &img, 2.0, Some(3.0));
+        assert_eq!((v.width(), v.height(), s), (300, 150, 3.0));
+        let first = cache.as_ref().map(|c| c as *const image::RgbImage);
+        let (v, _) = super::ocr_input(&mut cache, &img, 2.0, Some(3.0));
+        assert_eq!(
+            Some(v as *const image::RgbImage),
+            first,
+            "cached, not rebuilt"
+        );
+
+        let mut down = None;
+        let (v, s) = super::ocr_input(&mut down, &img, 2.0, Some(1.0));
+        assert_eq!((v.width(), v.height(), s), (100, 50, 1.0));
     }
 }

--- a/crates/docling-pdf/src/ocr.rs
+++ b/crates/docling-pdf/src/ocr.rs
@@ -66,6 +66,90 @@ impl OcrLang {
     }
 }
 
+/// Which document regions feed the OCR — docling 2.116's `OcrMode` (#254,
+/// upstream docling#3710). Upstream restructured its pipeline so OCR runs
+/// *after* layout, on layout regions filtered by the PDF text layer — the
+/// architecture this port has always had — and named the strategies:
+///
+/// - `PdfAwareLayoutRegions` (upstream's **default**): OCR only layout regions
+///   the embedded text layer can't cover. Exactly the standard path here —
+///   scanned pages OCR their regions, digital pages OCR only text-less bitmap
+///   areas.
+/// - `FullPage` / `LayoutRegions`: ignore the PDF text layer and OCR
+///   everything. Both map onto the [`force_full_page_ocr`] machinery (discard
+///   the text layer, OCR every layout region): the upstream distinction —
+///   whole-page vs per-region *detector* input — has no analogue in this
+///   engine, whose PP-OCR recognizer always consumes per-region line crops.
+///
+/// [`force_full_page_ocr`]: crate::Pipeline::force_full_page_ocr
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OcrMode {
+    /// Upstream's `default`: currently wired to `PdfAwareLayoutRegions`.
+    #[default]
+    Default,
+    /// OCR the full page, text layer ignored (docling's `full_page`; the
+    /// mode-shaped spelling of `force_full_page_ocr`).
+    FullPage,
+    /// OCR every layout region, text layer ignored (docling's
+    /// `layout_regions`).
+    LayoutRegions,
+    /// OCR layout regions the text layer can't cover (docling's
+    /// `pdf_aware_layout_regions` — the default behavior).
+    PdfAwareLayoutRegions,
+}
+
+impl OcrMode {
+    /// Parse docling's mode ids. `None` for anything else — callers surface
+    /// their own error/warning.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "default" => Some(Self::Default),
+            "full_page" => Some(Self::FullPage),
+            "layout_regions" => Some(Self::LayoutRegions),
+            "pdf_aware_layout_regions" => Some(Self::PdfAwareLayoutRegions),
+            _ => None,
+        }
+    }
+
+    /// The process-level choice from `DOCLING_RS_OCR_MODE` (empty/unset → the
+    /// default; unknown values warn and use the default).
+    pub fn from_env() -> Self {
+        let Some(raw) = docling_core::env::nonempty("DOCLING_RS_OCR_MODE") else {
+            return Self::default();
+        };
+        Self::parse(&raw).unwrap_or_else(|| {
+            eprintln!(
+                "docling-pdf: DOCLING_RS_OCR_MODE={raw:?} is not \
+                 default|full_page|layout_regions|pdf_aware_layout_regions; using default"
+            );
+            Self::default()
+        })
+    }
+
+    /// Whether this mode discards the embedded text layer — the engine truth
+    /// both non-default modes reduce to.
+    pub fn forces_full_page(self) -> bool {
+        matches!(self, Self::FullPage | Self::LayoutRegions)
+    }
+}
+
+/// The process-level OCR render scale from `DOCLING_RS_OCR_SCALE` (#254,
+/// upstream docling#3877's `OcrOptions.scale`): pixels per PDF point fed to
+/// the recognizer. Unset/empty → `None` (OCR reads the pipeline's own page
+/// render, 2.0 px/pt); non-positive or unparsable values warn and are ignored.
+pub fn scale_from_env() -> Option<f32> {
+    let raw = docling_core::env::nonempty("DOCLING_RS_OCR_SCALE")?;
+    match raw.parse::<f32>() {
+        Ok(s) if s > 0.0 && s.is_finite() => Some(s),
+        _ => {
+            eprintln!(
+                "docling-pdf: DOCLING_RS_OCR_SCALE={raw:?} is not a positive number; ignored"
+            );
+            None
+        }
+    }
+}
+
 /// Resolve the recognition model + dictionary pair for `lang`. An English
 /// default that isn't on disk (older model checkouts) degrades to the `ch_`
 /// pair with a warning rather than failing — the usual missing-optional-asset
@@ -237,5 +321,33 @@ impl OcrModel {
             cells.push((TextCell { text, l, t, r, b }, conf));
         }
         Ok(cells)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #254: docling's four `OcrMode` ids parse; `full_page`/`layout_regions`
+    /// reduce to the force-full-page machinery, the default/pdf-aware pair to
+    /// the standard text-layer-aware path. Unknown ids parse to nothing.
+    #[test]
+    fn ocr_mode_ids_parse_and_map_to_forcing() {
+        for (id, mode, forces) in [
+            ("default", OcrMode::Default, false),
+            ("full_page", OcrMode::FullPage, true),
+            ("layout_regions", OcrMode::LayoutRegions, true),
+            (
+                "pdf_aware_layout_regions",
+                OcrMode::PdfAwareLayoutRegions,
+                false,
+            ),
+        ] {
+            assert_eq!(OcrMode::parse(id), Some(mode));
+            assert_eq!(mode.forces_full_page(), forces, "{id}");
+        }
+        assert_eq!(OcrMode::parse(" Full_Page "), Some(OcrMode::FullPage));
+        assert_eq!(OcrMode::parse("easyocr"), None);
+        assert_eq!(OcrMode::parse(""), None);
     }
 }

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "calamine",
  "csv",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "docling-core",
  "ort",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -85,6 +85,14 @@ struct PyDocumentConverter {
     no_table_former: bool,
     no_text_panels: bool,
     enrich: docling::EnrichmentOptions,
+    /// OCR knobs the warm pipeline needs at `initialize_pipeline` time (the
+    /// transient `inner` path reads them off the converter instead). Parsed /
+    /// validated in `new`, so they hold engine values, not raw strings.
+    force_full_page_ocr: bool,
+    ocr_lang: Option<docling::OcrLang>,
+    ocr_mode: Option<docling::OcrMode>,
+    ocr_scale: Option<f32>,
+    page_range: Option<(usize, usize)>,
 }
 
 #[pymethods]
@@ -118,6 +126,13 @@ impl PyDocumentConverter {
     /// * `ocr_lang` — OCR recognition language for scanned pages: `"en"`
     ///   (default; proper Latin word spacing) or `"ch"` (the multilingual
     ///   docling-conformance model).
+    /// * `ocr_mode` — which regions feed the OCR (docling's `OcrMode`, #254):
+    ///   `"default"` | `"full_page"` | `"layout_regions"` |
+    ///   `"pdf_aware_layout_regions"`. `full_page`/`layout_regions` discard
+    ///   the text layer like `force_full_page_ocr`.
+    /// * `ocr_scale` — OCR render scale in px per PDF point (docling's
+    ///   `OcrOptions.scale`, #254); `None` reads the pipeline's own 2.0 px/pt
+    ///   render (docling's default is 3 = 216 dpi).
     /// * `asr_lang` — transcription language for audio/video: a Whisper code
     ///   (`"en"`, `"de"`, …) or `"auto"` (default) to detect it from the
     ///   first 30 seconds (docling 2.116 parity).
@@ -140,6 +155,8 @@ impl PyDocumentConverter {
         video_frames = None,
         page_range = None,
         ocr_lang = None,
+        ocr_mode = None,
+        ocr_scale = None,
         allowed_formats = None,
         text_layer_only = false,
         list_attachments = false,
@@ -161,6 +178,8 @@ impl PyDocumentConverter {
         video_frames: Option<usize>,
         page_range: Option<(usize, usize)>,
         ocr_lang: Option<String>,
+        ocr_mode: Option<String>,
+        ocr_scale: Option<f32>,
         allowed_formats: Option<Vec<String>>,
         text_layer_only: bool,
         list_attachments: bool,
@@ -197,16 +216,41 @@ impl PyDocumentConverter {
             Some((first, last)) => base.page_range(first, last),
             None => base,
         };
-        // `ocr_lang` — validated here so a typo raises instead of degrading.
-        let base = match ocr_lang {
-            Some(lang) => {
-                if docling::OcrLang::parse(&lang).is_none() {
-                    return Err(PyValueError::new_err(format!(
-                        "ocr_lang {lang:?} is not \"en\"|\"ch\""
-                    )));
-                }
-                base.ocr_lang(lang)
+        // `ocr_lang` / `ocr_mode` / `ocr_scale` (#254) — validated here so a
+        // typo raises instead of degrading; the parsed values also prime the
+        // warm pipeline in `initialize_pipeline`.
+        let ocr_lang_choice = match &ocr_lang {
+            Some(lang) => Some(docling::OcrLang::parse(lang).ok_or_else(|| {
+                PyValueError::new_err(format!("ocr_lang {lang:?} is not \"en\"|\"ch\""))
+            })?),
+            None => None,
+        };
+        let ocr_mode_choice = match &ocr_mode {
+            Some(mode) => Some(docling::OcrMode::parse(mode).ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "ocr_mode {mode:?} is not \"default\"|\"full_page\"|\
+                     \"layout_regions\"|\"pdf_aware_layout_regions\""
+                ))
+            })?),
+            None => None,
+        };
+        if let Some(s) = ocr_scale {
+            if !(s.is_finite() && s > 0.0) {
+                return Err(PyValueError::new_err(format!(
+                    "ocr_scale must be a positive number, got {s}"
+                )));
             }
+        }
+        let base = match ocr_lang {
+            Some(lang) => base.ocr_lang(lang),
+            None => base,
+        };
+        let base = match ocr_mode {
+            Some(mode) => base.ocr_mode(mode),
+            None => base,
+        };
+        let base = match ocr_scale {
+            Some(s) => base.ocr_scale(s),
             None => base,
         };
         Ok(Self {
@@ -231,6 +275,11 @@ impl PyDocumentConverter {
             no_table_former: !do_table_structure,
             no_text_panels,
             enrich,
+            force_full_page_ocr,
+            ocr_lang: ocr_lang_choice,
+            ocr_mode: ocr_mode_choice,
+            ocr_scale,
+            page_range,
         })
     }
 
@@ -254,6 +303,11 @@ impl PyDocumentConverter {
         let skip_ocr = self.skip_ocr;
         let no_text_panels = self.no_text_panels;
         let enrich = self.enrich;
+        let force_full_page_ocr = self.force_full_page_ocr;
+        let ocr_lang = self.ocr_lang;
+        let ocr_mode = self.ocr_mode;
+        let ocr_scale = self.ocr_scale;
+        let page_range = self.page_range;
         run_interruptible(py, move || {
             let mut slot = slot.lock().unwrap();
             if slot.is_none() {
@@ -263,6 +317,14 @@ impl PyDocumentConverter {
                     .no_ocr(no_ocr)
                     .skip_ocr(skip_ocr)
                     .no_text_panels(no_text_panels)
+                    // The warm path used to drop the converter's OCR knobs and
+                    // page window on the floor (#254) — prime it with the full
+                    // option set the transient path honors.
+                    .force_full_page_ocr(force_full_page_ocr)
+                    .ocr_lang(ocr_lang)
+                    .ocr_mode(ocr_mode)
+                    .ocr_scale(ocr_scale)
+                    .pages(page_range)
                     .enrichments(enrich);
                 pipeline
                     .warm_up()

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -40,6 +40,13 @@
 //! - `pages` — PDF page window `A-B` / `N` (1-based inclusive, #80)
 //! - `ocr_lang` — OCR recognition language for scanned pages: `en` (default)
 //!   | `ch` (the multilingual docling-conformance model)
+//! - `ocr_mode` — which regions feed the OCR (docling's `OcrMode`, #254):
+//!   `default` | `full_page` | `layout_regions` | `pdf_aware_layout_regions`
+//!   (`full_page`/`layout_regions` discard the text layer like
+//!   `force_full_page_ocr`)
+//! - `ocr_scale` — OCR render scale in px per PDF point (docling's
+//!   `OcrOptions.scale`, #254); unset reads the pipeline's own 2.0 px/pt
+//!   render, docling's default is 3 (216 dpi)
 //! - `fetch_images` — resolve external `<img src>` for HTML/EPUB (outbound
 //!   fetch, so honored only under `--allow-url-fetch`)
 //! - `list_attachments` — email (.eml/.msg): append an Attachments section
@@ -390,6 +397,12 @@ struct ConvertOptions {
     pages: Option<String>,
     /// OCR recognition language for scanned pages: `en` (default) | `ch`.
     ocr_lang: Option<String>,
+    /// Which regions feed the OCR (docling's `OcrMode`, #254): `default` |
+    /// `full_page` | `layout_regions` | `pdf_aware_layout_regions`.
+    ocr_mode: Option<String>,
+    /// OCR render scale in px per PDF point (docling's `OcrOptions.scale`,
+    /// #254); unset reads the pipeline's own 2.0 px/pt render.
+    ocr_scale: Option<f32>,
     /// `to=images` render scale in pixels per PDF point (#243): default 2.0
     /// (144 dpi, the pipeline's own render scale), accepted range 0.1–4.0.
     scale: Option<f32>,
@@ -414,6 +427,8 @@ impl ConvertOptions {
             video_frames: self.video_frames.or(base.video_frames),
             pages: self.pages.or(base.pages),
             ocr_lang: self.ocr_lang.or(base.ocr_lang),
+            ocr_mode: self.ocr_mode.or(base.ocr_mode),
+            ocr_scale: self.ocr_scale.or(base.ocr_scale),
             scale: self.scale.or(base.scale),
         }
     }
@@ -541,6 +556,11 @@ fn validate_output(options: &ConvertOptions) -> Result<(String, ImageMode), ApiE
             )))
         }
     };
+    // OCR mode/scale (#254) validate here too — before the conversion starts —
+    // because the streaming path flattens later errors into a mid-stream 422,
+    // and a bad option deserves a plain 400 up front.
+    parse_ocr_mode(options.ocr_mode.as_deref())?;
+    parse_ocr_scale(options.ocr_scale)?;
     Ok((to, image_mode))
 }
 
@@ -1166,6 +1186,13 @@ async fn read_multipart(
             "asr_lang" => body_opts.asr_lang = Some(text_field(field).await?),
             "pages" => body_opts.pages = Some(text_field(field).await?),
             "ocr_lang" => body_opts.ocr_lang = Some(text_field(field).await?),
+            "ocr_mode" => body_opts.ocr_mode = Some(text_field(field).await?),
+            "ocr_scale" => {
+                let v = text_field(field).await?;
+                body_opts.ocr_scale = Some(v.parse().map_err(|_| {
+                    ApiError::Bad(format!("ocr_scale must be a number, got {v:?}"))
+                })?);
+            }
             "ebcdic_layout" => body_opts.ebcdic_layout = Some(text_field(field).await?),
             "scale" => {
                 let v = text_field(field).await?;
@@ -1462,6 +1489,14 @@ fn convert_document(
             // OCR language likewise applies per request; only a worker whose
             // cached recognition model mismatches actually reloads anything.
             pipeline.set_ocr_lang(parse_ocr_lang(options.ocr_lang.as_deref())?);
+            // Forcing, mode and scale (#254) are pure per-worker configuration
+            // — set unconditionally like the page window. (This also makes
+            // `force_full_page_ocr` effective on the warm path at all: it was
+            // only ever applied to the declarative converter before, which
+            // PDFs never route through.)
+            pipeline.set_force_full_page_ocr(options.force_full_page_ocr.unwrap_or(false));
+            pipeline.set_ocr_mode(parse_ocr_mode(options.ocr_mode.as_deref())?);
+            pipeline.set_ocr_scale(parse_ocr_scale(options.ocr_scale)?);
             let doc = match source.format {
                 InputFormat::Pdf => pipeline.convert(&source.bytes, None, &source.name),
                 _ => pipeline.convert_image(&source.bytes, &source.name),
@@ -1564,7 +1599,40 @@ fn request_converter(
     if parse_ocr_lang(options.ocr_lang.as_deref())?.is_some() {
         converter = converter.ocr_lang(options.ocr_lang.clone().expect("checked above"));
     }
+    // #254: the converter path reaches the ML pipeline too (rasterized SVG),
+    // so mode/scale plumb here as well — validated up front like ocr_lang.
+    if parse_ocr_mode(options.ocr_mode.as_deref())?.is_some() {
+        converter = converter.ocr_mode(options.ocr_mode.clone().expect("checked above"));
+    }
+    if let Some(s) = parse_ocr_scale(options.ocr_scale)? {
+        converter = converter.ocr_scale(s);
+    }
     Ok(converter)
+}
+
+/// Validate a request's `ocr_mode` (#254; None passes through — the engine
+/// default).
+fn parse_ocr_mode(raw: Option<&str>) -> Result<Option<docling::OcrMode>, ApiError> {
+    raw.map(|v| {
+        docling::OcrMode::parse(v).ok_or_else(|| {
+            ApiError::Bad(format!(
+                "ocr_mode {v:?} is not \
+                 default|full_page|layout_regions|pdf_aware_layout_regions"
+            ))
+        })
+    })
+    .transpose()
+}
+
+/// Validate a request's `ocr_scale` (#254; None passes through — the engine
+/// default).
+fn parse_ocr_scale(raw: Option<f32>) -> Result<Option<f32>, ApiError> {
+    match raw {
+        Some(s) if !(s.is_finite() && s > 0.0) => Err(ApiError::Bad(format!(
+            "ocr_scale must be a positive number, got {s}"
+        ))),
+        other => Ok(other),
+    }
 }
 
 /// Validate a request's `ocr_lang` (None passes through — the engine default).

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -64,6 +64,8 @@ paths:
         - { $ref: "#/components/parameters/pages" }
         - { $ref: "#/components/parameters/scale" }
         - { $ref: "#/components/parameters/ocr_lang" }
+        - { $ref: "#/components/parameters/ocr_mode" }
+        - { $ref: "#/components/parameters/ocr_scale" }
         - { $ref: "#/components/parameters/asr_model" }
         - { $ref: "#/components/parameters/asr_lang" }
         - { $ref: "#/components/parameters/video_frames" }
@@ -89,6 +91,8 @@ paths:
                 fetch_images: { type: boolean }
                 pages: { type: string, examples: ["2-5"] }
                 ocr_lang: { $ref: "#/components/schemas/OcrLang" }
+                ocr_mode: { $ref: "#/components/schemas/OcrMode" }
+                ocr_scale: { $ref: "#/components/schemas/OcrScale" }
                 asr_model: { type: string }
                 asr_lang: { type: string, examples: ["auto", "en", "de"] }
                 video_frames: { type: integer, minimum: 0 }
@@ -337,6 +341,22 @@ components:
       enum: [en, ch]
       default: en
       description: OCR recognition language for scanned pages.
+    OcrMode:
+      type: string
+      enum: [default, full_page, layout_regions, pdf_aware_layout_regions]
+      default: default
+      description: >-
+        Which regions feed the OCR (docling's `OcrMode`) —
+        `full_page`/`layout_regions` discard the embedded text layer like
+        `force_full_page_ocr`; `pdf_aware_layout_regions` (= `default`) is the
+        standard text-layer-aware behavior.
+    OcrScale:
+      type: number
+      exclusiveMinimum: 0
+      description: >-
+        OCR render scale in pixels per PDF point (docling's
+        `OcrOptions.scale`). Unset reads the pipeline's own 2.0 px/pt render;
+        docling's default is 3 (216 dpi).
     Scale:
       type: number
       minimum: 0.1
@@ -406,6 +426,8 @@ components:
           description: PDF page window, `A-B` or a single `N` (1-based, inclusive).
           examples: ["2-5", "3"]
         ocr_lang: { $ref: "#/components/schemas/OcrLang" }
+        ocr_mode: { $ref: "#/components/schemas/OcrMode" }
+        ocr_scale: { $ref: "#/components/schemas/OcrScale" }
         scale: { $ref: "#/components/schemas/Scale" }
         asr_model:
           type: string
@@ -512,6 +534,10 @@ components:
       { name: scale, in: query, schema: { $ref: "#/components/schemas/Scale" } }
     ocr_lang:
       { name: ocr_lang, in: query, schema: { $ref: "#/components/schemas/OcrLang" } }
+    ocr_mode:
+      { name: ocr_mode, in: query, schema: { $ref: "#/components/schemas/OcrMode" } }
+    ocr_scale:
+      { name: ocr_scale, in: query, schema: { $ref: "#/components/schemas/OcrScale" } }
     asr_model:
       { name: asr_model, in: query, schema: { type: string } }
     asr_lang:

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -174,6 +174,8 @@ async fn serves_its_logo_and_openapi_description() {
         "ebcdic_layout:",
         "pages:",
         "ocr_lang:",
+        "ocr_mode:",
+        "ocr_scale:",
         "scale:",
         "asr_model:",
         "video_frames:",
@@ -280,6 +282,31 @@ async fn images_output_requires_a_pdf_input() {
     let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert!(body_string(response).await.contains("PDF inputs only"));
+}
+
+/// #254: an unknown `ocr_mode` and a non-positive `ocr_scale` are rejected up
+/// front (400), before any model work — the shared converter builder
+/// validates them, so a plain-CI markdown upload exercises it.
+#[tokio::test]
+async fn ocr_mode_and_scale_are_validated() {
+    let (ct, body) = multipart("x.md", b"# hi", &[("ocr_mode", "easyocr")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("ocr_mode"));
+
+    let (ct, body) = multipart("x.md", b"# hi", &[("ocr_scale", "0")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("ocr_scale"));
+
+    // Valid values pass straight through on a non-OCR format.
+    let (ct, body) = multipart(
+        "x.md",
+        b"# hi",
+        &[("ocr_mode", "full_page"), ("ocr_scale", "3")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 /// A `scale` outside 0.1–4.0 is rejected before pdfium is touched.

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -83,6 +83,10 @@ pub struct DocumentConverter {
     no_ocr: bool,
     skip_ocr: bool,
     force_full_page_ocr: bool,
+    /// OCR mode id (docling's `OcrMode`, #254); parsed at the ML call sites.
+    ocr_mode: Option<String>,
+    /// OCR render scale in px/pt (#254); validated at the ML call sites.
+    ocr_scale: Option<f32>,
     use_web_browser: bool,
     /// Named Whisper model preset for audio sources (docling's ASR model
     /// specs, PR #3741): English-only / Distil-Whisper variants under
@@ -151,6 +155,8 @@ impl Default for DocumentConverter {
             no_ocr: false,
             skip_ocr: false,
             force_full_page_ocr: false,
+            ocr_mode: None,
+            ocr_scale: None,
             use_web_browser: false,
             asr_model: None,
             asr_lang: None,
@@ -212,7 +218,9 @@ impl DocumentConverter {
             .skip_ocr(self.skip_ocr)
             .no_text_panels(self.no_text_panels)
             .enrichments(self.enrich)
-            .ocr_lang(self.ocr_lang_choice()))
+            .ocr_lang(self.ocr_lang_choice())
+            .ocr_mode(self.ocr_mode_choice())
+            .ocr_scale(self.ocr_scale_choice()))
     }
 
     /// The parsed [`Self::ocr_lang`] choice for the ML call sites; a value
@@ -226,6 +234,33 @@ impl DocumentConverter {
             eprintln!("docling: ocr_lang {raw:?} is not en|ch; using the default");
         }
         parsed
+    }
+
+    /// The parsed [`Self::ocr_mode`] choice (#254), with the same
+    /// warn-and-default degradation as [`ocr_lang_choice`](Self::ocr_lang_choice).
+    #[cfg(feature = "pdf")]
+    fn ocr_mode_choice(&self) -> Option<docling_pdf::OcrMode> {
+        let raw = self.ocr_mode.as_deref()?;
+        let parsed = docling_pdf::OcrMode::parse(raw);
+        if parsed.is_none() {
+            eprintln!(
+                "docling: ocr_mode {raw:?} is not \
+                 default|full_page|layout_regions|pdf_aware_layout_regions; using the default"
+            );
+        }
+        parsed
+    }
+
+    /// The validated [`Self::ocr_scale`] (#254): non-positive/non-finite
+    /// values warn and fall back to the engine default.
+    #[cfg(feature = "pdf")]
+    fn ocr_scale_choice(&self) -> Option<f32> {
+        let s = self.ocr_scale?;
+        if !(s.is_finite() && s > 0.0) {
+            eprintln!("docling: ocr_scale {s} is not a positive number; using the default");
+            return None;
+        }
+        Some(s)
     }
 
     /// Where [`ImageMode::Referenced`] streaming writes image files, and the
@@ -390,6 +425,30 @@ impl DocumentConverter {
         self
     }
 
+    /// Which document regions feed the OCR — docling's `OcrMode` (#254):
+    /// `default`, `full_page`, `layout_regions`, or
+    /// `pdf_aware_layout_regions`. The default is the text-layer-aware
+    /// behavior (docling's `pdf_aware_layout_regions`);
+    /// `full_page`/`layout_regions` discard the text layer like
+    /// [`force_full_page_ocr`](Self::force_full_page_ocr) — see
+    /// [`docling_pdf::OcrMode`] for the mapping. An unknown value warns at
+    /// conversion time and uses the default. PDF/image ML pipeline only.
+    pub fn ocr_mode(mut self, mode: impl Into<String>) -> Self {
+        self.ocr_mode = Some(mode.into());
+        self
+    }
+
+    /// OCR render scale in pixels per PDF point — docling's
+    /// `OcrOptions.scale` (#254; docling's default 3 = 216 dpi). Unset feeds
+    /// the recognizer the pipeline's own 2.0 px/pt page render; a different
+    /// value resamples that render for the OCR input only, leaving layout and
+    /// TableFormer pixels untouched. Non-positive values warn at conversion
+    /// time and are ignored. PDF/image ML pipeline only.
+    pub fn ocr_scale(mut self, scale: f32) -> Self {
+        self.ocr_scale = Some(scale);
+        self
+    }
+
     /// Classify each detected picture with the DocumentFigureClassifier model
     /// (docling's `do_picture_classification`). Off by default.
     ///
@@ -516,6 +575,8 @@ impl DocumentConverter {
             enrich: self.enrich,
             page_range: self.page_range,
             ocr_lang: self.ocr_lang_choice(),
+            ocr_mode: self.ocr_mode_choice(),
+            ocr_scale: self.ocr_scale_choice(),
             artifacts_dir: self.artifacts_dir.clone(),
         }
     }

--- a/crates/docling/src/lib.rs
+++ b/crates/docling/src/lib.rs
@@ -60,7 +60,7 @@ pub use docling_core::{
 #[cfg(feature = "pdf")]
 pub use docling_pdf::{
     model_inventory, page_count as pdf_page_count, render_pages as render_pdf_pages,
-    EnrichmentOptions, ModelEntry, OcrLang, Pipeline, RenderedPage,
+    EnrichmentOptions, ModelEntry, OcrLang, OcrMode, Pipeline, RenderedPage,
 };
 // The pure-Rust text-layer extraction (no pdfium, no models) — compiled with
 // either PDF feature. The CLI uses it as the `--no-ocr` fallback when the

--- a/crates/docling/src/stream.rs
+++ b/crates/docling/src/stream.rs
@@ -79,6 +79,8 @@ pub(crate) struct StreamSettings {
     pub enrich: docling_pdf::EnrichmentOptions,
     pub page_range: Option<(usize, usize)>,
     pub ocr_lang: Option<docling_pdf::OcrLang>,
+    pub ocr_mode: Option<docling_pdf::OcrMode>,
+    pub ocr_scale: Option<f32>,
     pub artifacts_dir: String,
 }
 
@@ -146,6 +148,8 @@ fn run_pdf(
             .skip_ocr(settings.skip_ocr)
             .force_full_page_ocr(settings.force_full_page_ocr)
             .ocr_lang(settings.ocr_lang)
+            .ocr_mode(settings.ocr_mode)
+            .ocr_scale(settings.ocr_scale)
             .enrichments(settings.enrich)
             .pages(settings.page_range)
     }) {

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -397,6 +397,20 @@ These are deliberate or unavoidable divergences, not bugs.
     the `skip_ocr` behavior with a one-time warning — docling errors there —
     matching the repo-wide degradation-over-failure convention.
 
+12. **`OcrMode` and `OcrOptions.scale`** (docling 2.116/2.117, #254) are
+    mirrored on every surface as `ocr_mode` (`--ocr-mode`,
+    `DOCLING_RS_OCR_MODE`) and `ocr_scale` (`--ocr-scale`,
+    `DOCLING_RS_OCR_SCALE`). `pdf_aware_layout_regions` — upstream's new
+    default, OCR gated by layout regions and the PDF text layer — is the
+    architecture this port always had, so the default behavior is already
+    aligned; `full_page` and `layout_regions` both map onto the
+    `force_full_page_ocr` machinery (the whole-page vs per-region *detector*
+    distinction has no analogue in the det-free PP-OCR recognizer here).
+    `ocr_scale` resamples the OCR input from the pipeline's 2.0 px/pt page
+    render instead of re-rendering (docling renders natively at
+    `72 × scale` dpi, default 3); unset keeps the pinned 144 dpi baseline,
+    so conformance snapshots never move.
+
 ---
 
 ## 5. Not migrated / out of scope


### PR DESCRIPTION
…ing 2.116-2.117 sync)

Upstream OCR-surface sync (#254), the ported slice of docling#3710 + docling#3877 after assessing all three tickets' changes:

- docling#3710 (2.116) restructured the Python pipeline into layout-driven OCR with a configurable OcrMode, whose new default (pdf_aware_layout_regions: OCR layout regions the PDF text layer can't cover) is the architecture this port has always had — so the default behavior needs no chasing (conformance sweep: 89/94 exact, only the known environmental drifts; zero movement from this change). The OcrMode *surface* is now mirrored: default | full_page | layout_regions | pdf_aware_layout_regions, where full_page/layout_regions discard the text layer via the existing force_full_page_ocr machinery (upstream's whole-page vs per-region detector distinction has no analogue in our det-free PP-OCR recognizer, which always reads per-region line crops) — verified byte-identical to --force-full-page-ocr, and pdf_aware_layout_regions byte-identical to the default, on real fixtures.

- docling#3877 (2.117): OCR render scale made configurable (upstream hardcoded scale=3, 216 dpi). ocr_scale feeds the recognizer a PIL-bicubic resample of the page render at the requested px/pt, built lazily once per page — resampling rather than a second native pdfium render keeps one code path across PDF/image/hOCR inputs and leaves layout/TableFormer pixels (and the pinned conformance baseline) untouched; the 144-dpi base render is itself supersampled down from 216 dpi, so little is lost against a native render. Unset keeps today's exact behavior.

Both knobs plumb through every surface: Pipeline/DocumentConverter builders (+ in-place set_* variants for warm instances), CLI --ocr-mode/--ocr-scale, serve ocr_mode/ocr_scale (multipart + JSON + query, OpenAPI documented, validated to a 400 before conversion starts), Python ocr_mode=/ocr_scale= kwargs, Node ocrMode/ocrScale options, and DOCLING_RS_OCR_MODE / DOCLING_RS_OCR_SCALE env fallbacks.

Two warm-path bugs of the same family fixed on the way: docling-serve only ever applied force_full_page_ocr to the declarative converter, which PDF/image requests never route through — the option was silently ignored on the warm pipeline path (now set per request, like the page window); the Python binding's initialize_pipeline likewise dropped force_full_page_ocr, ocr_lang and page_range on the floor when priming its warm pipeline.

docling#3863's RapidOCR all-languages matrix is assessed but deliberately not ported here: upstream delegates language -> model resolution to the rapidocr package's own resolver and model hosting; opening our en|ch matrix needs per-script PP-OCR rec models fetched, validated and hosted — its own ticket once that hosting decision is made.

Closes docling-project/docling.rs#254



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT