### PR TITLE
feat(serve): per-request chunking configuration — service-datamodel s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ honoring `pages=A-B` and a `scale` of 0.1–4.0 pixels per PDF point (default
 Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placeholder|embedded`,
 `skip_empty_cells`, `compact_tables`,
 `no_ocr`, `skip_ocr`, `no_table_former`, `no_text_panels`, `force_full_page_ocr`, `pages`,
-`ocr_lang`, `ocr_mode`, `ocr_scale`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images` — as query
+`ocr_lang`, `ocr_mode`, `ocr_scale`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images`,
+`chunker=hierarchical|hybrid`, `chunk_tokenizer`, `chunk_max_tokens`, `chunk_merge_peers` (#256:
+per-request `to=chunks` configuration; the tokenizer is a server-local relative path) — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
 `--allow-url-fetch`, `--no-url-fetch`, `--strict`, `--max-memory-mb` (#263:
@@ -399,7 +401,10 @@ HuggingFace tokenizer (MiniLM etc.) sits behind the `chunking` cargo feature
 `scripts/install/download_dependencies.sh` fetches MiniLM's tokenizer to
 `.models/chunk/tokenizer.json`, which every surface picks up automatically when
 no explicit tokenizer path is given (`DOCLING_CHUNK_TOKENIZER` overrides the
-path and `DOCLING_CHUNK_MAX_TOKENS` the 256-token budget for the CLI). The chunkers are also
+path and `DOCLING_CHUNK_MAX_TOKENS` the 256-token budget; per-run overrides:
+`--chunker hierarchical|hybrid`, `--chunk-tokenizer`, `--chunk-max-tokens`,
+`--no-chunk-merge-peers` on the CLI and the matching serve request fields,
+#256). The chunkers are also
 exposed in the [Node bindings](./crates/docling-node) (`chunkFile` /
 `chunkDocument` + async variants), the
 [Python bindings](./crates/docling-py) (`docling_rs.chunking`), and the

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -7,7 +7,7 @@
 //! (docling's independent `do_ocr=False`); `--no-ocr` remains the
 //! skip-everything fast path.
 //!
-//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
+//! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--chunker hierarchical|hybrid] [--chunk-tokenizer PATH] [--chunk-max-tokens N] [--no-chunk-merge-peers] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
 //!                      shell doesn't expand it) instead of one positional file.
@@ -108,6 +108,7 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::process::ExitCode;
 
+use docling::chunks::{ChunkOptions, ChunkerKind};
 use docling::{DocumentConverter, ImageMode, InputFormat, Pipeline, SourceDocument};
 
 fn main() -> ExitCode {
@@ -158,6 +159,7 @@ fn main() -> ExitCode {
     let mut ocr_lang: Option<String> = None;
     let mut ocr_mode: Option<String> = None;
     let mut ocr_scale: Option<f32> = None;
+    let mut chunk_opts = docling::chunks::ChunkOptions::default();
     let mut pipeline: Option<String> = None;
     let mut vlm_endpoint: Option<String> = None;
     let mut vlm_model: Option<String> = None;
@@ -311,6 +313,35 @@ fn main() -> ExitCode {
                     return ExitCode::from(2);
                 }
             },
+            // Per-run `--to chunks` configuration (#256, mirrors the serve
+            // fields / docling's service-datamodel `HybridChunkerOptions`);
+            // the DOCLING_CHUNK_* env knobs stay the defaults.
+            "--chunker" => match args.next().as_deref().map(ChunkerKind::parse) {
+                Some(Ok(k)) => chunk_opts.chunker = Some(k),
+                Some(Err(e)) => {
+                    eprintln!("error: --chunker: {e}");
+                    return ExitCode::from(2);
+                }
+                None => {
+                    eprintln!("error: --chunker needs a value (hierarchical|hybrid)");
+                    return ExitCode::from(2);
+                }
+            },
+            "--chunk-tokenizer" => match args.next() {
+                Some(v) => chunk_opts.tokenizer = Some(v),
+                None => {
+                    eprintln!("error: --chunk-tokenizer needs a tokenizer.json path");
+                    return ExitCode::from(2);
+                }
+            },
+            "--chunk-max-tokens" => match args.next().map(|v| v.trim().parse::<usize>()) {
+                Some(Ok(n)) if n > 0 => chunk_opts.max_tokens = Some(n),
+                _ => {
+                    eprintln!("error: --chunk-max-tokens needs a positive integer");
+                    return ExitCode::from(2);
+                }
+            },
+            "--no-chunk-merge-peers" => chunk_opts.merge_peers = Some(false),
             // Pipeline selection (#77): `standard` (default, the ML stack) or
             // `vlm` — render pages and convert them through a remote
             // OpenAI-compatible vision endpoint returning DocLang.
@@ -441,13 +472,14 @@ fn main() -> ExitCode {
             ocr_mode,
             ocr_scale,
             scale,
+            chunk: chunk_opts.clone(),
             vlm,
         };
         return run_batch(files, &base, Path::new(&outdir), jobs, &cfg);
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--use-web-browser] <input-file>");
+        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--chunker hierarchical|hybrid] [--chunk-tokenizer PATH] [--chunk-max-tokens N] [--no-chunk-merge-peers] [--use-web-browser] <input-file>");
         return ExitCode::from(2);
     };
 
@@ -527,7 +559,7 @@ fn main() -> ExitCode {
             }
         };
         document.strict_markdown = strict;
-        return output_document(document, &to, image_mode, &path);
+        return output_document(document, &to, image_mode, &path, &chunk_opts);
     }
 
     let mut converter = DocumentConverter::new()
@@ -577,7 +609,7 @@ fn main() -> ExitCode {
                 if let Some(doc) =
                     pdf_no_ocr_fallback(&e.to_string(), is_pdf, no_ocr, strict, &path, pages)
                 {
-                    return output_document(doc, &to, image_mode, &path);
+                    return output_document(doc, &to, image_mode, &path, &chunk_opts);
                 }
                 eprintln!("error: {e}");
                 return ExitCode::FAILURE;
@@ -609,7 +641,7 @@ fn main() -> ExitCode {
                             &path,
                             pages,
                         ) {
-                            return output_document(doc, &to, image_mode, &path);
+                            return output_document(doc, &to, image_mode, &path, &chunk_opts);
                         }
                     }
                     eprintln!("error: {e}");
@@ -633,13 +665,13 @@ fn main() -> ExitCode {
             if let Some(doc) =
                 pdf_no_ocr_fallback(&e.to_string(), is_pdf, no_ocr, strict, &path, pages)
             {
-                return output_document(doc, &to, image_mode, &path);
+                return output_document(doc, &to, image_mode, &path, &chunk_opts);
             }
             eprintln!("error: {e}");
             return ExitCode::FAILURE;
         }
     };
-    output_document(document, &to, image_mode, &path)
+    output_document(document, &to, image_mode, &path, &chunk_opts)
 }
 
 /// Launch-blocker fallback: a bare `cargo install docling-cli` ships neither
@@ -713,6 +745,8 @@ struct BatchCfg {
     ocr_scale: Option<f32>,
     /// `--to images` render scale (pixels per PDF point, #243).
     scale: f32,
+    /// Per-run `--to chunks` configuration (#256).
+    chunk: ChunkOptions,
     vlm: Option<docling::vlm::VlmOptions>,
 }
 
@@ -988,7 +1022,7 @@ fn batch_convert_one(
     match cfg.to.as_str() {
         "json" => std::fs::write(&out, document.export_to_json())
             .map_err(|e| format!("writing {}: {e}", out.display()))?,
-        "chunks" => std::fs::write(&out, chunks_json(&document))
+        "chunks" => std::fs::write(&out, chunks_json(&document, &cfg.chunk)?)
             .map_err(|e| format!("writing {}: {e}", out.display()))?,
         "dclx" => docling::dclx::save_as_dclx(&document, &out).map_err(|e| e.to_string())?,
         _ => {
@@ -1123,6 +1157,7 @@ fn output_document(
     to: &str,
     image_mode: ImageMode,
     path: &str,
+    chunk: &ChunkOptions,
 ) -> ExitCode {
     if to == "json" {
         println!("{}", document.export_to_json());
@@ -1133,8 +1168,15 @@ fn output_document(
         // Chunking conformance/debug dump: a JSON object with the hierarchical
         // chunk records and, when a tokenizer is configured, the hybrid ones.
         // `DOCLING_CHUNK_TOKENIZER` points at a HuggingFace tokenizer.json
-        // (`DOCLING_CHUNK_MAX_TOKENS` overrides the default budget of 256).
-        print!("{}", chunks_json(&document));
+        // (`DOCLING_CHUNK_MAX_TOKENS` overrides the default budget of 256);
+        // `--chunker`/`--chunk-*` override per run (#256).
+        match chunks_json(&document, chunk) {
+            Ok(json) => print!("{json}"),
+            Err(e) => {
+                eprintln!("error: chunks: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
         return ExitCode::SUCCESS;
     }
 
@@ -1299,14 +1341,19 @@ fn bench_warm_conversion(
 }
 
 /// Serialize the chunk records `--to chunks` prints (see
-/// [`docling::chunks::chunk_records`] for the tokenizer resolution rules).
-fn chunks_json(document: &docling::DoclingDocument) -> String {
+/// [`docling::chunks::chunk_records_with`] for the tokenizer resolution
+/// rules). Errors only when an explicitly requested configuration can't be
+/// honored (`--chunker hybrid` without a usable tokenizer).
+fn chunks_json(
+    document: &docling::DoclingDocument,
+    chunk: &ChunkOptions,
+) -> Result<String, String> {
     let mut warn = |msg: String| eprintln!("warning: {msg}");
-    let out = docling::chunks::chunk_records(document, &mut warn);
-    format!(
+    let out = docling::chunks::chunk_records_with(document, chunk, &mut warn)?;
+    Ok(format!(
         "{}\n",
         serde_json::to_string_pretty(&out).expect("chunks are serializable")
-    )
+    ))
 }
 
 #[cfg(test)]

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -58,6 +58,14 @@
 //! - `ebcdic_layout` — EBCDIC (#252): the copybook layout as inline
 //!   `EbcdicLayout` JSON (mandatory for the format — the bytes are
 //!   meaningless without it)
+//! - `chunker`, `chunk_tokenizer`, `chunk_max_tokens`, `chunk_merge_peers` —
+//!   per-request `to=chunks` configuration (#256, mirroring docling's
+//!   service-datamodel `ChunkerType`/`HybridChunkerOptions`): pick one
+//!   chunker (`hierarchical` | `hybrid`; unset returns both), a server-local
+//!   relative `tokenizer.json` path, the hybrid token budget (default 256 /
+//!   `DOCLING_CHUNK_MAX_TOKENS`) and peer-merging (default true). An
+//!   explicitly requested `chunker=hybrid` without a usable tokenizer is a
+//!   400 instead of the legacy silent skip
 //!
 //! Markdown converts through the streaming serializer and the response body
 //! streams page by page (chunked transfer); `json`/`dclx`/`chunks` (and every
@@ -415,6 +423,22 @@ struct ConvertOptions {
     /// `to=images` render scale in pixels per PDF point (#243): default 2.0
     /// (144 dpi, the pipeline's own render scale), accepted range 0.1–4.0.
     scale: Option<f32>,
+    /// Which chunker `to=chunks` returns (#256, docling's `ChunkerType`):
+    /// `hierarchical` | `hybrid`; unset keeps the legacy both-chunkers shape
+    /// (hierarchical always, hybrid best-effort).
+    chunker: Option<String>,
+    /// Hybrid tokenizer for `to=chunks` (#256): a server-local *relative*
+    /// path to a HuggingFace `tokenizer.json` (absolute paths and `..` are
+    /// rejected — requests select among tokenizers the operator deployed,
+    /// they don't read arbitrary server files). Default:
+    /// `DOCLING_CHUNK_TOKENIZER`, else `.models/chunk/tokenizer.json`.
+    chunk_tokenizer: Option<String>,
+    /// Hybrid chunk budget for `to=chunks` (#256, docling's `max_tokens`);
+    /// default `DOCLING_CHUNK_MAX_TOKENS`, else 256.
+    chunk_max_tokens: Option<usize>,
+    /// Hybrid peer-merging for `to=chunks` (docling's `merge_peers`, default
+    /// true, #256).
+    chunk_merge_peers: Option<bool>,
 }
 
 impl ConvertOptions {
@@ -441,6 +465,10 @@ impl ConvertOptions {
             ocr_mode: self.ocr_mode.or(base.ocr_mode),
             ocr_scale: self.ocr_scale.or(base.ocr_scale),
             scale: self.scale.or(base.scale),
+            chunker: self.chunker.or(base.chunker),
+            chunk_tokenizer: self.chunk_tokenizer.or(base.chunk_tokenizer),
+            chunk_max_tokens: self.chunk_max_tokens.or(base.chunk_max_tokens),
+            chunk_merge_peers: self.chunk_merge_peers.or(base.chunk_merge_peers),
         }
     }
 }
@@ -572,7 +600,44 @@ fn validate_output(options: &ConvertOptions) -> Result<(String, ImageMode), ApiE
     // and a bad option deserves a plain 400 up front.
     parse_ocr_mode(options.ocr_mode.as_deref())?;
     parse_ocr_scale(options.ocr_scale)?;
+    parse_chunk_options(options)?;
     Ok((to, image_mode))
+}
+
+/// Validate and build the per-request chunking configuration (#256). The
+/// tokenizer must be a server-local *relative* path with no `..` components:
+/// requests pick among tokenizers the operator deployed next to the server,
+/// they don't read arbitrary files (the unrestricted knob is the operator-set
+/// `DOCLING_CHUNK_TOKENIZER` env).
+fn parse_chunk_options(
+    options: &ConvertOptions,
+) -> Result<docling::chunks::ChunkOptions, ApiError> {
+    let chunker = options
+        .chunker
+        .as_deref()
+        .map(docling::chunks::ChunkerKind::parse)
+        .transpose()
+        .map_err(ApiError::Bad)?;
+    if let Some(p) = options.chunk_tokenizer.as_deref() {
+        let path = std::path::Path::new(p);
+        let unsafe_component = path.components().any(|c| {
+            !matches!(
+                c,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        });
+        if unsafe_component || p.is_empty() {
+            return Err(ApiError::Bad(format!(
+                "chunk_tokenizer must be a relative path without '..' components, got {p:?}"
+            )));
+        }
+    }
+    Ok(docling::chunks::ChunkOptions {
+        chunker,
+        tokenizer: options.chunk_tokenizer.clone(),
+        max_tokens: options.chunk_max_tokens,
+        merge_peers: options.chunk_merge_peers,
+    })
 }
 
 async fn convert(
@@ -884,9 +949,7 @@ fn run_conversion(
         }
         let name = source.name.clone();
         let document = convert_document(state, source, options)?;
-        return Ok(render_stored(
-            state, to, image_mode, &name, &document, options,
-        ));
+        return render_stored(state, to, image_mode, &name, &document, options);
     }
     let items: Vec<serde_json::Value> = sources
         .into_iter()
@@ -1040,9 +1103,9 @@ fn render_stored(
     name: &str,
     document: &DoclingDocument,
     options: &ConvertOptions,
-) -> StoredResponse {
+) -> Result<StoredResponse, ApiError> {
     let confidence = confidence_header(document);
-    match to {
+    Ok(match to {
         "md" | "markdown" => StoredResponse {
             content_type: "text/markdown; charset=utf-8",
             disposition: None,
@@ -1062,8 +1125,13 @@ fn render_stored(
             }
         }
         "chunks" => {
+            let chunk_opts = parse_chunk_options(options)?;
             let mut warnings: Vec<String> = Vec::new();
-            let mut records = docling::chunks::chunk_records(document, &mut |m| warnings.push(m));
+            let mut records =
+                docling::chunks::chunk_records_with(document, &chunk_opts, &mut |m| {
+                    warnings.push(m)
+                })
+                .map_err(ApiError::Bad)?;
             if !warnings.is_empty() {
                 records["warnings"] = json!(warnings);
             }
@@ -1081,7 +1149,7 @@ fn render_stored(
             body: docling::dclx::to_dclx_bytes(document),
         },
         _ => unreachable!("validated above"),
-    }
+    })
 }
 
 /// One batch item (#182) as JSON. Text outputs inline as strings, the
@@ -1109,12 +1177,28 @@ fn batch_item(
             item["document"] = value;
         }
         "chunks" => {
+            // A per-request chunking config that can't be honored fails this
+            // item (batch semantics: other items still convert).
             let mut warnings: Vec<String> = Vec::new();
-            let mut records = docling::chunks::chunk_records(document, &mut |m| warnings.push(m));
-            if !warnings.is_empty() {
-                records["warnings"] = json!(warnings);
+            match parse_chunk_options(options).map(|o| {
+                docling::chunks::chunk_records_with(document, &o, &mut |m| warnings.push(m))
+            }) {
+                Ok(Ok(mut records)) => {
+                    if !warnings.is_empty() {
+                        records["warnings"] = json!(warnings);
+                    }
+                    item["chunks"] = records;
+                }
+                Ok(Err(e)) => {
+                    item["status"] = json!("failure");
+                    item["error"] = json!(e);
+                }
+                Err(e) => {
+                    let (_, msg) = api_error_parts(e);
+                    item["status"] = json!("failure");
+                    item["error"] = json!(msg);
+                }
             }
-            item["chunks"] = records;
         }
         "dclx" => {
             item["dclx_base64"] = json!(docling::base64::encode(&docling::dclx::to_dclx_bytes(
@@ -1205,6 +1289,16 @@ async fn read_multipart(
                 })?);
             }
             "ebcdic_layout" => body_opts.ebcdic_layout = Some(text_field(field).await?),
+            "chunker" => body_opts.chunker = Some(text_field(field).await?),
+            "chunk_tokenizer" => body_opts.chunk_tokenizer = Some(text_field(field).await?),
+            "chunk_max_tokens" => {
+                let v = text_field(field).await?;
+                body_opts.chunk_max_tokens = Some(v.parse().map_err(|_| {
+                    ApiError::Bad(format!(
+                        "chunk_max_tokens must be a positive integer, got {v:?}"
+                    ))
+                })?);
+            }
             "scale" => {
                 let v = text_field(field).await?;
                 body_opts.scale =
@@ -1229,7 +1323,8 @@ async fn read_multipart(
             | "fetch_images"
             | "list_attachments"
             | "skip_empty_cells"
-            | "compact_tables" => {
+            | "compact_tables"
+            | "chunk_merge_peers" => {
                 let v = text_field(field).await?;
                 let b = matches!(v.as_str(), "1" | "true" | "yes" | "on");
                 match name.as_str() {
@@ -1242,6 +1337,7 @@ async fn read_multipart(
                     "list_attachments" => body_opts.list_attachments = Some(b),
                     "skip_empty_cells" => body_opts.skip_empty_cells = Some(b),
                     "compact_tables" => body_opts.compact_tables = Some(b),
+                    "chunk_merge_peers" => body_opts.chunk_merge_peers = Some(b),
                     _ => body_opts.fetch_images = Some(b),
                 }
             }

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -71,6 +71,10 @@ paths:
         - { $ref: "#/components/parameters/asr_model" }
         - { $ref: "#/components/parameters/asr_lang" }
         - { $ref: "#/components/parameters/video_frames" }
+        - { $ref: "#/components/parameters/chunker" }
+        - { $ref: "#/components/parameters/chunk_tokenizer" }
+        - { $ref: "#/components/parameters/chunk_max_tokens" }
+        - { $ref: "#/components/parameters/chunk_merge_peers" }
       requestBody:
         required: true
         content:
@@ -100,6 +104,10 @@ paths:
                 asr_model: { type: string }
                 asr_lang: { type: string, examples: ["auto", "en", "de"] }
                 video_frames: { type: integer, minimum: 0 }
+                chunker: { $ref: "#/components/schemas/Chunker" }
+                chunk_tokenizer: { type: string }
+                chunk_max_tokens: { type: integer, minimum: 1 }
+                chunk_merge_peers: { type: boolean }
           application/json:
             schema:
               allOf:
@@ -460,6 +468,28 @@ components:
           type: integer
           minimum: 0
           description: Video — max frames sampled as pictures (0 = transcript only; needs ffmpeg on the server).
+        chunker: { $ref: "#/components/schemas/Chunker" }
+        chunk_tokenizer:
+          type: string
+          description: >
+            `to=chunks` — hybrid tokenizer: a server-local *relative* path to a
+            HuggingFace `tokenizer.json` (absolute paths and `..` are
+            rejected). Default: the server's `DOCLING_CHUNK_TOKENIZER`, else
+            `.models/chunk/tokenizer.json`.
+        chunk_max_tokens:
+          type: integer
+          minimum: 1
+          default: 256
+          description: >
+            `to=chunks` — hybrid chunk budget in tokens (docling's
+            `max_tokens`; server default overridable via
+            `DOCLING_CHUNK_MAX_TOKENS`).
+        chunk_merge_peers:
+          type: boolean
+          default: true
+          description: >
+            `to=chunks` — merge undersized successive hybrid chunks with the
+            same headings (docling's `merge_peers`).
     DoclingDocument:
       type: object
       description: >
@@ -475,6 +505,14 @@ components:
         groups: { type: array, items: { type: object } }
         tables: { type: array, items: { type: object } }
         pictures: { type: array, items: { type: object } }
+    Chunker:
+      type: string
+      enum: [hierarchical, hybrid]
+      description: >
+        `to=chunks` — return only this chunker's records (docling's
+        `ChunkerType`, #256). Unset returns both: `hierarchical` always,
+        `hybrid` when a tokenizer is available. An explicit `hybrid` without a
+        usable tokenizer is a 400.
     Chunks:
       type: object
       description: Chunker output for `to=chunks`.
@@ -565,3 +603,11 @@ components:
       { name: asr_lang, in: query, schema: { type: string } }
     video_frames:
       { name: video_frames, in: query, schema: { type: integer, minimum: 0 } }
+    chunker:
+      { name: chunker, in: query, schema: { $ref: "#/components/schemas/Chunker" } }
+    chunk_tokenizer:
+      { name: chunk_tokenizer, in: query, schema: { type: string } }
+    chunk_max_tokens:
+      { name: chunk_max_tokens, in: query, schema: { type: integer, minimum: 1 } }
+    chunk_merge_peers:
+      { name: chunk_merge_peers, in: query, schema: { type: boolean } }

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -766,3 +766,66 @@ async fn index_serves_docs_and_form() {
     let body = body_string(response).await;
     assert!(body.contains("/v1/convert") && body.contains("<form") || body.contains("Convert"));
 }
+
+#[tokio::test]
+async fn chunker_hierarchical_returns_only_that_chunker() {
+    // #256: an explicit chunker selects a single record set.
+    let (ct, body) = multipart(
+        "t.csv",
+        b"a,b\n1,2\n",
+        &[("to", "chunks"), ("chunker", "hierarchical")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    assert!(v.get("hierarchical").is_some());
+    assert!(v.get("hybrid").is_none(), "hierarchical only: {v}");
+}
+
+#[tokio::test]
+async fn unknown_chunker_is_a_400() {
+    let (ct, body) = multipart(
+        "t.csv",
+        b"a,b\n1,2\n",
+        &[("to", "chunks"), ("chunker", "nope")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn chunk_tokenizer_path_escape_is_a_400() {
+    // #256: the request-side tokenizer must stay a server-local relative
+    // path — traversal is rejected before any conversion work.
+    for bad in ["../secrets/tok.json", "/etc/passwd"] {
+        let (ct, body) = multipart(
+            "t.csv",
+            b"a,b\n1,2\n",
+            &[("to", "chunks"), ("chunk_tokenizer", bad)],
+        );
+        let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "for {bad:?}");
+    }
+}
+
+#[tokio::test]
+async fn explicit_hybrid_without_tokenizer_is_a_400() {
+    // Legacy both-chunkers mode silently skips hybrid when no tokenizer is
+    // installed; asking for hybrid outright must fail loudly instead. (The
+    // test env has no .models/chunk/tokenizer.json and no
+    // DOCLING_CHUNK_TOKENIZER; if one is installed, the request succeeds —
+    // accept both, but never a silent hierarchical-only 200.)
+    let (ct, body) = multipart(
+        "t.csv",
+        b"a,b\n1,2\n",
+        &[("to", "chunks"), ("chunker", "hybrid")],
+    );
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    if response.status() == StatusCode::OK {
+        let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+        assert!(v.get("hybrid").is_some(), "hybrid requested: {v}");
+        assert!(v.get("hierarchical").is_none());
+    } else {
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/docling/src/chunks.rs
+++ b/crates/docling/src/chunks.rs
@@ -4,9 +4,57 @@
 //! or `.models/chunk/tokenizer.json` as populated by
 //! `scripts/install/download_dependencies.sh` (requires the `chunking` build
 //! feature; `DOCLING_CHUNK_MAX_TOKENS` overrides the default budget of 256).
+//!
+//! Per-call [`ChunkOptions`] (#256, mirroring the fields of docling's
+//! service-datamodel `HybridChunkerOptions`) select a single chunker and
+//! override the environment-derived tokenizer/budget; the env knobs stay the
+//! operator-side defaults.
 
 use docling_core::chunker::{contextualize, DocChunk, HierarchicalChunker};
 use docling_core::DoclingDocument;
+
+/// Which chunker's records `to=chunks` returns (docling's service-datamodel
+/// `ChunkerType`, #256). `None` on [`ChunkOptions`] keeps the legacy "both"
+/// shape: hierarchical always, hybrid best-effort.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ChunkerKind {
+    Hierarchical,
+    Hybrid,
+}
+
+impl ChunkerKind {
+    /// Parse the wire value (`"hierarchical"` / `"hybrid"`, as in docling's
+    /// `ChunkerType` enum).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "hierarchical" => Ok(Self::Hierarchical),
+            "hybrid" => Ok(Self::Hybrid),
+            other => Err(format!(
+                "unknown chunker {other:?} (expected: hierarchical, hybrid)"
+            )),
+        }
+    }
+}
+
+/// Per-call chunking configuration (#256). Every field falls back to the
+/// environment-derived behavior [`chunk_records`] always had, so
+/// `ChunkOptions::default()` is exactly the legacy export.
+#[derive(Default, Clone, Debug)]
+pub struct ChunkOptions {
+    /// `Some` returns only that chunker's records (an explicit hybrid request
+    /// *fails* when no tokenizer is available instead of silently degrading);
+    /// `None` keeps the legacy both-chunkers shape.
+    pub chunker: Option<ChunkerKind>,
+    /// Explicit HuggingFace `tokenizer.json` path for the hybrid chunker —
+    /// overrides `DOCLING_CHUNK_TOKENIZER` and the `.models/chunk/` default.
+    pub tokenizer: Option<String>,
+    /// Hybrid chunk budget — overrides `DOCLING_CHUNK_MAX_TOKENS` (default
+    /// 256, docling's MiniLM budget).
+    pub max_tokens: Option<usize>,
+    /// Hybrid peer-merging (docling's `merge_peers`, default true); `None`
+    /// keeps the chunker default.
+    pub merge_peers: Option<bool>,
+}
 
 fn records(chunks: &[DocChunk]) -> serde_json::Value {
     serde_json::Value::Array(
@@ -27,29 +75,78 @@ fn records(chunks: &[DocChunk]) -> serde_json::Value {
 /// The chunk records for `document` as a JSON object
 /// (`{"hierarchical": [...], "hybrid": [...]?}`). Tokenizer problems don't
 /// fail the export — the hybrid records are skipped and the problem is
-/// reported through `warn`.
+/// reported through `warn`. Equivalent to [`chunk_records_with`] under
+/// `ChunkOptions::default()`.
 pub fn chunk_records(
     document: &DoclingDocument,
     warn: &mut dyn FnMut(String),
 ) -> serde_json::Value {
-    let hierarchical = HierarchicalChunker.chunk(document);
-    #[cfg_attr(not(feature = "chunking"), allow(unused_mut, unused_variables))]
-    let mut out = serde_json::json!({ "hierarchical": records(&hierarchical) });
+    chunk_records_with(document, &ChunkOptions::default(), warn)
+        .expect("default options never error")
+}
+
+/// [`chunk_records`] with per-call [`ChunkOptions`] (#256). Errors only on an
+/// *explicitly requested* configuration that cannot be honored: `chunker:
+/// hybrid` without a usable tokenizer (or in a build without the `chunking`
+/// feature). The legacy both-chunkers mode still degrades through `warn`.
+pub fn chunk_records_with(
+    document: &DoclingDocument,
+    options: &ChunkOptions,
+    warn: &mut dyn FnMut(String),
+) -> Result<serde_json::Value, String> {
+    let mut out = serde_json::json!({});
+    if options.chunker != Some(ChunkerKind::Hybrid) {
+        let hierarchical = HierarchicalChunker.chunk(document);
+        out["hierarchical"] = records(&hierarchical);
+    }
+    if options.chunker == Some(ChunkerKind::Hierarchical) {
+        return Ok(out);
+    }
 
     #[cfg(feature = "chunking")]
-    if let Some(tok_path) = docling_core::env::nonempty("DOCLING_CHUNK_TOKENIZER")
-        .or_else(|| docling_core::chunker::resolve_tokenizer_path(None).ok())
     {
-        let max_tokens = docling_core::env::parse("DOCLING_CHUNK_MAX_TOKENS").unwrap_or(256);
-        match docling_core::chunker::HuggingFaceTokenizer::from_file(&tok_path, max_tokens) {
-            Ok(tok) => {
-                let hybrid = docling_core::chunker::HybridChunker::new(tok).chunk(document);
-                out["hybrid"] = records(&hybrid);
+        let explicit = options.chunker == Some(ChunkerKind::Hybrid);
+        let tok_path = match options
+            .tokenizer
+            .clone()
+            .or_else(|| docling_core::env::nonempty("DOCLING_CHUNK_TOKENIZER"))
+        {
+            Some(p) => Some(p),
+            // In legacy mode a missing default tokenizer just skips the
+            // hybrid records (no warning — it was never configured); an
+            // explicit hybrid request surfaces the resolution error.
+            None => match docling_core::chunker::resolve_tokenizer_path(None) {
+                Ok(p) => Some(p),
+                Err(e) if explicit => return Err(e),
+                Err(_) => None,
+            },
+        };
+        if let Some(tok_path) = tok_path {
+            let max_tokens = options
+                .max_tokens
+                .or_else(|| docling_core::env::parse("DOCLING_CHUNK_MAX_TOKENS"))
+                .unwrap_or(256);
+            match docling_core::chunker::HuggingFaceTokenizer::from_file(&tok_path, max_tokens) {
+                Ok(tok) => {
+                    let mut chunker = docling_core::chunker::HybridChunker::new(tok);
+                    if let Some(mp) = options.merge_peers {
+                        chunker = chunker.with_merge_peers(mp);
+                    }
+                    out["hybrid"] = records(&chunker.chunk(document));
+                }
+                Err(e) if explicit => return Err(e),
+                Err(e) => warn(e),
             }
-            Err(e) => warn(e),
         }
     }
     #[cfg(not(feature = "chunking"))]
-    let _ = warn;
-    out
+    {
+        let _ = warn;
+        if options.chunker == Some(ChunkerKind::Hybrid) {
+            return Err(
+                "the hybrid chunker needs the `chunking` build feature (not enabled)".into(),
+            );
+        }
+    }
+    Ok(out)
 }

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -420,6 +420,22 @@ These are deliberate or unavoidable divergences, not bugs.
     `72 × scale` dpi, default 3); unset keeps the pinned 144 dpi baseline,
     so conformance snapshots never move.
 
+14. **Per-request chunking configuration** (docling 2.117–2.119
+    service-datamodel, #256): `to=chunks` accepts `chunker`
+    (`hierarchical`|`hybrid`, docling's `ChunkerType`; unset returns both),
+    `chunk_tokenizer` (a server-local *relative* `tokenizer.json` path —
+    absolute paths and `..` are rejected, unlike upstream's
+    fetch-any-HF-model semantics), `chunk_max_tokens` and
+    `chunk_merge_peers` on serve, with matching `--chunker`/`--chunk-*` CLI
+    flags; the `DOCLING_CHUNK_*` env knobs remain the operator defaults. An
+    explicit `chunker=hybrid` without a usable tokenizer fails loudly (400)
+    instead of the legacy silent skip. Out of the same sync window but *not*
+    ported: upstream's `do_pdf_heading_hierarchy` (`HeadingHierarchyModel`
+    — PDF section-header levels from bookmarks/numbering/font style; our
+    PDF path emits docling's pre-2.117 flat `##` levels, so the option has
+    nothing to switch yet) and `dclx` in the `ArtifactRef` union (only
+    meaningful once the sources/targets wire shape lands — #139).
+
 ---
 
 ## 5. Not migrated / out of scope


### PR DESCRIPTION
…ync (docling 2.117-2.119)

The #256 sync, item by item:

- Chunking options into request fields (the core): to=chunks now takes chunker (hierarchical|hybrid, docling's ChunkerType; unset keeps the legacy both-chunkers shape), chunk_tokenizer, chunk_max_tokens (docling's HybridChunkerOptions.max_tokens, default 256) and chunk_merge_peers (default true) — as query params, multipart fields and JSON keys, OpenAPI-documented, with matching CLI flags (--chunker, --chunk-tokenizer, --chunk-max-tokens, --no-chunk-merge-peers). The DOCLING_CHUNK_* env knobs stay the operator-side defaults. New docling::chunks::ChunkOptions + chunk_records_with carry the config; chunk_records keeps the legacy degrade-with-warning behavior, but an *explicitly requested* hybrid without a usable tokenizer now fails loudly (400 / CLI error) instead of silently returning hierarchical-only. Unlike upstream's fetch-any-HF-model tokenizer field, the request-side tokenizer is a server-local relative path — absolute paths and '..' are rejected up front, so requests select among operator-deployed tokenizers rather than reading arbitrary server files.

- PDF heading-level inference (verification requested by the issue): not present — our PDF path emits docling's pre-2.117 flat '##' section headers (assemble.rs), so upstream's do_pdf_heading_hierarchy / HeadingHierarchyModel (levels from bookmarks, numbering, font style) has nothing to switch yet; porting it is its own work item and moves conformance snapshots. Recorded in MIGRATION.md.

- dclx in the ArtifactRef union: deferred to the sources/targets wire shape (#139), as the issue itself anticipated.

Serve tests cover the single-chunker shape, unknown-chunker 400, tokenizer path-escape 400, and explicit-hybrid semantics.

Closes docling-project/docling.rs#256