### PR TITLE
fix(py): ocr_lang was silently inert on the download_models()+ensure_…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,11 @@ cargo check -p docling --no-default-features --features pdf-text \
 - `.models/` (repo root): layout, TableFormer, OCR, ASR (`.models/asr/`,
   presets in subdirs), enrichment, embedder. `.pdfium/lib/libpdfium.so` for
   page rendering. Fetch: `scripts/install/download_dependencies.sh`.
-- Resolution is CWD-relative with exe-dir fallback; env overrides:
-  `PDFIUM_DYNAMIC_LIB_PATH`, `DOCLING_ASR_{ENCODER,DECODER,VOCAB}`,
+- Resolution is CWD-relative, then `$DOCLING_RS_MODELS_DIR` for `.models/…`
+  paths (#285 — whole-dir override keeping the engine's own selection logic,
+  e.g. the OCR en/ch pair; the py bindings point it at their cache), then
+  exe-dir fallback; env overrides: `PDFIUM_DYNAMIC_LIB_PATH`,
+  `DOCLING_ASR_{ENCODER,DECODER,VOCAB}`,
   `DOCLING_FFMPEG` (video frames — ffmpeg is a runtime binary, never a build
   dep), `DOCLING_RS_PDF_WORKERS/_THREADS/_INTRA`, `DOCLING_RS_TF_INTRA` (#262),
   `DOCLING_RS_NO_ARENA` (#263; serve defaults it on),

--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,12 @@ option, Python `ocr_lang=` kwarg (also mapped from docling-shaped
 docling conformance is measured against, and the conformance scripts pin it
 themselves; explicit `DOCLING_OCR_REC_ONNX`+`DOCLING_OCR_DICT` (a pair — set
 both) override the language switch entirely. An install without the English
-model falls back to `ch_` with a warning.
+model falls back to `ch_` with a warning. Because those per-file pins beat
+the switch, the Python bindings' `ensure_env()` hands the cache over as
+`DOCLING_RS_MODELS_DIR` (a whole-directory override in the asset resolver)
+instead of pinning the pair, and `download_models()` fetches both language
+pairs — so the `ocr_lang=` kwarg works on the documented setup path (#285;
+re-run `download_models()` on an older cache to pick up the English pair).
 
 ## Testing
 

--- a/crates/docling-core/src/assets.rs
+++ b/crates/docling-core/src/assets.rs
@@ -6,15 +6,28 @@
 //! Resolution is CWD-relative with an executable-directory fallback.
 
 /// Resolve a default (CWD-relative) asset path. If it doesn't exist relative
-/// to the current directory, try next to the executable and one level above
-/// it (following symlinks — the layout `scripts/install/install.sh` produces:
-/// `/usr/local/bin/docling-rs` → `/usr/local/docling.rs/bin/docling-rs` with
-/// `.models/` and `.pdfium/` in `/usr/local/docling.rs`). Returns `rel`
-/// unchanged when nothing exists anywhere, so callers' error messages keep
-/// the familiar path. Explicit env overrides never reach this.
+/// to the current directory, a `.models/…` path is tried under
+/// `$DOCLING_RS_MODELS_DIR` (#285 — a whole-directory override, so the
+/// engine's *own* selection logic — the OCR language pair, the int8
+/// preference chains — keeps working against a relocated model set; the
+/// Python bindings point it at their per-user cache). After that, try next
+/// to the executable and one level above it (following symlinks — the layout
+/// `scripts/install/install.sh` produces: `/usr/local/bin/docling-rs` →
+/// `/usr/local/docling.rs/bin/docling-rs` with `.models/` and `.pdfium/` in
+/// `/usr/local/docling.rs`). Returns `rel` unchanged when nothing exists
+/// anywhere, so callers' error messages keep the familiar path. Explicit
+/// per-file env overrides never reach this.
 pub fn resolve(rel: &str) -> String {
     if std::path::Path::new(rel).exists() {
         return rel.to_string();
+    }
+    if let Some(stripped) = rel.strip_prefix(".models/") {
+        if let Some(dir) = crate::env::nonempty("DOCLING_RS_MODELS_DIR") {
+            let p = std::path::Path::new(&dir).join(stripped);
+            if p.exists() {
+                return p.to_string_lossy().into_owned();
+            }
+        }
     }
     let dir = std::env::current_exe()
         .ok()
@@ -41,5 +54,25 @@ mod tests {
             resolve(".models/definitely/not/there.onnx"),
             ".models/definitely/not/there.onnx"
         );
+    }
+
+    /// `.models/…` resolves under `$DOCLING_RS_MODELS_DIR` when the file
+    /// exists there (#285) — and only then; a miss falls through unchanged.
+    #[test]
+    fn models_dir_override_applies_to_dot_models_paths() {
+        let dir = std::env::temp_dir().join(format!("docling-assets-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        std::fs::write(dir.join("sub/x.onnx"), b"x").unwrap();
+        std::env::set_var("DOCLING_RS_MODELS_DIR", &dir);
+        assert_eq!(
+            resolve(".models/sub/x.onnx"),
+            dir.join("sub/x.onnx").to_string_lossy()
+        );
+        // Missing under the override → the input comes back unchanged.
+        assert_eq!(resolve(".models/sub/y.onnx"), ".models/sub/y.onnx");
+        // Non-.models assets are not redirected.
+        assert_eq!(resolve(".pdfium/lib/nope.so"), ".pdfium/lib/nope.so");
+        std::env::remove_var("DOCLING_RS_MODELS_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "calamine",
  "csv",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "docling-core",
  "fast_image_resize",

--- a/crates/docling-py/python/docling_rs/models.py
+++ b/crates/docling-py/python/docling_rs/models.py
@@ -48,6 +48,13 @@ _REQUIRED = {
 # Fetched when the release hosts them; a 404 is fine (older tag, optional
 # sidecars, INT8 variants — the pipeline falls back to fp32 gracefully).
 _OPTIONAL = {
+    # The English PP-OCRv3 recognition pair — the engine's ocr_lang="en"
+    # *default* (#285; the ch_ pair above stays the docling-conformance
+    # model, selected with ocr_lang="ch"). The release may not host them;
+    # the fallbacks below fetch straight from upstream, mirroring
+    # scripts/install/download_dependencies.sh.
+    "ocr_rec_en.onnx": "models/ocr_rec_en.onnx",
+    "en_dict.txt": "models/en_dict.txt",
     "layout_heron_int8.onnx": "models/layout_heron_int8.onnx",
     "decoder_int8.onnx": "models/tableformer/decoder_int8.onnx",
     # The #97 hoisted-KV TableFormer decoder — byte-exact vs the legacy graph
@@ -81,6 +88,12 @@ _ENRICH_FP32_DECODER = ("cf_decoder_kv.onnx", "models/code_formula/decoder_kv.on
 # Straight-from-upstream fallback for assets older release tags don't host:
 # cache path -> upstream URL.
 _FALLBACK_URLS = {
+    "models/ocr_rec_en.onnx": (
+        "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/en_PP-OCRv3_rec_infer.onnx"
+    ),
+    "models/en_dict.txt": (
+        "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/en_dict.txt"
+    ),
     "models/chunk/tokenizer.json": (
         "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
     ),
@@ -182,10 +195,13 @@ def ensure_env(dest: "str | Path | None" = None) -> Path:
     exists in the working directory (the native code resolves those itself, so a repo
     checkout keeps using its own exports). Prefers the INT8 models when
     present, matching the Rust pipeline's default; ``DOCLING_RS_FP32=1`` opts
-    out. Safe to call when nothing is downloaded yet — missing files simply
-    leave the env untouched (and the converter will fail with its usual clear
-    "model not found" message)."""
-    root = Path(dest) if dest else cache_dir()
+    out. OCR is handed over as ``DOCLING_RS_MODELS_DIR`` (the cache's models
+    directory) rather than per-file pins, so the ``ocr_lang`` kwarg keeps
+    selecting the en/ch recognition pair (#285). Safe to call when nothing is
+    downloaded yet — missing files simply leave the env untouched (and the
+    converter will fail with its usual clear "model not found" message)."""
+    # Absolute paths in the env: a later os.chdir() must not orphan them.
+    root = (Path(dest) if dest else cache_dir()).expanduser().resolve()
     # Same truthiness vocabulary as Rust's docling_core::env::flag.
     fp32 = os.environ.get("DOCLING_RS_FP32", "").strip().lower() not in ("", "0", "false", "no", "off")
     m = root / "models"
@@ -223,8 +239,14 @@ def ensure_env(dest: "str | Path | None" = None) -> Path:
         classifier = m / "picture_classifier.onnx"
     _point_at("DOCLING_PICTURE_CLASSIFIER_ONNX", _local(classifier_chain), classifier)
 
-    _point_at("DOCLING_OCR_REC_ONNX", _local(["models/ocr_rec.onnx"]), m / "ocr_rec.onnx")
-    _point_at("DOCLING_OCR_DICT", _local(["models/ppocr_keys_v1.txt"]), m / "ppocr_keys_v1.txt")
+    # OCR is deliberately NOT pinned per file (#285): DOCLING_OCR_REC_ONNX /
+    # DOCLING_OCR_DICT override the engine's en/ch pair selection outright,
+    # which made the ocr_lang kwarg silently inert. Handing over the models
+    # *directory* instead lets the engine resolve the pair for the requested
+    # language itself (missing English pair → its usual warn-and-fall-back
+    # to ch_; re-run download_models() to fetch it). The per-file vars stay
+    # honored when the caller sets them — that is the pin-any-model hatch.
+    _point_at("DOCLING_RS_MODELS_DIR", [".models"], m)
     _point_at(
         "DOCLING_TABLEFORMER_ENCODER",
         _local(["models/tableformer/encoder.onnx"]),

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -266,3 +266,65 @@ def test_ocr_kwargs_forward_and_validate():
         DocumentConverter(
             format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=shaped)}
         )
+
+
+def test_ensure_env_leaves_ocr_lang_selectable(tmp_path, monkeypatch):
+    """#285: ensure_env must NOT pin DOCLING_OCR_REC_ONNX/DOCLING_OCR_DICT —
+    those per-file overrides beat the engine's en/ch pair selection and made
+    the ocr_lang kwarg silently inert. The cache is handed over as
+    DOCLING_RS_MODELS_DIR instead, and download_models() knows the English
+    pair."""
+    from docling_rs import models as m
+
+    # A fake cache with the layout the downloader produces.
+    cache = tmp_path / "cache"
+    for rel in (
+        "models/ocr_rec.onnx",
+        "models/ppocr_keys_v1.txt",
+        "models/ocr_rec_en.onnx",
+        "models/en_dict.txt",
+    ):
+        p = cache / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"stub")
+
+    # Run from a directory without a local .models/ (a checkout's own assets
+    # outrank the cache by design and would short-circuit the test).
+    monkeypatch.chdir(tmp_path)
+    for var in ("DOCLING_RS_MODELS_DIR", "DOCLING_OCR_REC_ONNX", "DOCLING_OCR_DICT"):
+        monkeypatch.delenv(var, raising=False)
+
+    m.ensure_env(cache)
+
+    import os
+
+    assert os.environ.get("DOCLING_RS_MODELS_DIR") == str(cache / "models")
+    assert "DOCLING_OCR_REC_ONNX" not in os.environ
+    assert "DOCLING_OCR_DICT" not in os.environ
+
+    # The download manifest carries the English pair (with upstream
+    # fallbacks for release tags that don't host it).
+    assert m._OPTIONAL["ocr_rec_en.onnx"] == "models/ocr_rec_en.onnx"
+    assert m._OPTIONAL["en_dict.txt"] == "models/en_dict.txt"
+    assert "models/ocr_rec_en.onnx" in m._FALLBACK_URLS
+    assert "models/en_dict.txt" in m._FALLBACK_URLS
+
+
+def test_ensure_env_still_respects_explicit_ocr_pins(tmp_path, monkeypatch):
+    """The per-file vars remain the pin-any-model hatch (#285 workaround 2):
+    ensure_env never overwrites caller-set values."""
+    from docling_rs import models as m
+
+    cache = tmp_path / "cache"
+    (cache / "models").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DOCLING_OCR_REC_ONNX", "/custom/rec.onnx")
+    monkeypatch.setenv("DOCLING_OCR_DICT", "/custom/dict.txt")
+    monkeypatch.delenv("DOCLING_RS_MODELS_DIR", raising=False)
+
+    m.ensure_env(cache)
+
+    import os
+
+    assert os.environ["DOCLING_OCR_REC_ONNX"] == "/custom/rec.onnx"
+    assert os.environ["DOCLING_OCR_DICT"] == "/custom/dict.txt"


### PR DESCRIPTION
…env() path

Both root causes from the report, plus the native piece that makes the clean fix possible:

- docling-core: asset resolution learns DOCLING_RS_MODELS_DIR — a whole-directory override for `.models/...` paths, checked after the CWD and before the exe-dir fallback. Unlike the per-file env pins it relocates the model set while keeping the engine's OWN selection logic working against it: the OCR en/ch pair for the requested language, the int8 preference chains, the chunker tokenizer default.

- ensure_env() no longer pins DOCLING_OCR_REC_ONNX/DOCLING_OCR_DICT (per-file pins beat OcrModel's language resolution outright — that was the silent inertness); it hands the cache over as DOCLING_RS_MODELS_DIR instead. The per-file vars remain honored when the caller sets them — the pin-any-PP-OCR-model hatch from the report's second workaround. Env values are now absolutized so a later os.chdir() can't orphan them.

- download_models() fetches the English recognition pair (ocr_rec_en.onnx + en_dict.txt) — release-first with the same upstream fallbacks download_dependencies.sh uses; a stale cache keeps converting (engine warns and falls back to ch_) until download_models() is re-run.

Verified end-to-end with the reporter's repro shape: from a clean CWD with only the cache configured, ocr_lang="en" and "ch" now produce different outputs (visibly different recognitions) with no OCR pins in the environment. Unit tests pin the resolver override (docling-core) and the ensure_env contract (no pins set, explicit pins respected, manifest carries the en pair).

Closes docling-project/docling.rs#285