### PR TITLE
fix(docker): ARM64 image builds — pdfium selected by TARGETARCH / mac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,15 @@ docker run --rm -v "$PWD:/data" docling-rs /data/input.pdf --to json
 ```
 
 The image converts PDFs/images fully offline; the model export (torch +
-`docling-ibm-models`) happens only at build time, never at runtime.
+`docling-ibm-models`) happens only at build time, never at runtime. Both
+`linux/amd64` and `linux/arm64` build (#281) — the pdfium prebuilt follows
+BuildKit's `TARGETARCH`, and `scripts/install/download_dependencies.sh`
+likewise picks the pdfium for the machine it runs on (pinned x64 from the
+models release; the bblanchon `arm64` prebuilt elsewhere):
+
+```bash
+docker buildx build --platform linux/arm64 -f examples/Dockerfile -t docling-rs .
+```
 
 ## Performance
 

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -9,6 +9,10 @@
 #
 # Build from the repository root:
 #   docker build -f examples/Dockerfile -t docling-rs .
+# Multi-arch (#281): the pdfium prebuilt is selected by BuildKit's TARGETARCH
+# (amd64 and arm64 are supported; everything else in the image is
+# arch-neutral or built from source), e.g. on/for an ARM64 host:
+#   docker buildx build --platform linux/arm64 -f examples/Dockerfile -t docling-rs .
 # Convert a document (Markdown to stdout):
 #   docker run --rm -v "$PWD:/data" docling-rs /data/input.pdf
 #
@@ -68,6 +72,12 @@ RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/wh
         docling-ibm-models onnxscript onnxruntime huggingface_hub \
         opencv-python-headless sympy pypdfium2 pillow numpy
 
+# TARGETARCH is set by BuildKit/buildx from --platform (amd64, arm64, …); a
+# classic single-arch build leaves it empty, so fall back to the stage's own
+# dpkg architecture. Maps onto pdfium-binaries' naming (amd64 -> x64), which
+# is the only arch-specific asset in this stage — the ONNX models and
+# tokenizer are architecture-neutral (#281).
+ARG TARGETARCH
 RUN true \
     # TableFormer encoder/decoder/bbox. Exports both decoder generations: the
     # #97 hoisted-KV step graph (decoder_kv.onnx — per-layer cross-attention
@@ -87,9 +97,14 @@ RUN true \
     # all-MiniLM-L6-v2 tokenizer — the hybrid chunker works out of the box
     && curl -fsSL -o /opt/models/chunk/tokenizer.json \
         "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" \
-    # pdfium prebuilt (page rasterization only)
+    # pdfium prebuilt (page rasterization only), arch-selected (#281)
+    && case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+        amd64) PDFIUM_ARCH=x64 ;; \
+        arm64) PDFIUM_ARCH=arm64 ;; \
+        *) echo "unsupported TARGETARCH '${TARGETARCH}' (amd64|arm64)" >&2; exit 1 ;; \
+    esac \
     && curl -fsSL -o /tmp/pdfium.tgz \
-        "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz" \
+        "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-${PDFIUM_ARCH}.tgz" \
     && tar xzf /tmp/pdfium.tgz -C /opt/pdfium \
     && rm /tmp/pdfium.tgz \
     && rm -rf /root/.cache/huggingface
@@ -123,8 +138,9 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# TARGET_CPU: empty (default) = portable x86-64 image; "x86-64-v3" = require
-# AVX2 (2013+ CPUs, most cloud fleets); "native" = tune for the build host
+# TARGET_CPU: empty (default) = portable image for the build platform
+# (x86-64 or arm64); "x86-64-v3" = require AVX2 (2013+ CPUs, most cloud
+# fleets — x86-64 builds only); "native" = tune for the build host
 # (only for images that run where they're built). Affects the Rust-side image
 # processing hot paths (resize, normalization); ONNX Runtime ships its own
 # runtime CPU dispatch either way.

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -56,8 +56,10 @@
 # doesn't host the int8 assets (older tag), a note explains how to produce
 # them locally with scripts/install/quantize_models.py.
 #
-# pdfium is Linux x64 only for now, matching what's hosted in the release; for
-# other platforms (or to build the models from source) see scripts/install/pdf_setup.sh.
+# pdfium: the models release hosts the pinned Linux x64 libpdfium.so
+# (the conformance build); on Linux arm64 the bblanchon prebuilt of the
+# same release line is fetched instead (#281). Other platforms (or building
+# the models from source): see scripts/install/pdf_setup.sh.
 #
 # Idempotent: skips files already on disk. Pass --force to re-fetch everything.
 set -eu
@@ -139,7 +141,35 @@ fetch_optional() { # <url> <dest> — ignore a missing/failed asset (sidecar fil
 }
 
 echo "fetching docling.rs ML dependencies from $BASE_URL"
-fetch "$BASE_URL/libpdfium.so" .pdfium/lib/libpdfium.so
+# pdfium by machine architecture (#281): x64 takes the release's pinned
+# conformance build; arm64 falls back to the bblanchon prebuilt (same source
+# the pinned x64 lib was built from). The tarball unpacks lib/libpdfium.so
+# into .pdfium/ directly.
+case "$(uname -m)" in
+  x86_64 | amd64)
+    fetch "$BASE_URL/libpdfium.so" .pdfium/lib/libpdfium.so
+    ;;
+  aarch64 | arm64)
+    if [ "$FORCE" = false ] && [ -f .pdfium/lib/libpdfium.so ]; then
+      echo "  = .pdfium/lib/libpdfium.so (already present)"
+    else
+      echo "  (arm64: pdfium from the bblanchon prebuilt — the pinned x64 build doesn't apply)"
+      # shellcheck disable=SC2086
+      if curl -fsSL $CURL_TIMEOUTS -o .pdfium/pdfium.tgz \
+          "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-arm64.tgz" 2>/dev/null; then
+        tar xzf .pdfium/pdfium.tgz -C .pdfium lib/libpdfium.so
+        rm -f .pdfium/pdfium.tgz
+        echo "  > .pdfium/lib/libpdfium.so"
+      else
+        rm -f .pdfium/pdfium.tgz
+        echo "  ! pdfium-linux-arm64.tgz not fetched (offline?) — PDF rasterization stays unavailable"
+      fi
+    fi
+    ;;
+  *)
+    echo "  (skipping pdfium: unsupported arch $(uname -m) — see scripts/install/pdf_setup.sh)"
+    ;;
+esac
 fetch "$BASE_URL/layout_heron.onnx" .models/layout_heron.onnx
 fetch "$BASE_URL/ocr_rec.onnx" .models/ocr_rec.onnx
 fetch "$BASE_URL/ppocr_keys_v1.txt" .models/ppocr_keys_v1.txt

--- a/scripts/install/pdf_setup.sh
+++ b/scripts/install/pdf_setup.sh
@@ -18,7 +18,19 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."   # docling.rs/
 mkdir -p .pdfium .models
 
-PLATFORM="${PDFIUM_PLATFORM:-linux-x64}"
+# pdfium-binaries platform: auto-detected from the host (#281);
+# $PDFIUM_PLATFORM overrides (e.g. a cross-arch fetch).
+detect_platform() {
+  case "$(uname -s)" in
+    Darwin) os=mac ;;
+    *) os=linux ;;
+  esac
+  case "$(uname -m)" in
+    aarch64 | arm64) echo "$os-arm64" ;;
+    *) echo "$os-x64" ;;
+  esac
+}
+PLATFORM="${PDFIUM_PLATFORM:-$(detect_platform)}"
 if [ ! -f .pdfium/lib/libpdfium.so ]; then
   echo "→ libpdfium ($PLATFORM)"
   curl -sSL -o /tmp/pdfium.tgz \


### PR DESCRIPTION
…hine arch

examples/Dockerfile hardcoded the pdfium-linux-x64 prebuilt, so a linux/arm64 image build (Apple Silicon, Graviton) got an x64 libpdfium.so and no working PDF rasterization. Everything else in the image is already arch-neutral (ONNX models, tokenizer) or built from source (the CLI; ort fetches the ONNX Runtime for the target arch), so pdfium was the only gap:

- examples/Dockerfile: ARG TARGETARCH (BuildKit sets it from --platform; a classic build falls back to the stage's dpkg architecture), mapped amd64 -> x64 / arm64 -> arm64 onto pdfium-binaries' naming — the reporter's approach, verified against the release asset (the pdfium-linux-arm64.tgz layout matches: lib/libpdfium.so, a real aarch64 ELF). Other arches fail the build with a clear message. TARGET_CPU docs updated (x86-64-v3 is x86-only; empty default is portable on both).

- scripts/install/download_dependencies.sh: pdfium now picks by uname -m — x64 keeps the models release's pinned conformance build, arm64 fetches the bblanchon prebuilt (with the usual idempotent-skip / --force semantics and a soft-fail note offline). This makes crates/docling-serve/Dockerfile build on arm64 too, unchanged.

- scripts/install/pdf_setup.sh: PDFIUM_PLATFORM now defaults from the host (linux/mac x x64/arm64) instead of hardcoded linux-x64; the env override stays.

README documents the buildx --platform linux/arm64 invocation.

Closes docling-project/docling.rs#281