### PR TITLE
feat(serve): cloud source/target passthrough — docling sources/target…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1569,7 @@ dependencies = [
  "docling-core",
  "http-body-util",
  "libc",
+ "object_store",
  "serde",
  "serde_json",
  "tokio",
@@ -1919,6 +1930,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431a4c31778fde52b4400de34975f219eeca55cc829a9de157cd743a5b230ecb"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2017,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,8 +2045,10 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2090,6 +2129,25 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -2276,6 +2334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2358,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2315,6 +2380,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3398,6 +3464,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5 0.10.6",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.5",
+ "reqwest",
+ "ring",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +3555,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3964,6 +4074,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -4339,6 +4459,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4351,6 +4473,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4358,12 +4481,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.9",
 ]
@@ -4497,7 +4622,7 @@ checksum = "70cc376c6ba1823ae229bacf8ad93c136d93524eab0e4e5e0e4f96b9c4e5b212"
 dependencies = [
  "log",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "rustls-webpki",
 ]
@@ -4508,11 +4633,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4641,7 +4778,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6165,6 +6315,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ enable them; the fetcher blocks private-IP targets
 (`DOCLING_RS_MAX_FETCH_BYTES`). The server binds loopback by default — front
 it with a policy proxy for anything wider.
 
+The JSON body also takes docling's service-datamodel `sources`/`target` shape
+(#139): `kind`-tagged `file` (base64) and `http` (URL + headers) sources, and —
+with the opt-in `cloud` cargo feature (feature-gated `object_store`) — `s3`,
+`azure_blob` and `google_cloud_storage` sources and output targets, coordinate
+fields mirroring upstream's models. A cloud target uploads each converted
+output as `<stem>.<ext>` under the prefix and answers with a
+`RemoteTargetResult` acknowledgment; everything outbound sits behind
+`--allow-url-fetch`. See the `s3_pipeline` example in `/openapi.yaml`.
+
 ## In the browser — `docling-wasm`
 
 The declarative converters (everything except the PDF/image/audio ML

--- a/crates/docling-serve/Cargo.toml
+++ b/crates/docling-serve/Cargo.toml
@@ -12,6 +12,11 @@ default = ["chunking"]
 # Tokenization-aware chunking: enables the hybrid chunk records in `to=chunks`
 # responses (hierarchical records work without it).
 chunking = ["docling/chunking"]
+# Cloud source/target passthrough (#139, upstream docling#3795): S3 / Azure
+# Blob / GCS request sources and output targets through `object_store`. Off
+# by default — the kinds still parse without it and answer a clear
+# rebuild-with-the-feature error.
+cloud = ["dep:object_store"]
 # GPU execution providers for the PDF/image ML pipeline (#74) — pass-through
 # to docling → docling-pdf; select at runtime with DOCLING_RS_EP.
 cuda = ["docling/cuda"]
@@ -32,6 +37,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "signal"] }
 tokio-stream = "0.1"
+# Cloud passthrough (#139): one uniform client for S3/GCS/Azure, only in the
+# graph under the opt-in `cloud` feature (it brings its own HTTP stack).
+object_store = { version = "0.12", features = ["aws", "azure", "gcp"], optional = true }
 # URL inputs are fetched with the same blocking client the converter already
 # uses for remote <img src> (keeps the dependency graph to a single HTTP stack).
 ureq = { version = "3", default-features = false, features = ["rustls", "gzip"] }

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -67,6 +67,16 @@
 //!   explicitly requested `chunker=hybrid` without a usable tokenizer is a
 //!   400 instead of the legacy silent skip
 //!
+//! A JSON body may also use docling's service-datamodel `sources`/`target`
+//! shape instead of the `{"url": …}` shorthand (#139, see `passthrough.rs`):
+//! `kind`-tagged sources (`file` base64 uploads, `http` URLs with headers,
+//! and — behind the `cloud` cargo feature — `s3` / `azure_blob` /
+//! `google_cloud_storage` prefixes) plus an optional `kind`-tagged output
+//! `target` (`inbody` default, or the same cloud stores: each converted
+//! output uploads as `<stem>.<ext>` under the prefix and the response is a
+//! `RemoteTargetResult` acknowledgment). Everything outbound — `http` and
+//! cloud alike — sits behind `--allow-url-fetch`.
+//!
 //! Markdown converts through the streaming serializer and the response body
 //! streams page by page (chunked transfer); `json`/`dclx`/`chunks` (and every
 //! batch/async result) buffer.
@@ -129,6 +139,8 @@ use docling::{
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::Semaphore;
+
+mod passthrough;
 
 /// Server configuration (see the binary's `--help` for the flag spellings).
 #[derive(Clone, Debug)]
@@ -473,13 +485,21 @@ impl ConvertOptions {
     }
 }
 
-/// JSON body for URL inputs.
-#[derive(Debug, Deserialize)]
+/// JSON body: the legacy `{"url": …}` shorthand, or docling's
+/// service-datamodel `sources`/`target` shape (#139) — exactly one of `url`
+/// and `sources` must be present.
+#[derive(Deserialize)]
 struct UrlRequest {
-    url: String,
+    url: Option<String>,
     /// Overrides the name (and thus format-selecting extension) taken from
-    /// the URL path's last segment.
+    /// the URL path's last segment (`url` shorthand only).
     file_name: Option<String>,
+    /// docling `kind`-tagged source items: `file`, `http`, `s3`,
+    /// `azure_blob`, `google_cloud_storage` (#139).
+    sources: Option<Vec<passthrough::SourceSpec>>,
+    /// docling `kind`-tagged output target; default `inbody` (the response
+    /// body, exactly as without a target).
+    target: Option<passthrough::TargetSpec>,
     #[serde(flatten)]
     options: ConvertOptions,
 }
@@ -527,15 +547,24 @@ impl IntoResponse for ApiError {
 type SourceItem = Result<SourceDocument, (String, ApiError)>;
 
 /// Parse a conversion request body — `multipart/form-data` uploads (one or
-/// more `file` parts, #182 batch) or an `application/json` `{"url": …}` — into
-/// sources plus the merged options. Shared by the sync and async endpoints so
-/// both accept exactly the same requests (and reject bad ones synchronously).
+/// more `file` parts, #182 batch) or an `application/json` body (`{"url": …}`
+/// or docling's `sources`/`target` shape, #139) — into sources, the merged
+/// options and the optional cloud output target. Shared by the sync and
+/// async endpoints so both accept exactly the same requests (and reject bad
+/// ones synchronously).
 async fn parse_convert_request(
     state: &Arc<AppState>,
     query: ConvertOptions,
     headers: HeaderMap,
     body: axum::extract::Request,
-) -> Result<(Vec<SourceItem>, ConvertOptions), ApiError> {
+) -> Result<
+    (
+        Vec<SourceItem>,
+        ConvertOptions,
+        Option<passthrough::CloudCoords>,
+    ),
+    ApiError,
+> {
     let content_type = headers
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
@@ -546,32 +575,132 @@ async fn parse_convert_request(
         let multipart = Multipart::from_request(body, &())
             .await
             .map_err(|e| ApiError::Bad(format!("bad multipart body: {e}")))?;
-        read_multipart(multipart, query).await
+        let (sources, options) = read_multipart(multipart, query).await?;
+        Ok((sources, options, None))
     } else if content_type.starts_with("application/json") {
         let bytes = axum::body::to_bytes(body.into_body(), state.cfg.max_body_bytes)
             .await
             .map_err(|e| ApiError::Bad(format!("bad body: {e}")))?;
         let req: UrlRequest = serde_json::from_slice(&bytes)
             .map_err(|e| ApiError::Bad(format!("bad JSON body: {e}")))?;
-        if !state.cfg.allow_url_fetch {
-            return Err(ApiError::Unsupported(
-                "URL inputs are disabled; start docling-serve with --allow-url-fetch \
-                 (SSRF surface — see docs/SECURITY.md), or upload the file instead"
-                    .into(),
-            ));
-        }
         let options = req.options.clone().merge_over(query);
-        let url = req.url.clone();
-        let name = req.file_name.clone();
-        let source = tokio::task::spawn_blocking(move || fetch_url(&url, name.as_deref()))
-            .await
-            .map_err(|e| ApiError::Internal(format!("fetch task: {e}")))??;
-        Ok((vec![Ok(source)], options))
+        let target = match req.target {
+            None | Some(passthrough::TargetSpec::Inbody) => None,
+            Some(spec) => {
+                require_outbound(state, "cloud targets")?;
+                Some(match spec {
+                    passthrough::TargetSpec::S3(c) => passthrough::CloudCoords::S3(c),
+                    passthrough::TargetSpec::AzureBlob(c) => passthrough::CloudCoords::Azure(c),
+                    passthrough::TargetSpec::GoogleCloudStorage(c) => {
+                        passthrough::CloudCoords::Gcs(c)
+                    }
+                    passthrough::TargetSpec::Inbody => unreachable!("matched above"),
+                })
+            }
+        };
+        let sources = match (req.url, req.sources) {
+            (Some(url), None) => {
+                require_outbound(state, "URL inputs")?;
+                let name = req.file_name.clone();
+                let source =
+                    tokio::task::spawn_blocking(move || fetch_url(&url, name.as_deref(), &[]))
+                        .await
+                        .map_err(|e| ApiError::Internal(format!("fetch task: {e}")))??;
+                vec![Ok(source)]
+            }
+            (None, Some(specs)) => parse_source_specs(state, specs).await?,
+            (Some(_), Some(_)) => {
+                return Err(ApiError::Bad(
+                    "pass either \"url\" or \"sources\", not both".into(),
+                ))
+            }
+            (None, None) => {
+                return Err(ApiError::Bad(
+                    "JSON body needs \"url\" or a non-empty \"sources\" array".into(),
+                ))
+            }
+        };
+        Ok((sources, options, target))
     } else {
         Err(ApiError::Bad(
             "expected multipart/form-data (file upload) or application/json ({\"url\": …})".into(),
         ))
     }
+}
+
+/// Outbound access (URL fetch, cloud stores) is one opt-in: the server-wide
+/// `--allow-url-fetch` flag (SSRF surface — docs/SECURITY.md).
+fn require_outbound(state: &Arc<AppState>, what: &str) -> Result<(), ApiError> {
+    if state.cfg.allow_url_fetch {
+        Ok(())
+    } else {
+        Err(ApiError::Unsupported(format!(
+            "{what} are disabled; start docling-serve with --allow-url-fetch \
+             (SSRF surface — see docs/SECURITY.md), or upload the file instead"
+        )))
+    }
+}
+
+/// Materialize docling-shaped `sources[]` items (#139) into [`SourceItem`]s.
+/// A bad `file` item fails only itself (batch semantics, like a bad upload);
+/// an unreachable store or URL fails the request — there is nothing partial
+/// to convert.
+async fn parse_source_specs(
+    state: &Arc<AppState>,
+    specs: Vec<passthrough::SourceSpec>,
+) -> Result<Vec<SourceItem>, ApiError> {
+    if specs.is_empty() {
+        return Err(ApiError::Bad("\"sources\" must not be empty".into()));
+    }
+    let mut items: Vec<SourceItem> = Vec::new();
+    for spec in specs {
+        match spec {
+            passthrough::SourceSpec::File {
+                base64_string,
+                filename,
+            } => {
+                let item = match docling::base64::decode(base64_string.trim()) {
+                    Some(bytes) => {
+                        source_from_named_bytes(&filename, bytes).map_err(|e| (filename.clone(), e))
+                    }
+                    None => Err((
+                        filename.clone(),
+                        ApiError::Bad(format!("file source {filename:?}: bad base64")),
+                    )),
+                };
+                items.push(item);
+            }
+            passthrough::SourceSpec::Http { url, headers } => {
+                require_outbound(state, "URL inputs")?;
+                let header_vec: Vec<(String, String)> = headers.into_iter().collect();
+                let source =
+                    tokio::task::spawn_blocking(move || fetch_url(&url, None, &header_vec))
+                        .await
+                        .map_err(|e| ApiError::Internal(format!("fetch task: {e}")))??;
+                items.push(Ok(source));
+            }
+            spec @ (passthrough::SourceSpec::S3(_)
+            | passthrough::SourceSpec::AzureBlob(_)
+            | passthrough::SourceSpec::GoogleCloudStorage(_)) => {
+                require_outbound(state, "cloud sources")?;
+                let coords = match spec {
+                    passthrough::SourceSpec::S3(c) => passthrough::CloudCoords::S3(c),
+                    passthrough::SourceSpec::AzureBlob(c) => passthrough::CloudCoords::Azure(c),
+                    passthrough::SourceSpec::GoogleCloudStorage(c) => {
+                        passthrough::CloudCoords::Gcs(c)
+                    }
+                    _ => unreachable!("matched above"),
+                };
+                let fetched = passthrough::fetch_sources(&coords)
+                    .await
+                    .map_err(ApiError::Bad)?;
+                for (name, bytes) in fetched {
+                    items.push(source_from_named_bytes(&name, bytes).map_err(|e| (name, e)));
+                }
+            }
+        }
+    }
+    Ok(items)
 }
 
 /// Validate the `to` / `images` options (shared by sync and async so an async
@@ -646,8 +775,9 @@ async fn convert(
     headers: HeaderMap,
     body: axum::extract::Request,
 ) -> Result<Response, ApiError> {
-    let (sources, options) = parse_convert_request(&state, query, headers, body).await?;
+    let (sources, options, target) = parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    validate_target(&to, target.as_ref())?;
     // Admission control (#263): shed load before taking a conversion slot.
     if let Some(msg) = state.overloaded() {
         return Err(ApiError::Overloaded(msg));
@@ -664,9 +794,10 @@ async fn convert(
         .map_err(|e| ApiError::Internal(format!("semaphore: {e}")))?;
 
     // A single Markdown conversion streams; everything else (other formats,
-    // #182 batches — which need per-item framing) buffers.
+    // #182 batches — which need per-item framing, and cloud targets — whose
+    // outputs leave through the store, #139) buffers.
     let is_markdown = matches!(to.as_str(), "md" | "markdown");
-    if is_markdown && sources.len() == 1 {
+    if is_markdown && sources.len() == 1 && target.is_none() {
         let source = sources
             .into_iter()
             .next()
@@ -676,8 +807,17 @@ async fn convert(
     }
 
     let st = state.clone();
+    let rt = tokio::runtime::Handle::current();
     let stored = tokio::task::spawn_blocking(move || {
-        let out = run_conversion(&st, sources, &options, &to, image_mode);
+        let out = run_conversion(
+            &st,
+            sources,
+            &options,
+            &to,
+            image_mode,
+            target.as_ref(),
+            &rt,
+        );
         trim_heap();
         out
     })
@@ -685,6 +825,17 @@ async fn convert(
     .map_err(|e| ApiError::Internal(format!("convert task: {e}")))?;
     drop(permit);
     Ok(stored?.into_response())
+}
+
+/// A cloud target combines with every buffered output format except
+/// `to=images` (page PNGs are a debugging aid, not a pipeline artifact).
+fn validate_target(to: &str, target: Option<&passthrough::CloudCoords>) -> Result<(), ApiError> {
+    if target.is_some() && to == "images" {
+        return Err(ApiError::Bad(
+            "to=images does not combine with a cloud target".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// One async conversion job (#182).
@@ -748,8 +899,10 @@ async fn convert_async(
     headers: HeaderMap,
     body: axum::extract::Request,
 ) -> Result<Response, ApiError> {
-    let (mut sources, options) = parse_convert_request(&state, query, headers, body).await?;
+    let (mut sources, options, target) =
+        parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    validate_target(&to, target.as_ref())?;
     // Admission control (#263) applies to async submissions too — a queued
     // job holds its upload bytes and will run into the same ceiling.
     if let Some(msg) = state.overloaded() {
@@ -801,8 +954,9 @@ async fn convert_async(
         }
         let stx = st.clone();
         let opts = options;
+        let rt = tokio::runtime::Handle::current();
         let outcome = tokio::task::spawn_blocking(move || {
-            let out = run_conversion(&stx, sources, &opts, &to, image_mode);
+            let out = run_conversion(&stx, sources, &opts, &to, image_mode, target.as_ref(), &rt);
             trim_heap();
             out
         })
@@ -923,14 +1077,24 @@ impl StoredResponse {
 /// Convert one or more sources on the current (blocking) thread and serialize
 /// the result. A single source renders as the plain output format; multiple
 /// sources (#182 batch) render as a JSON results array with per-item status,
-/// so one bad file fails its item, not the whole batch.
+/// so one bad file fails its item, not the whole batch. With a cloud
+/// `target` (#139) every rendered output is uploaded instead and the
+/// response is a `RemoteTargetResult` acknowledgment (uploads run on the
+/// runtime `rt` — `Handle::block_on` is the sanctioned bridge from a
+/// blocking worker).
+#[allow(clippy::too_many_arguments)]
 fn run_conversion(
     state: &AppState,
     sources: Vec<SourceItem>,
     options: &ConvertOptions,
     to: &str,
     image_mode: ImageMode,
+    target: Option<&passthrough::CloudCoords>,
+    rt: &tokio::runtime::Handle,
 ) -> Result<StoredResponse, ApiError> {
+    if let Some(coords) = target {
+        return run_conversion_to_target(state, sources, options, to, image_mode, coords, rt);
+    }
     if sources.len() == 1 {
         let source = sources
             .into_iter()
@@ -995,6 +1159,87 @@ fn run_conversion(
         confidence: None,
         body: serde_json::to_vec_pretty(&json!({ "results": items }))
             .expect("batch JSON serializes"),
+    })
+}
+
+/// The #139 cloud-target path: convert each source, upload its rendered
+/// output as `<stem>.<ext>` under the target's prefix, answer with docling's
+/// `RemoteTargetResult` kind plus per-item detail. Batch semantics
+/// throughout — a failing item (conversion or upload) fails only itself.
+fn run_conversion_to_target(
+    state: &AppState,
+    sources: Vec<SourceItem>,
+    options: &ConvertOptions,
+    to: &str,
+    image_mode: ImageMode,
+    coords: &passthrough::CloudCoords,
+    rt: &tokio::runtime::Handle,
+) -> Result<StoredResponse, ApiError> {
+    let ext = match to {
+        "md" | "markdown" => "md",
+        "json" => "json",
+        "chunks" => "chunks.json",
+        "dclx" => "dclx",
+        _ => unreachable!("validated above"),
+    };
+    let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let items: Vec<serde_json::Value> = sources
+        .into_iter()
+        .map(|item| {
+            let source = match item {
+                Ok(source) => source,
+                Err((name, e)) => {
+                    return json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    })
+                }
+            };
+            let name = source.name.clone();
+            let rendered = convert_document(state, source, options)
+                .and_then(|doc| render_stored(state, to, image_mode, &name, &doc, options));
+            let stored = match rendered {
+                Ok(stored) => stored,
+                Err(e) => {
+                    return json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    })
+                }
+            };
+            // `<stem>.<ext>` mirrors the CLI batch naming; a duplicate stem
+            // in one request gets `-2`, `-3`, … instead of overwriting.
+            let stem = std::path::Path::new(&name)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "document".into());
+            let mut key = format!("{stem}.{ext}");
+            let mut n = 1;
+            while !used.insert(key.clone()) {
+                n += 1;
+                key = format!("{stem}-{n}.{ext}");
+            }
+            match rt.block_on(passthrough::put_object(coords, &key, stored.body)) {
+                Ok(()) => json!({ "name": name, "status": "success", "key": key }),
+                Err(e) => json!({ "name": name, "status": "failure", "error": e }),
+            }
+        })
+        .collect();
+    Ok(StoredResponse {
+        content_type: "application/json",
+        disposition: None,
+        confidence: None,
+        // Upstream's RemoteTargetResult is the bare kind ("no content, the
+        // result has been pushed to a remote target"); the credential-free
+        // target display and per-item outcomes ride along as extra keys.
+        body: serde_json::to_vec_pretty(&json!({
+            "kind": "RemoteTargetResult",
+            "target": coords.display(),
+            "results": items,
+        }))
+        .expect("target ack serializes"),
     })
 }
 
@@ -1487,7 +1732,11 @@ fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
 
 /// Fetch a URL input (blocking; run on the blocking pool). The name comes
 /// from `file_name` or the URL path's last segment.
-fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiError> {
+fn fetch_url(
+    url: &str,
+    file_name: Option<&str>,
+    headers: &[(String, String)],
+) -> Result<SourceDocument, ApiError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(ApiError::Bad(format!("unsupported URL scheme in '{url}'")));
     }
@@ -1529,8 +1778,13 @@ fn fetch_url(url: &str, file_name: Option<&str>) -> Result<SourceDocument, ApiEr
         .timeout_global(Some(std::time::Duration::from_secs(300)))
         .build()
         .into();
-    let mut response = agent
-        .get(url)
+    // Request headers ride along verbatim (docling's `HttpSource.headers`,
+    // #139 — auth tokens for protected origins).
+    let mut request = agent.get(url);
+    for (k, v) in headers {
+        request = request.header(k, v);
+    }
+    let mut response = request
         .call()
         .map_err(|e| ApiError::Bad(format!("fetching {url}: {e}")))?;
     // Kept for format detection when the URL/name has no usable extension.

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -112,22 +112,45 @@ paths:
             schema:
               allOf:
                 - type: object
-                  required: [url]
                   properties:
                     url:
                       type: string
                       format: uri
                       description: >
-                        Source URL. Honored only when the server runs with
+                        Source URL shorthand (mutually exclusive with `sources`).
+                        Honored only when the server runs with
                         `--allow-url-fetch`, otherwise the request is rejected.
                     file_name:
                       type: string
                       description: Overrides the format-selecting name taken from the URL path.
+                    sources:
+                      type: array
+                      minItems: 1
+                      items: { $ref: "#/components/schemas/SourceSpec" }
+                      description: >
+                        docling service-datamodel sources (#139) — mutually
+                        exclusive with `url`. `http` and the cloud kinds need
+                        `--allow-url-fetch`; cloud kinds additionally need a
+                        server built with the `cloud` cargo feature.
+                    target:
+                      $ref: "#/components/schemas/TargetSpec"
                 - $ref: "#/components/schemas/Options"
             examples:
               markdown:
                 summary: URL to Markdown
                 value: { url: "https://example.com/doc.pdf", to: "md" }
+              s3_pipeline:
+                summary: Convert an S3 prefix into another S3 prefix (#139)
+                value:
+                  sources:
+                    - { kind: s3, endpoint: "s3.us-east-2.amazonaws.com",
+                        access_key: "…", secret_key: "…", bucket: "in",
+                        key_prefix: "reports/", max_num_elements: 25 }
+                  target:
+                    { kind: s3, endpoint: "s3.us-east-2.amazonaws.com",
+                      access_key: "…", secret_key: "…", bucket: "out",
+                      key_prefix: "converted/" }
+                  to: "json"
       responses:
         "200":
           description: The converted document.
@@ -505,6 +528,37 @@ components:
         groups: { type: array, items: { type: object } }
         tables: { type: array, items: { type: object } }
         pictures: { type: array, items: { type: object } }
+    SourceSpec:
+      type: object
+      required: [kind]
+      description: >
+        docling `kind`-tagged source (#139). `file`: {base64_string, filename}.
+        `http`: {url, headers?}. `s3`: {endpoint, access_key, secret_key,
+        bucket, key_prefix?, verify_ssl?, max_num_elements?}. `azure_blob`:
+        {account_name, container, connection_string, blob_prefix?,
+        max_num_elements?}. `google_cloud_storage`: {bucket, key_prefix?,
+        project?, service_account_key?, max_num_elements?}. Field names mirror
+        docling's service-datamodel models; credentials ride in the request
+        (trusted-client + TLS assumption, as upstream).
+      properties:
+        kind:
+          type: string
+          enum: [file, http, s3, azure_blob, google_cloud_storage]
+      additionalProperties: true
+    TargetSpec:
+      type: object
+      required: [kind]
+      description: >
+        docling `kind`-tagged output target (#139): `inbody` (default — the
+        response body) or a cloud store with the same coordinate fields as the
+        matching source kind; each converted document uploads as
+        `<stem>.<ext>` under the prefix and the response is a
+        `RemoteTargetResult` acknowledgment with per-item outcomes.
+      properties:
+        kind:
+          type: string
+          enum: [inbody, s3, azure_blob, google_cloud_storage]
+      additionalProperties: true
     Chunker:
       type: string
       enum: [hierarchical, hybrid]

--- a/crates/docling-serve/src/passthrough.rs
+++ b/crates/docling-serve/src/passthrough.rs
@@ -1,0 +1,323 @@
+//! Cloud source/target passthrough (#139, upstream docling#3795).
+//!
+//! The JSON convert body accepts docling's service-datamodel `sources` /
+//! `target` wire shape: `kind`-tagged source items (`file`, `http`, `s3`,
+//! `azure_blob`, `google_cloud_storage` — field names mirror upstream's
+//! `FileSource`/`HttpSource`/`*Coordinates` models) and a `kind`-tagged
+//! output target (`inbody` default, or the same three cloud stores). The
+//! cloud stores go through the `object_store` crate behind the opt-in
+//! `cloud` cargo feature; without it the kinds still *parse* and answer a
+//! clear "rebuild with --features cloud" error instead of a serde puzzle.
+//!
+//! Deliberately not covered (documented in MIGRATION.md): `google_drive`
+//! (OAuth flows, no object_store backend), and the jobkit-only targets
+//! (`zip`, `put`, `presigned_url`) — an unknown `kind` is a 400 listing
+//! the supported ones. Credentials ride in the request exactly as they do
+//! upstream: passthrough assumes a trusted client and TLS, and the whole
+//! surface sits behind `--allow-url-fetch` like every other outbound
+//! fetch this server makes.
+
+use serde::Deserialize;
+
+fn default_true() -> bool {
+    true
+}
+
+/// Upstream `S3Coordinates` (docling.datamodel.service.sources), field for
+/// field. `endpoint` is host[:port] without protocol; `verify_ssl: false`
+/// selects plain http (docling hands it to boto3 the same way).
+#[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+pub struct S3Coordinates {
+    pub endpoint: String,
+    #[serde(default = "default_true")]
+    pub verify_ssl: bool,
+    pub access_key: String,
+    pub secret_key: String,
+    pub bucket: String,
+    #[serde(default)]
+    pub key_prefix: String,
+    #[serde(default)]
+    pub max_num_elements: Option<usize>,
+}
+
+/// Upstream `AzureBlobCoordinates`. The connection string is parsed for
+/// `AccountKey=`/`SharedAccessSignature=` — the two auth shapes the Azure
+/// portal hands out.
+#[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+pub struct AzureBlobCoordinates {
+    pub account_name: String,
+    pub container: String,
+    pub connection_string: String,
+    #[serde(default)]
+    pub blob_prefix: String,
+    #[serde(default)]
+    pub max_num_elements: Option<usize>,
+}
+
+/// Upstream `GoogleCloudStorageCoordinates`. `service_account_key` is the
+/// standard service-account JSON (upstream models its fields; any JSON
+/// object with the usual keys is accepted here) — omitted, Application
+/// Default Credentials apply, as upstream documents.
+#[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+pub struct GcsCoordinates {
+    pub bucket: String,
+    #[serde(default)]
+    pub key_prefix: String,
+    #[serde(default)]
+    pub max_num_elements: Option<usize>,
+    /// Accepted for wire parity; object_store takes quota attribution from
+    /// the credentials, so nothing reads it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub service_account_key: Option<serde_json::Value>,
+}
+
+/// One `sources[]` item — docling's `kind`-discriminated source union.
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SourceSpec {
+    /// Upstream `FileSource`: base64 bytes + the filename that selects the
+    /// input format. Needs no network and no feature gate.
+    File {
+        base64_string: String,
+        filename: String,
+    },
+    /// Upstream `HttpSource`: URL plus request headers (auth tokens etc.).
+    Http {
+        url: String,
+        #[serde(default)]
+        headers: std::collections::BTreeMap<String, String>,
+    },
+    S3(S3Coordinates),
+    AzureBlob(AzureBlobCoordinates),
+    GoogleCloudStorage(GcsCoordinates),
+}
+
+/// The `target` — docling's `kind`-discriminated target union (the subset
+/// with an object-store backend, plus the `inbody` default).
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TargetSpec {
+    Inbody,
+    S3(S3Coordinates),
+    AzureBlob(AzureBlobCoordinates),
+    GoogleCloudStorage(GcsCoordinates),
+}
+
+/// A cloud store reference: coordinates + the key prefix reads list under
+/// and writes prepend.
+pub enum CloudCoords {
+    S3(S3Coordinates),
+    Azure(AzureBlobCoordinates),
+    Gcs(GcsCoordinates),
+}
+
+#[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+impl CloudCoords {
+    pub fn prefix(&self) -> &str {
+        match self {
+            CloudCoords::S3(c) => &c.key_prefix,
+            CloudCoords::Azure(c) => &c.blob_prefix,
+            CloudCoords::Gcs(c) => &c.key_prefix,
+        }
+    }
+
+    fn max_num_elements(&self) -> Option<usize> {
+        match self {
+            CloudCoords::S3(c) => c.max_num_elements,
+            CloudCoords::Azure(c) => c.max_num_elements,
+            CloudCoords::Gcs(c) => c.max_num_elements,
+        }
+    }
+
+    /// Credential-free display form for responses/errors,
+    /// e.g. `s3://bucket/prefix`.
+    pub fn display(&self) -> String {
+        match self {
+            CloudCoords::S3(c) => format!("s3://{}/{}", c.bucket, c.key_prefix),
+            CloudCoords::Azure(c) => {
+                format!(
+                    "azure://{}/{}/{}",
+                    c.account_name, c.container, c.blob_prefix
+                )
+            }
+            CloudCoords::Gcs(c) => format!("gs://{}/{}", c.bucket, c.key_prefix),
+        }
+    }
+}
+
+#[cfg(feature = "cloud")]
+mod cloud {
+    use super::CloudCoords;
+    use object_store::path::Path as StorePath;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+    use tokio_stream::StreamExt;
+
+    /// How many objects a prefix may expand to when the request doesn't
+    /// bound it — matches the multipart path's "a request is one batch"
+    /// scale, not a bucket crawl.
+    const DEFAULT_MAX_ELEMENTS: usize = 100;
+
+    fn build(coords: &CloudCoords) -> Result<Arc<dyn ObjectStore>, String> {
+        match coords {
+            CloudCoords::S3(c) => {
+                let scheme = if c.verify_ssl { "https" } else { "http" };
+                // The endpoint carries the region for AWS-style hosts
+                // (s3.us-east-2.amazonaws.com); other S3 implementations
+                // ignore the signing region, so a lenient parse + default
+                // keeps MinIO/IBM COS endpoints working.
+                let region = c
+                    .endpoint
+                    .split('.')
+                    .nth(1)
+                    .filter(|s| s.contains('-'))
+                    .unwrap_or("us-east-1");
+                object_store::aws::AmazonS3Builder::new()
+                    .with_endpoint(format!("{scheme}://{}", c.endpoint))
+                    .with_allow_http(!c.verify_ssl)
+                    .with_region(region)
+                    .with_bucket_name(&c.bucket)
+                    .with_access_key_id(&c.access_key)
+                    .with_secret_access_key(&c.secret_key)
+                    .build()
+                    .map(|s| Arc::new(s) as Arc<dyn ObjectStore>)
+                    .map_err(|e| format!("s3 store: {e}"))
+            }
+            CloudCoords::Azure(c) => {
+                let mut builder = object_store::azure::MicrosoftAzureBuilder::new()
+                    .with_account(&c.account_name)
+                    .with_container_name(&c.container);
+                // The portal's connection strings carry either an
+                // AccountKey or a SharedAccessSignature.
+                let mut authed = false;
+                for part in c.connection_string.split(';') {
+                    if let Some(key) = part.strip_prefix("AccountKey=") {
+                        builder = builder.with_access_key(key);
+                        authed = true;
+                    } else if let Some(sas) = part.strip_prefix("SharedAccessSignature=") {
+                        builder =
+                            builder.with_config(object_store::azure::AzureConfigKey::SasKey, sas);
+                        authed = true;
+                    }
+                }
+                if !authed {
+                    return Err("azure connection_string carries neither AccountKey= nor \
+                         SharedAccessSignature="
+                        .into());
+                }
+                builder
+                    .build()
+                    .map(|s| Arc::new(s) as Arc<dyn ObjectStore>)
+                    .map_err(|e| format!("azure store: {e}"))
+            }
+            CloudCoords::Gcs(c) => {
+                let mut builder =
+                    object_store::gcp::GoogleCloudStorageBuilder::new().with_bucket_name(&c.bucket);
+                if let Some(sa) = &c.service_account_key {
+                    builder = builder.with_service_account_key(sa.to_string());
+                }
+                // ADC applies when no key is passed (object_store reads
+                // GOOGLE_APPLICATION_CREDENTIALS / metadata itself);
+                // `project` only matters for quota attribution, which the
+                // XML/JSON storage APIs take from the credentials.
+                builder
+                    .build()
+                    .map(|s| Arc::new(s) as Arc<dyn ObjectStore>)
+                    .map_err(|e| format!("gcs store: {e}"))
+            }
+        }
+    }
+
+    /// List `prefix` (bounded by `max_num_elements`, default
+    /// [`DEFAULT_MAX_ELEMENTS`]) and download each object. Names are the
+    /// key's last segment — what format detection runs on.
+    pub async fn fetch_sources(coords: &CloudCoords) -> Result<Vec<(String, Vec<u8>)>, String> {
+        let store = build(coords)?;
+        let max = coords.max_num_elements().unwrap_or(DEFAULT_MAX_ELEMENTS);
+        let prefix = coords.prefix().trim_matches('/').to_string();
+        let list_prefix = (!prefix.is_empty()).then(|| StorePath::from(prefix.as_str()));
+        let mut keys: Vec<StorePath> = Vec::new();
+        {
+            let mut listing = store.list(list_prefix.as_ref());
+            while let Some(meta) = listing.next().await {
+                let meta = meta.map_err(|e| format!("listing {}: {e}", coords.display()))?;
+                keys.push(meta.location);
+                if keys.len() >= max {
+                    break;
+                }
+            }
+        }
+        if keys.is_empty() {
+            return Err(format!("no objects under {}", coords.display()));
+        }
+        // Deterministic order for reproducible batch responses.
+        keys.sort();
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            let bytes = store
+                .get(&key)
+                .await
+                .map_err(|e| format!("fetching {key}: {e}"))?
+                .bytes()
+                .await
+                .map_err(|e| format!("reading {key}: {e}"))?;
+            let name = key
+                .filename()
+                .map(str::to_string)
+                .unwrap_or_else(|| key.to_string());
+            out.push((name, bytes.to_vec()));
+        }
+        Ok(out)
+    }
+
+    /// Upload one rendered output under the target's prefix.
+    pub async fn put_object(coords: &CloudCoords, key: &str, bytes: Vec<u8>) -> Result<(), String> {
+        let store = build(coords)?;
+        let prefix = coords.prefix().trim_matches('/');
+        let full = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}/{key}")
+        };
+        store
+            .put(&StorePath::from(full.as_str()), bytes.into())
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("uploading {key} to {}: {e}", coords.display()))
+    }
+}
+
+#[cfg(feature = "cloud")]
+pub use cloud::{fetch_sources, put_object};
+
+#[cfg(not(feature = "cloud"))]
+mod no_cloud {
+    use super::CloudCoords;
+
+    const MSG: &str = "cloud sources/targets need the `cloud` build feature — rebuild \
+                       docling-serve with `--features cloud` (feature-gated object_store, #139)";
+
+    pub async fn fetch_sources(_coords: &CloudCoords) -> Result<Vec<(String, Vec<u8>)>, String> {
+        Err(MSG.into())
+    }
+
+    pub async fn put_object(
+        _coords: &CloudCoords,
+        _key: &str,
+        _bytes: Vec<u8>,
+    ) -> Result<(), String> {
+        Err(MSG.into())
+    }
+}
+
+#[cfg(not(feature = "cloud"))]
+pub use no_cloud::{fetch_sources, put_object};

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -829,3 +829,127 @@ async fn explicit_hybrid_without_tokenizer_is_a_400() {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }
+
+// --- #139: docling sources/target passthrough ------------------------------
+
+fn json_convert(body: &str, allow_fetch: bool) -> Request<Body> {
+    let _ = allow_fetch;
+    convert_request("application/json", body.as_bytes().to_vec(), "")
+}
+
+#[tokio::test]
+async fn file_sources_convert_without_any_gate() {
+    // kind=file is base64 in the body — no outbound access, no gate.
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [
+            {{"kind": "file", "base64_string": "{b64}", "filename": "one.csv"}},
+            {{"kind": "file", "base64_string": "{b64}", "filename": "two.csv"}}
+        ], "to": "json"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    let results = v["results"].as_array().expect("batch shape");
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|r| r["status"] == "success"), "{v}");
+}
+
+fn docling_b64(text: &str) -> String {
+    // Tiny local base64 (no test dep): RFC 4648 standard alphabet.
+    const A: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let bytes = text.as_bytes();
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+        out.push(A[(n >> 18) as usize & 63] as char);
+        out.push(A[(n >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            A[(n >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            A[n as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[tokio::test]
+async fn url_and_sources_together_is_a_400() {
+    let b64 = docling_b64("x");
+    let body = format!(
+        r#"{{"url": "https://example.com/a.md",
+            "sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "a.csv"}}]}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn unknown_source_kind_is_a_400() {
+    let body = r#"{"sources": [{"kind": "google_drive", "document_id": "x"}]}"#;
+    let response = app().oneshot(json_convert(body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let msg = body_string(response).await;
+    assert!(
+        msg.contains("unknown variant") && msg.contains("google_cloud_storage"),
+        "should list the supported kinds: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn cloud_source_and_target_are_gated_behind_allow_url_fetch() {
+    // Both directions of cloud passthrough sit behind --allow-url-fetch.
+    let s3 = r#"{"kind": "s3", "endpoint": "s3.us-east-2.amazonaws.com",
+                 "access_key": "k", "secret_key": "s", "bucket": "b"}"#;
+    let body = format!(r#"{{"sources": [{s3}]}}"#);
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "a.csv"}}],
+            "target": {s3}}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[cfg(not(feature = "cloud"))]
+#[tokio::test]
+async fn cloud_kind_without_the_feature_names_the_rebuild() {
+    // Gate open, feature absent: the error must say how to get the feature,
+    // not fail as a mystery.
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let body = r#"{"sources": [{"kind": "s3", "endpoint": "s3.us-east-2.amazonaws.com",
+                   "access_key": "k", "secret_key": "s", "bucket": "b"}]}"#;
+    let response = router(cfg).oneshot(json_convert(body, true)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let msg = body_string(response).await;
+    assert!(msg.contains("--features cloud"), "{msg}");
+}
+
+#[tokio::test]
+async fn explicit_inbody_target_answers_in_the_body() {
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "a.csv"}}],
+            "target": {{"kind": "inbody"}}, "to": "json"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+    assert_eq!(v["schema_name"], "DoclingDocument");
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -436,6 +436,23 @@ These are deliberate or unavoidable divergences, not bugs.
     nothing to switch yet) and `dclx` in the `ArtifactRef` union (only
     meaningful once the sources/targets wire shape lands — #139).
 
+15. **Cloud source/target passthrough** (#139, upstream docling#3795 /
+    docling-jobkit): the serve JSON body accepts docling's
+    service-datamodel `sources`/`target` shape — `kind`-tagged `file`
+    (base64) and `http` (URL + headers) sources always, and `s3` /
+    `azure_blob` / `google_cloud_storage` sources *and* targets behind the
+    opt-in `cloud` cargo feature (a feature-gated `object_store`
+    dependency, so the default build keeps its single-HTTP-stack graph).
+    Coordinate field names mirror upstream's `*Coordinates` models;
+    a cloud target uploads each converted output as `<stem>.<ext>` under
+    the prefix and answers with upstream's `RemoteTargetResult` kind plus
+    per-item outcomes. All outbound kinds sit behind `--allow-url-fetch`.
+    Not covered, as upstream-jobkit-specific or OAuth-bound:
+    `google_drive`, `zip`, `put`, `presigned_url` (and with the last of
+    those, the `ArtifactRef` union — still parked). Without the feature the
+    cloud kinds parse and answer a clear rebuild-with-`--features cloud`
+    error.
+
 ---
 
 ## 5. Not migrated / out of scope


### PR DESCRIPTION
…s wire shape (#139)

The serve JSON body now takes docling's service-datamodel sources/target shape alongside the {"url": ...} shorthand (mutually exclusive), closing the upstream docling#3795 / docling-jobkit gap the issue tracked:

- sources[]: kind-tagged items with upstream's exact field names — "file" (base64_string + filename; no network, no gate), "http" (url + headers, riding the existing SSRF-guarded fetcher, which now forwards request headers), and "s3" / "azure_blob" / "google_cloud_storage" (S3Coordinates / AzureBlobCoordinates / GoogleCloudStorageCoordinates field-for-field). A cloud source lists its prefix (bounded by max_num_elements, default 100) and converts every object as one batch.

- target: "inbody" (default — the response body, unchanged) or the same three cloud stores; each converted output uploads as <stem>.<ext> (CLI-batch naming, deduped within a request) under the prefix, and the response is upstream's RemoteTargetResult kind plus a credential-free target display and per-item outcomes. Batch semantics throughout; the single-source Markdown fast path skips streaming when a target is set, and to=images does not combine with one. Works on the async endpoint too — both share parse_convert_request/run_conversion.

- The stores go through object_store (aws+azure+gcp), feature-gated behind the new opt-in `cloud` cargo feature exactly as the issue proposed, so the default build keeps its single-HTTP-stack dependency graph. Without the feature the kinds still parse and answer a clear rebuild-with---features-cloud error. S3 maps endpoint/verify_ssl the boto3 way (scheme + lenient region parse, MinIO/COS friendly); Azure auths from the connection string's AccountKey= or SharedAccessSignature=; GCS takes the service-account JSON or falls back to ADC. All outbound kinds sit behind --allow-url-fetch, same as URL inputs.

Out of scope, documented in MIGRATION.md: google_drive (OAuth, no object_store backend) and the jobkit-only zip/put/presigned_url targets (with the latter, the ArtifactRef union stays parked). OpenAPI describes the new shapes with an s3-to-s3 pipeline example; router tests cover the file-source batch, url-xor-sources, unknown kinds, the outbound gate on both directions, the without-feature error, and the explicit inbody target.

Closes docling-project/docling.rs#139