### PR TITLE
feat(xlsx): skip-empty-cells + compact-tables options — sparse-sheet …

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ honoring `pages=A-B` and a `scale` of 0.1–4.0 pixels per PDF point (default
 (`DOCLING_RS_MAX_RASTER_PAGES`); narrow big documents with `pages`.
 
 Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placeholder|embedded`,
+`skip_empty_cells`, `compact_tables`,
 `no_ocr`, `skip_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
 `ocr_lang`, `ocr_mode`, `ocr_scale`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
@@ -578,6 +579,21 @@ every surface: `no_text_panels(bool)` on the library builder, a
 `no_text_panels` option in docling-serve (with a "keep pictures" toggle in
 the playground), the `no_text_panels=` kwarg in Python, and `noTextPanels`
 in Node.
+
+Two sparse-spreadsheet knobs (#271, docling.rs extensions, off by default —
+default output stays byte-for-byte docling), on every surface (CLI flag,
+`DocumentConverter` builder, serve option, Python kwarg, Node option):
+
+- `--skip-empty-cells` — XLSX/XLS family: omit empty cells from each table
+  row instead of materialising the full bounding box of every detected
+  region. A ragged region's box is mostly padding on sparse sheets (a
+  reported 2.7 MB workbook inflated ~7× over its content); a table that
+  loses cells this way drops its merged-span overlay, and dense sheets are
+  untouched.
+- `--compact-tables` — all formats: render Markdown tables in the compact
+  `| a | b |` form instead of the width-padded GitHub style. Grid semantics
+  are unchanged — only inter-cell padding is dropped, which is what
+  dominates the output size on sparse sheets.
 
 ### VLM pipeline (remote endpoint)
 

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -7,7 +7,7 @@
 //! (docling's independent `do_ocr=False`); `--no-ocr` remains the
 //! skip-everything fast path.
 //!
-//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
 //!                      shell doesn't expand it) instead of one positional file.
@@ -136,6 +136,8 @@ fn main() -> ExitCode {
     let mut images = "placeholder".to_string();
     let mut fetch_images = false;
     let mut list_attachments = false;
+    let mut skip_empty_cells = false;
+    let mut compact_tables = false;
     let mut ebcdic_layout: Option<String> = None;
     let mut no_stream = false;
     let mut no_table_former = false;
@@ -171,6 +173,11 @@ fn main() -> ExitCode {
             // #251: append an Attachments section to converted emails
             // (.eml/.msg) — names and content types only.
             "--list-attachments" => list_attachments = true,
+            // Sparse-spreadsheet compaction (#271, docling.rs extensions):
+            // omit empty cells from XLSX/XLS table grids, and/or render all
+            // Markdown tables compact (no width padding).
+            "--skip-empty-cells" => skip_empty_cells = true,
+            "--compact-tables" => compact_tables = true,
             // #252: EBCDIC copybook layout — inline JSON or a file path
             // (default: the <stem>.layout.json sidecar next to the source).
             "--ebcdic-layout" => match args.next() {
@@ -414,6 +421,8 @@ fn main() -> ExitCode {
             strict,
             fetch_images,
             list_attachments,
+            skip_empty_cells,
+            compact_tables,
             ebcdic_layout,
             no_table_former,
             no_ocr,
@@ -438,7 +447,7 @@ fn main() -> ExitCode {
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--use-web-browser] <input-file>");
+        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--use-web-browser] <input-file>");
         return ExitCode::from(2);
     };
 
@@ -527,6 +536,8 @@ fn main() -> ExitCode {
         .asr_lang(asr_lang.clone())
         .fetch_images(fetch_images)
         .list_attachments(list_attachments)
+        .skip_empty_cells(skip_empty_cells)
+        .compact_tables(compact_tables)
         .ebcdic_layout_opt(ebcdic_layout.clone())
         .no_table_former(no_table_former)
         .skip_ocr(skip_ocr)
@@ -677,6 +688,10 @@ struct BatchCfg {
     strict: bool,
     fetch_images: bool,
     list_attachments: bool,
+    /// Omit empty cells from sparse spreadsheet grids (#271).
+    skip_empty_cells: bool,
+    /// Compact (unpadded) Markdown tables (#271).
+    compact_tables: bool,
     ebcdic_layout: Option<String>,
     no_table_former: bool,
     no_ocr: bool,
@@ -798,6 +813,8 @@ fn batch_converter(cfg: &BatchCfg) -> DocumentConverter {
         .asr_lang(cfg.asr_lang.clone())
         .fetch_images(cfg.fetch_images)
         .list_attachments(cfg.list_attachments)
+        .skip_empty_cells(cfg.skip_empty_cells)
+        .compact_tables(cfg.compact_tables)
         .ebcdic_layout_opt(cfg.ebcdic_layout.clone())
         .no_table_former(cfg.no_table_former)
         .no_ocr(cfg.no_ocr)

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -59,6 +59,12 @@ pub struct ConverterOptions {
     /// Email (.eml/.msg): append an Attachments section — names and content
     /// types only, never the payload (#251). Default `false`.
     pub list_attachments: Option<bool>,
+    /// Omit empty cells from sparse XLSX/XLS table grids (#271; docling.rs
+    /// extension). Default `false`.
+    pub skip_empty_cells: Option<bool>,
+    /// Unpadded `| a | b |` Markdown tables, all formats (#271; docling.rs
+    /// extension). Default `false`.
+    pub compact_tables: Option<bool>,
     /// EBCDIC (#252): copybook layout as inline `EbcdicLayout` JSON or a
     /// file path; defaults to the `<stem>.layout.json` sidecar.
     pub ebcdic_layout: Option<String>,
@@ -129,6 +135,11 @@ pub struct ConvertOptions {
     /// Email (.eml/.msg): append an Attachments section — names and content
     /// types only, never the payload (#251). Default `false`.
     pub list_attachments: Option<bool>,
+    /// Omit empty cells from sparse XLSX/XLS table grids (#271). Default
+    /// `false`.
+    pub skip_empty_cells: Option<bool>,
+    /// Unpadded Markdown tables (#271). Default `false`.
+    pub compact_tables: Option<bool>,
     /// EBCDIC (#252): copybook layout as inline `EbcdicLayout` JSON or a
     /// file path; defaults to the `<stem>.layout.json` sidecar.
     pub ebcdic_layout: Option<String>,
@@ -203,6 +214,8 @@ struct ConvertConfig {
     ocr_mode: Option<String>,
     ocr_scale: Option<f32>,
     list_attachments: bool,
+    skip_empty_cells: bool,
+    compact_tables: bool,
     ebcdic_layout: Option<String>,
     skip_ocr: bool,
     force_full_page_ocr: bool,
@@ -270,6 +283,8 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         ocr_mode: parse_ocr_mode(o.ocr_mode)?,
         ocr_scale: parse_ocr_scale(o.ocr_scale)?,
         list_attachments: o.list_attachments.unwrap_or(false),
+        skip_empty_cells: o.skip_empty_cells.unwrap_or(false),
+        compact_tables: o.compact_tables.unwrap_or(false),
         ebcdic_layout: o.ebcdic_layout,
         skip_ocr: o.skip_ocr.unwrap_or(false),
         force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
@@ -327,6 +342,8 @@ fn build_converter(cfg: &ConvertConfig) -> RsConverter {
         .strict(cfg.strict)
         .fetch_images(cfg.fetch_images)
         .list_attachments(cfg.list_attachments)
+        .skip_empty_cells(cfg.skip_empty_cells)
+        .compact_tables(cfg.compact_tables)
         .ebcdic_layout_opt(cfg.ebcdic_layout.clone())
         .skip_ocr(cfg.skip_ocr)
         .force_full_page_ocr(cfg.force_full_page_ocr)
@@ -529,6 +546,8 @@ pub struct DocumentConverter {
     ocr_mode: Option<String>,
     ocr_scale: Option<f32>,
     list_attachments: bool,
+    skip_empty_cells: bool,
+    compact_tables: bool,
     ebcdic_layout: Option<String>,
     skip_ocr: bool,
     force_full_page_ocr: bool,
@@ -560,6 +579,8 @@ impl DocumentConverter {
             ocr_mode: parse_ocr_mode(o.ocr_mode.clone())?,
             ocr_scale: parse_ocr_scale(o.ocr_scale)?,
             list_attachments: o.list_attachments.unwrap_or(false),
+            skip_empty_cells: o.skip_empty_cells.unwrap_or(false),
+            compact_tables: o.compact_tables.unwrap_or(false),
             ebcdic_layout: o.ebcdic_layout.clone(),
             skip_ocr: o.skip_ocr.unwrap_or(false),
             force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
@@ -581,6 +602,8 @@ impl DocumentConverter {
             ocr_mode: self.ocr_mode.clone(),
             ocr_scale: self.ocr_scale,
             list_attachments: self.list_attachments,
+            skip_empty_cells: self.skip_empty_cells,
+            compact_tables: self.compact_tables,
             ebcdic_layout: self.ebcdic_layout.clone(),
             skip_ocr: self.skip_ocr,
             force_full_page_ocr: self.force_full_page_ocr,
@@ -1000,6 +1023,8 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
         video_frames: None,
         page_range: None,
         list_attachments: false,
+        skip_empty_cells: false,
+        compact_tables: false,
         ebcdic_layout: None,
         skip_ocr: false,
         force_full_page_ocr: false,

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "calamine",
  "csv",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -133,6 +133,11 @@ impl PyDocumentConverter {
     /// * `ocr_scale` — OCR render scale in px per PDF point (docling's
     ///   `OcrOptions.scale`, #254); `None` reads the pipeline's own 2.0 px/pt
     ///   render (docling's default is 3 = 216 dpi).
+    /// * `skip_empty_cells` — omit empty cells from sparse XLSX/XLS table
+    ///   grids instead of materialising each region's full bounding box
+    ///   (#271; docling.rs extension, off by default).
+    /// * `compact_tables` — unpadded `| a | b |` Markdown tables, all
+    ///   formats (#271; docling.rs extension, off by default).
     /// * `asr_lang` — transcription language for audio/video: a Whisper code
     ///   (`"en"`, `"de"`, …) or `"auto"` (default) to detect it from the
     ///   first 30 seconds (docling 2.116 parity).
@@ -160,6 +165,8 @@ impl PyDocumentConverter {
         allowed_formats = None,
         text_layer_only = false,
         list_attachments = false,
+        skip_empty_cells = false,
+        compact_tables = false,
         ebcdic_layout = None,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -183,6 +190,8 @@ impl PyDocumentConverter {
         allowed_formats: Option<Vec<String>>,
         text_layer_only: bool,
         list_attachments: bool,
+        skip_empty_cells: bool,
+        compact_tables: bool,
         ebcdic_layout: Option<String>,
     ) -> PyResult<Self> {
         // `allowed_formats` (docling's converter arg) restricts which input
@@ -257,6 +266,8 @@ impl PyDocumentConverter {
             inner: base
                 .fetch_images(fetch_images)
                 .list_attachments(list_attachments)
+                .skip_empty_cells(skip_empty_cells)
+                .compact_tables(compact_tables)
                 .ebcdic_layout_opt(ebcdic_layout)
                 .asr_model(asr_model)
                 .asr_lang(asr_lang)

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -49,6 +49,10 @@
 //!   render, docling's default is 3 (216 dpi)
 //! - `fetch_images` — resolve external `<img src>` for HTML/EPUB (outbound
 //!   fetch, so honored only under `--allow-url-fetch`)
+//! - `skip_empty_cells` — omit empty cells from sparse XLSX/XLS table grids
+//!   (#271; docling.rs extension, off by default)
+//! - `compact_tables` — unpadded `| a | b |` Markdown tables, all formats
+//!   (#271; docling.rs extension, off by default)
 //! - `list_attachments` — email (.eml/.msg): append an Attachments section
 //!   with names and content types (#251; payload bytes are never embedded)
 //! - `ebcdic_layout` — EBCDIC (#252): the copybook layout as inline
@@ -382,6 +386,11 @@ struct ConvertOptions {
     /// Email (.eml/.msg): append an Attachments section — names and content
     /// types only, never the payload (#251).
     list_attachments: Option<bool>,
+    /// Omit empty cells from sparse XLSX/XLS table grids (#271, opt-in
+    /// docling.rs extension).
+    skip_empty_cells: Option<bool>,
+    /// Compact (unpadded) Markdown tables (#271, opt-in docling.rs extension).
+    compact_tables: Option<bool>,
     /// EBCDIC copybook layout (#252): inline `EbcdicLayout` JSON (uploads
     /// have no filesystem, so the JSON itself rides in the request).
     ebcdic_layout: Option<String>,
@@ -421,6 +430,8 @@ impl ConvertOptions {
             no_text_panels: self.no_text_panels.or(base.no_text_panels),
             fetch_images: self.fetch_images.or(base.fetch_images),
             list_attachments: self.list_attachments.or(base.list_attachments),
+            skip_empty_cells: self.skip_empty_cells.or(base.skip_empty_cells),
+            compact_tables: self.compact_tables.or(base.compact_tables),
             ebcdic_layout: self.ebcdic_layout.or(base.ebcdic_layout),
             asr_model: self.asr_model.or(base.asr_model),
             asr_lang: self.asr_lang.or(base.asr_lang),
@@ -1216,7 +1227,9 @@ async fn read_multipart(
             | "force_full_page_ocr"
             | "no_text_panels"
             | "fetch_images"
-            | "list_attachments" => {
+            | "list_attachments"
+            | "skip_empty_cells"
+            | "compact_tables" => {
                 let v = text_field(field).await?;
                 let b = matches!(v.as_str(), "1" | "true" | "yes" | "on");
                 match name.as_str() {
@@ -1227,6 +1240,8 @@ async fn read_multipart(
                     "no_table_former" => body_opts.no_table_former = Some(b),
                     "no_text_panels" => body_opts.no_text_panels = Some(b),
                     "list_attachments" => body_opts.list_attachments = Some(b),
+                    "skip_empty_cells" => body_opts.skip_empty_cells = Some(b),
+                    "compact_tables" => body_opts.compact_tables = Some(b),
                     _ => body_opts.fetch_images = Some(b),
                 }
             }
@@ -1578,6 +1593,8 @@ fn request_converter(
         // placeholder images instead of a surprise outbound fetch).
         .fetch_images(state.cfg.allow_url_fetch && options.fetch_images.unwrap_or(false))
         .list_attachments(options.list_attachments.unwrap_or(false))
+        .skip_empty_cells(options.skip_empty_cells.unwrap_or(false))
+        .compact_tables(options.compact_tables.unwrap_or(false))
         .ebcdic_layout_opt(options.ebcdic_layout.clone())
         .asr_model(options.asr_model.clone())
         .asr_lang(options.asr_lang.clone())

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -59,6 +59,8 @@ paths:
         - { $ref: "#/components/parameters/no_table_former" }
         - { $ref: "#/components/parameters/no_text_panels" }
         - { $ref: "#/components/parameters/fetch_images" }
+        - { $ref: "#/components/parameters/skip_empty_cells" }
+        - { $ref: "#/components/parameters/compact_tables" }
         - { $ref: "#/components/parameters/list_attachments" }
         - { $ref: "#/components/parameters/ebcdic_layout" }
         - { $ref: "#/components/parameters/pages" }
@@ -89,6 +91,8 @@ paths:
                 no_table_former: { type: boolean }
                 no_text_panels: { type: boolean }
                 fetch_images: { type: boolean }
+                skip_empty_cells: { type: boolean }
+                compact_tables: { type: boolean }
                 pages: { type: string, examples: ["2-5"] }
                 ocr_lang: { $ref: "#/components/schemas/OcrLang" }
                 ocr_mode: { $ref: "#/components/schemas/OcrMode" }
@@ -420,6 +424,19 @@ components:
           description: >
             HTML/EPUB — resolve external `<img src>` and embed the bytes.
             Outbound fetch; honored only with `--allow-url-fetch`.
+        skip_empty_cells:
+          type: boolean
+          default: false
+          description: >
+            XLSX/XLS — omit empty cells from sparse-sheet table grids instead
+            of materialising each region's full bounding box (docling.rs
+            extension; a table that loses cells drops its span overlay).
+        compact_tables:
+          type: boolean
+          default: false
+          description: >
+            Render Markdown tables in the compact `| a | b |` form instead of
+            the width-padded GitHub style (docling.rs extension, all formats).
         pages:
           type: string
           pattern: '^\d+(-\d+)?$'
@@ -524,6 +541,10 @@ components:
       { name: no_text_panels, in: query, schema: { type: boolean } }
     fetch_images:
       { name: fetch_images, in: query, schema: { type: boolean } }
+    skip_empty_cells:
+      { name: skip_empty_cells, in: query, schema: { type: boolean } }
+    compact_tables:
+      { name: compact_tables, in: query, schema: { type: boolean } }
     list_attachments:
       { name: list_attachments, in: query, schema: { type: boolean } }
     ebcdic_layout:

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -170,6 +170,8 @@ async fn serves_its_logo_and_openapi_description() {
         "force_full_page_ocr:",
         "no_table_former:",
         "fetch_images:",
+        "skip_empty_cells:",
+        "compact_tables:",
         "list_attachments:",
         "ebcdic_layout:",
         "pages:",

--- a/crates/docling/src/backend/xls.rs
+++ b/crates/docling/src/backend/xls.rs
@@ -21,7 +21,12 @@ use crate::backend::DeclarativeBackend;
 use crate::error::ConversionError;
 use crate::source::SourceDocument;
 
-pub struct XlsBackend;
+#[derive(Default)]
+pub struct XlsBackend {
+    /// Omit empty cells from sparse-sheet table grids (#271, opt-in) — see
+    /// [`find_tables`].
+    pub skip_empty: bool,
+}
 
 impl DeclarativeBackend for XlsBackend {
     fn convert(&self, source: &SourceDocument) -> Result<DoclingDocument, ConversionError> {
@@ -69,7 +74,7 @@ impl DeclarativeBackend for XlsBackend {
             let (or, oc) = (rs_r as usize, rs_c as usize);
 
             let mut items: Vec<((usize, usize, usize, usize), Node)> = Vec::new();
-            for t in find_tables(&range, &merge_of, height, width) {
+            for t in find_tables(&range, &merge_of, height, width, self.skip_empty) {
                 if let Some(label) = t.label {
                     items.push((
                         (
@@ -142,7 +147,7 @@ mod tests {
 
     #[test]
     fn parses_xls_tables_like_the_xlsx_twin() {
-        let doc = XlsBackend
+        let doc = XlsBackend::default()
             .convert(&fixture("xlsx_01.xls"))
             .expect("converts");
         let tables: Vec<_> = doc
@@ -156,6 +161,6 @@ mod tests {
     #[test]
     fn garbage_is_an_error_not_a_panic() {
         let src = SourceDocument::from_bytes("x.xls", InputFormat::Xls, vec![0u8; 64]);
-        assert!(XlsBackend.convert(&src).is_err());
+        assert!(XlsBackend::default().convert(&src).is_err());
     }
 }

--- a/crates/docling/src/backend/xlsx.rs
+++ b/crates/docling/src/backend/xlsx.rs
@@ -44,7 +44,12 @@ fn sheet_merges<R: std::io::Read + std::io::Seek>(wb: &mut Xlsx<R>, name: &str) 
         .collect()
 }
 
-pub struct XlsxBackend;
+#[derive(Default)]
+pub struct XlsxBackend {
+    /// Omit empty cells from sparse-sheet table grids (#271, opt-in) — see
+    /// [`find_tables`].
+    pub skip_empty: bool,
+}
 
 impl DeclarativeBackend for XlsxBackend {
     fn convert(&self, source: &SourceDocument) -> Result<DoclingDocument, ConversionError> {
@@ -54,7 +59,7 @@ impl DeclarativeBackend for XlsxBackend {
         if Package::open(&source.bytes)
             .is_some_and(|mut pkg| pkg.read_bytes("xl/workbook.bin").is_some())
         {
-            return convert_xlsb(source);
+            return convert_xlsb(source, self.skip_empty);
         }
         let cursor = Cursor::new(source.bytes.clone());
         let mut workbook: Xlsx<_> =
@@ -165,6 +170,7 @@ impl DeclarativeBackend for XlsxBackend {
                     ranges: &ranges,
                     persons: &persons,
                     resolve_ref: &resolve_ref,
+                    skip_empty: self.skip_empty,
                 })
             })
             .collect();
@@ -248,7 +254,10 @@ impl DeclarativeBackend for XlsxBackend {
 /// and the page-break convention reuse the xlsx machinery. What the binary
 /// format does not expose through calamine — drawings, charts, comments,
 /// merged regions — degrades to absent rather than failing the conversion.
-fn convert_xlsb(source: &SourceDocument) -> Result<DoclingDocument, ConversionError> {
+fn convert_xlsb(
+    source: &SourceDocument,
+    skip_empty: bool,
+) -> Result<DoclingDocument, ConversionError> {
     let cursor = Cursor::new(source.bytes.clone());
     let mut workbook: calamine::Xlsb<_> =
         calamine::Xlsb::new(cursor).map_err(|e| ConversionError::with_source("xlsb", e))?;
@@ -272,7 +281,7 @@ fn convert_xlsb(source: &SourceDocument) -> Result<DoclingDocument, ConversionEr
         let (height, width) = range.get_size();
         let merge_of = HashMap::new();
         let mut items: Vec<((usize, usize, usize, usize), Node)> = Vec::new();
-        for t in find_tables(&range, &merge_of, height, width) {
+        for t in find_tables(&range, &merge_of, height, width, skip_empty) {
             if let Some(label) = t.label {
                 items.push((
                     (
@@ -341,6 +350,7 @@ struct SheetCtx<'a, F: Fn(&str, &str) -> Vec<String> + Sync> {
     ranges: &'a HashMap<String, (Range<Data>, Merges)>,
     persons: &'a HashMap<String, String>,
     resolve_ref: &'a F,
+    skip_empty: bool,
 }
 
 /// Assemble one sheet's `(bbox, node)` items and its comment lines — the
@@ -357,6 +367,7 @@ fn sheet_items<F: Fn(&str, &str) -> Vec<String> + Sync>(ctx: SheetCtx<'_, F>) ->
         ranges,
         persons,
         resolve_ref,
+        skip_empty,
     } = ctx;
     let mut comments: Vec<String> = Vec::new();
     // (bbox in cell units, node) items for this sheet/page.
@@ -380,7 +391,7 @@ fn sheet_items<F: Fn(&str, &str) -> Vec<String> + Sync>(ctx: SheetCtx<'_, F>) ->
             // docling's bboxes are in *absolute* cell indices; calamine's
             // range is clipped to its first non-empty row/column.
             let (or, oc) = (rs_r as usize, rs_c as usize);
-            for t in find_tables(range, &merge_of, height, width) {
+            for t in find_tables(range, &merge_of, height, width, skip_empty) {
                 if let Some(label) = t.label {
                     // The label row sits directly above the table's region.
                     items.push((
@@ -618,11 +629,21 @@ pub(crate) struct FoundTable {
 
 /// docling's default `gap_tolerance = 0`), in row-major discovery order. A cell
 /// covered by a merge counts as content even if its own value is empty.
+///
+/// `skip_empty` (#271, opt-in — docling materialises the full box too): omit
+/// empty, non-merge-covered positions from each row instead of padding the
+/// region's bounding box. A ragged/diagonal region's box is mostly padding —
+/// a sparse sheet inflated ~7× over its content — and every flood-fill row
+/// holds at least one content cell, so whole rows never vanish. Rows keep
+/// their surviving cells in column order; a table that loses cells this way
+/// also drops its span/structure overlay (the grid positions no longer line
+/// up), while a dense region is byte-identical to the default path.
 pub(crate) fn find_tables(
     range: &Range<Data>,
     merge_of: &HashMap<(usize, usize), (usize, usize)>,
     height: usize,
     width: usize,
+    skip_empty: bool,
 ) -> Vec<FoundTable> {
     let has_content = |r: usize, c: usize| -> bool {
         merge_of.contains_key(&(r, c))
@@ -707,9 +728,22 @@ pub(crate) fn find_tables(
                 }
             }
 
-            // Materialise the region's bounding box; gaps become empty cells.
+            // Materialise the region's bounding box; gaps become empty cells —
+            // or, with `skip_empty`, only the occupied positions per row.
+            let mut omitted = false;
             let rows: Vec<Vec<String>> = (min_r..=max_r)
-                .map(|gr| (min_c..=max_c).map(|gc| cell_text(gr, gc)).collect())
+                .map(|gr| {
+                    (min_c..=max_c)
+                        .filter(|&gc| {
+                            if skip_empty && !has_content(gr, gc) {
+                                omitted = true;
+                                return false;
+                            }
+                            true
+                        })
+                        .map(|gc| cell_text(gr, gc))
+                        .collect()
+                })
                 .collect();
             // Merge spans as OTSL continuations (docling's table cells carry
             // row/col spans from the merged regions): a covered cell continues
@@ -740,7 +774,7 @@ pub(crate) fn find_tables(
                     }
                 }
             }
-            let structure = any_span.then(|| {
+            let structure = (any_span && !omitted).then(|| {
                 let mut header_row = vec![false; nrows];
                 if let Some(h) = header_row.first_mut() {
                     *h = true;
@@ -809,6 +843,69 @@ mod tests {
     use crate::backend::DeclarativeBackend;
     use crate::{InputFormat, SourceDocument};
 
+    /// #271: `skip_empty` omits empty positions from each row of a ragged
+    /// region instead of padding its bounding box; a dense region (or the
+    /// default mode) is untouched, and a table that lost cells drops its
+    /// span/structure overlay.
+    #[test]
+    fn skip_empty_compacts_ragged_regions() {
+        // A 3×3 "staircase": (0,0)-(0,1), (1,1), (2,1)-(2,2) — connected via
+        // column 1, bounding box 3×3 with 4 empty positions.
+        let mut range: Range<Data> = Range::new((0, 0), (2, 2));
+        range.set_value((0, 0), Data::String("a".into()));
+        range.set_value((0, 1), Data::String("b".into()));
+        range.set_value((1, 1), Data::String("c".into()));
+        range.set_value((2, 1), Data::String("d".into()));
+        range.set_value((2, 2), Data::String("e".into()));
+        let merges = HashMap::new();
+
+        let padded = find_tables(&range, &merges, 3, 3, false);
+        assert_eq!(
+            padded[0].table.rows,
+            vec![vec!["a", "b", ""], vec!["", "c", ""], vec!["", "d", "e"]],
+            "default: the full bounding box materialises"
+        );
+
+        let compact = find_tables(&range, &merges, 3, 3, true);
+        assert_eq!(
+            compact[0].table.rows,
+            vec![vec!["a", "b"], vec!["c"], vec!["d", "e"]],
+            "skip_empty: rows keep only their occupied cells"
+        );
+        // Provenance keeps the true region box either way.
+        assert_eq!(
+            (
+                compact[0].min_r,
+                compact[0].min_c,
+                compact[0].max_r,
+                compact[0].max_c
+            ),
+            (0, 0, 2, 2)
+        );
+
+        // A merge-covered position counts as content (span continuation text
+        // repeats), and a dense region keeps its structure overlay untouched.
+        // (Vertical merge in column 0 — a full-width merge above a header row
+        // would trip the #3727 section-label split instead.)
+        let mut merged: HashMap<(usize, usize), (usize, usize)> = HashMap::new();
+        merged.insert((0, 0), (0, 0));
+        merged.insert((1, 0), (0, 0));
+        let mut range2: Range<Data> = Range::new((0, 0), (1, 1));
+        range2.set_value((0, 0), Data::String("tall".into()));
+        range2.set_value((0, 1), Data::String("a".into()));
+        range2.set_value((1, 1), Data::String("b".into()));
+        let dense = find_tables(&range2, &merged, 2, 2, true);
+        assert_eq!(
+            dense[0].table.rows,
+            vec![vec!["tall", "a"], vec!["tall", "b"]],
+            "nothing to omit: identical to the default grid"
+        );
+        assert!(
+            dense[0].table.structure.is_some(),
+            "dense region keeps its span overlay under skip_empty"
+        );
+    }
+
     /// docling PR #3727: a merged full-width cell directly above a real
     /// header row is a section label — a paragraph before the table, not a
     /// swallowed header.
@@ -820,7 +917,7 @@ mod tests {
         );
         let bytes = std::fs::read(&path).expect("fixture exists");
         let src = SourceDocument::from_bytes("x.xlsx", InputFormat::Xlsx, bytes);
-        let doc = XlsxBackend.convert(&src).expect("converts");
+        let doc = XlsxBackend::default().convert(&src).expect("converts");
         let para = doc
             .nodes
             .iter()
@@ -853,7 +950,7 @@ mod tests {
         );
         let bytes = std::fs::read(&path).expect("fixture exists");
         let src = SourceDocument::from_bytes("x.xlsb", InputFormat::Xlsx, bytes);
-        let doc = XlsxBackend.convert(&src).expect("converts");
+        let doc = XlsxBackend::default().convert(&src).expect("converts");
         let Some(Node::Table(sales)) = doc.nodes.iter().find(|n| matches!(n, Node::Table(_)))
         else {
             panic!("no visible table in {:?}", doc.nodes);

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -75,6 +75,12 @@ pub struct DocumentConverter {
     strict: bool,
     fetch_images: bool,
     list_attachments: bool,
+    /// Omit empty cells from sparse spreadsheet table grids (#271, XLSX/XLS
+    /// family; opt-in docling.rs extension).
+    skip_empty_cells: bool,
+    /// Emit Markdown tables in the compact `| a | b |` form instead of the
+    /// width-padded GitHub serializer (#271, opt-in docling.rs extension).
+    compact_tables: bool,
     /// EBCDIC copybook layout (#252): inline JSON or a file path. `None`
     /// falls back to the `<stem>.layout.json` sidecar.
     ebcdic_layout: Option<String>,
@@ -149,6 +155,8 @@ impl Default for DocumentConverter {
             strict: false,
             fetch_images: false,
             list_attachments: false,
+            skip_empty_cells: false,
+            compact_tables: false,
             ebcdic_layout: None,
             no_table_former: false,
             no_text_panels: false,
@@ -337,6 +345,29 @@ impl DocumentConverter {
     /// `EmailBackendOptions.list_attachments` (#251); off by default.
     pub fn list_attachments(mut self, list: bool) -> Self {
         self.list_attachments = list;
+        self
+    }
+
+    /// Omit empty cells from sparse spreadsheet table grids (#271; XLSX/XLS
+    /// family, opt-in — a docling.rs extension, docling materialises the full
+    /// bounding box). A ragged region's box is mostly padding on sparse
+    /// sheets (~7× output inflation); with this on, each row keeps only its
+    /// occupied cells (merge-covered continuations included) and a table
+    /// that loses cells drops its span/structure overlay. Off by default —
+    /// default output stays byte-for-byte docling.
+    pub fn skip_empty_cells(mut self, skip: bool) -> Self {
+        self.skip_empty_cells = skip;
+        self
+    }
+
+    /// Emit Markdown tables in the compact `| a | b |` / `| - | - |` form
+    /// instead of docling-core's width-padded GitHub serializer (#271, all
+    /// formats; opt-in — a docling.rs extension). On sparse spreadsheets the
+    /// padding dominates the output size; compact rendering keeps the grid
+    /// semantics and drops only whitespace. Off by default — default output
+    /// stays byte-for-byte docling.
+    pub fn compact_tables(mut self, compact: bool) -> Self {
+        self.compact_tables = compact;
         self
     }
 
@@ -632,7 +663,10 @@ impl DocumentConverter {
                 }
             }
             InputFormat::Asciidoc => AsciiDocBackend.convert(&source)?,
-            InputFormat::Xlsx => XlsxBackend.convert(&source)?,
+            InputFormat::Xlsx => XlsxBackend {
+                skip_empty: self.skip_empty_cells,
+            }
+            .convert(&source)?,
             InputFormat::Pptx => PptxBackend.convert(&source)?,
             // RTF (#209): a docling.rs extension — docling reaches RTF only via
             // LibreOffice; here it parses natively (hand-rolled tokenizer).
@@ -652,7 +686,10 @@ impl DocumentConverter {
             InputFormat::Docx => DocxBackend.convert(&source)?,
             // Legacy binary Office (issue #127): parsed natively — docling
             // proper converts these through LibreOffice first (PR #3804).
-            InputFormat::Xls => XlsBackend.convert(&source)?,
+            InputFormat::Xls => XlsBackend {
+                skip_empty: self.skip_empty_cells,
+            }
+            .convert(&source)?,
             InputFormat::Ppt => PptBackend.convert(&source)?,
             InputFormat::Doc => DocBackend.convert(&source)?,
             InputFormat::Vtt => WebVttBackend.convert(&source)?,
@@ -813,6 +850,11 @@ impl DocumentConverter {
         };
         // Carry the mode so `result.document.export_to_markdown()` reflects it.
         document.strict_markdown = self.strict;
+        // Compact tables (#271) is additive: the PDF backend already turns it
+        // on for its own corpus; never turn it back off here.
+        if self.compact_tables {
+            document.compact_tables = true;
+        }
         // First-class cells for every table (#240): backends with page
         // geometry (the PDF TableFormer paths) set them; everything else —
         // declarative tables included — derives them from the grid plus the

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -397,7 +397,14 @@ These are deliberate or unavoidable divergences, not bugs.
     the `skip_ocr` behavior with a one-time warning — docling errors there —
     matching the repo-wide degradation-over-failure convention.
 
-12. **`OcrMode` and `OcrOptions.scale`** (docling 2.116/2.117, #254) are
+12. **Sparse spreadsheets can skip empty cells** (#271, docling.rs-only
+    options, both off by default): `skip_empty_cells` omits empty positions
+    from each XLSX/XLS table row instead of materialising every region's
+    full bounding box (docling pads the box too — its own #3328 tracks the
+    RAM cost), and `compact_tables` renders Markdown tables unpadded for
+    every format. Default output stays byte-for-byte docling.
+
+13. **`OcrMode` and `OcrOptions.scale`** (docling 2.116/2.117, #254) are
     mirrored on every surface as `ocr_mode` (`--ocr-mode`,
     `DOCLING_RS_OCR_MODE`) and `ocr_scale` (`--ocr-scale`,
     `DOCLING_RS_OCR_SCALE`). `pdf_aware_layout_regions` — upstream's new


### PR DESCRIPTION
…output bloat

A sparse workbook inflated ~7x over its content (a 2.7 MB sheet produced 27.7M chars against a competing tool's 3.7M): every detected region materialises its full bounding box, so a ragged/diagonal region is mostly empty padding, and the width-padded GitHub table serializer then pads every one of those empty cells to its column's width. Two opt-in docling.rs extensions attack both halves (docling pads the box too — its #3328 tracks the same cost upstream; default output stays byte-for-byte docling, the full regression corpus is unchanged):

- skip_empty_cells (--skip-empty-cells): XLSX/XLS/XLSB table materialisation omits empty, non-merge-covered positions from each row instead of padding the bounding box. Every flood-fill row holds at least one content cell, so whole rows never vanish; rows keep their surviving cells in column order, merge-covered continuations count as content, and a table that loses cells drops its span/structure overlay (the grid positions no longer line up) while a dense region stays byte-identical.

- compact_tables (--compact-tables): all formats — render Markdown tables in the compact `| a | b |` form instead of the width-padded style, by exposing the serializer switch the PDF corpus already used internally. Grid semantics unchanged; only the inter-cell padding (which dominates sparse-sheet output) is dropped.

Both plumb through every surface: DocumentConverter builder, CLI flags, serve options (multipart + JSON + query, OpenAPI documented), Python kwargs, Node options. Unit test covers the ragged compaction, the dense-region identity, and the merge/section-label interplay.

Closes docling-project/docling.rs#271



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT