### PR TITLE
fix(py): forward skip_empty_cells/compact_tables + ocr_mode/ocr_scale in the DocumentConverter wrapper

### DIFF
--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "calamine",
  "csv",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -136,6 +136,18 @@ class DocumentConverter:
       paragraphs — the image-extraction escape hatch, #174).
     * ``fetch_images`` — resolve remote/local ``<img src>`` for HTML/EPUB.
     * ``use_web_browser`` — render HTML via headless Chrome before parsing.
+    * ``ocr_mode`` / ``ocr_scale`` — docling 2.116's ``OcrMode`` (which regions
+      feed the OCR; ``"full_page"``/``"layout_regions"`` discard the embedded
+      text layer) and ``OcrOptions.scale`` (OCR input resolution in px per PDF
+      point), #254. Also accepted docling-shaped, via
+      ``pipeline_options.ocr_options.mode`` / ``.scale``.
+    * ``skip_empty_cells`` / ``compact_tables`` — sparse-spreadsheet output
+      controls (docling.rs extensions, #271): omit empty cells from XLSX/XLS
+      table rows; render Markdown tables unpadded (all formats). Note
+      ``compact_tables`` shapes the *engine's* Markdown serializer only —
+      this wrapper's ``document.export_to_markdown()`` runs upstream Python
+      docling-core, whose padded table style is untouched;
+      ``skip_empty_cells`` is structural and carries through everywhere.
     * ``allowed_formats`` — restrict conversion to these :class:`InputFormat`\\ s
       (docling's converter arg); a source of any other format raises.
     * ``asr_lang`` — transcription language for audio/video: a Whisper code
@@ -160,6 +172,10 @@ class DocumentConverter:
         fetch_images: bool = False,
         use_web_browser: bool = False,
         ocr_lang: Optional[str] = None,
+        ocr_mode: Optional[str] = None,
+        ocr_scale: Optional[float] = None,
+        skip_empty_cells: bool = False,
+        compact_tables: bool = False,
         asr_lang: Optional[str] = None,
         artifacts_path=None,
     ):
@@ -192,6 +208,15 @@ class DocumentConverter:
             # anything that isn't recognisably English/Chinese is ignored with
             # a warning (the engine default — English — applies).
             ocr_opts = getattr(pipeline, "ocr_options", None)
+            # docling 2.116's OcrMode / OcrOptions.scale (#254). An enum mode
+            # collapses to its string value; the direct kwargs stay the
+            # fallback, matching the pipeline-overrides-shorthand rule above.
+            mode = getattr(ocr_opts, "mode", None)
+            if mode is not None:
+                ocr_mode = getattr(mode, "value", mode)
+            scale = getattr(ocr_opts, "scale", None)
+            if scale is not None:
+                ocr_scale = float(scale)
             langs = list(getattr(ocr_opts, "lang", None) or [])
             if langs:
                 head = str(langs[0]).lower()
@@ -239,6 +264,10 @@ class DocumentConverter:
             do_code_enrichment=do_code_enrichment,
             do_formula_enrichment=do_formula_enrichment,
             ocr_lang=ocr_lang,
+            ocr_mode=ocr_mode,
+            ocr_scale=ocr_scale,
+            skip_empty_cells=skip_empty_cells,
+            compact_tables=compact_tables,
             asr_lang=asr_lang,
             allowed_formats=(
                 [InputFormat(f).value for f in allowed_formats]

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -212,3 +212,57 @@ def test_no_text_panels_reaches_the_native_converter():
     ):
         result = converter.convert(HTML)
         assert "homepage" in result.document.export_to_markdown().lower()
+
+
+def test_sparse_sheet_kwargs_forward_to_engine():
+    """#274: the wrapper forwards skip_empty_cells / compact_tables to the
+    native converter (they were native-only in v1.14.0). skip_empty_cells is
+    structural, so it must show up in the docling-core document the wrapper
+    hands back: fewer table cells on a gappy sheet."""
+    from docling_rs import DocumentConverter
+
+    xlsx = REPO / "tests/data/xlsx/sources/xlsx_07_gap_tolerance_.xlsx"
+
+    def cell_count(converter):
+        doc = converter.convert(xlsx).document
+        return sum(len(t.data.table_cells) for t in doc.tables)
+
+    dense = cell_count(DocumentConverter())
+    sparse = cell_count(
+        DocumentConverter(skip_empty_cells=True, compact_tables=True)
+    )
+    assert sparse < dense
+
+
+def test_ocr_kwargs_forward_and_validate():
+    """#274 follow-through for #254: ocr_mode / ocr_scale reach the native
+    converter (which validates them), directly and docling-shaped via
+    ocr_options.mode / .scale."""
+    from types import SimpleNamespace
+
+    from docling_rs import DocumentConverter, InputFormat, PdfFormatOption
+
+    # Valid values construct; the native layer rejects bad ones — the error
+    # surfacing at all is proof of forwarding.
+    DocumentConverter(ocr_mode="full_page", ocr_scale=3.0)
+    with pytest.raises(Exception):
+        DocumentConverter(ocr_mode="not_a_mode")
+    with pytest.raises(Exception):
+        DocumentConverter(ocr_scale=-1.0)
+
+    # docling-shaped: OcrOptions.mode may be an enum (collapses to .value).
+    shaped = SimpleNamespace(
+        do_ocr=True,
+        do_table_structure=True,
+        ocr_options=SimpleNamespace(
+            mode=SimpleNamespace(value="layout_regions"), scale=2.5, lang=[]
+        ),
+    )
+    DocumentConverter(
+        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=shaped)}
+    )
+    shaped.ocr_options.mode = "bogus"
+    with pytest.raises(Exception):
+        DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=shaped)}
+        )


### PR DESCRIPTION


The pure-Python DocumentConverter wrapper never forwarded four kwargs the native PyO3 class already accepts, so reaching them required bypassing the wrapper (losing the format_options/PdfFormatOption translation) and skip_empty_cells was effectively unreachable from Python:

- skip_empty_cells / compact_tables (#271, native-only since v1.14.0): now forwarded. skip_empty_cells is structural and carries through the docling-core document the wrapper hands back (fewer table cells on gappy sheets — asserted against xlsx_07_gap_tolerance_); compact_tables configures the engine's Markdown serializer, and the docstring now says plainly that the wrapper's export_to_markdown() (upstream Python docling-core) keeps its padded style.

- ocr_mode / ocr_scale (#254, same gap): forwarded directly and accepted docling-shaped via pipeline_options.ocr_options.mode/.scale (an enum mode collapses to its string value), following the existing pipeline-overrides-shorthand rule; the native layer's validation (unknown mode, non-positive scale) now surfaces through the wrapper.

Also refreshes the crate's Cargo.lock (path deps lagged at 1.13.0).

Closes docling-project/docling.rs#274