### PR TITLE
fix(html): unclosed inline tag no longer swallows subsequent tables i…

### DIFF
--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -301,23 +301,35 @@ fn walk_block(
                             image: src.as_deref().and_then(|s| images.resolve(s)),
                             classification: None,
                         });
-                    } else if has_descendant(cref, "img") {
-                        // An anchor with an image among other content: docling
-                        // treats `img` as a block tag, so the wrapper is walked
-                        // block-wise (its text becomes text items, the image a
-                        // Picture with the `alt` caption).
+                    } else if has_descendant(cref, "img") || contains_block(cref) {
+                        // An anchor with an image among other content (docling
+                        // treats `img` as a block tag), or one hiding real block
+                        // structure (#284 — an *unclosed* `<a name=…>` legally
+                        // swallows every following block under HTML5 parsing):
+                        // the wrapper is walked block-wise, so nested tables and
+                        // lists come out as their own items instead of
+                        // flattening into inline text. (The anchor's own href —
+                        // if any — is not threaded through, matching the
+                        // image-wrapper branch.)
                         flush_inline(&mut inline, nodes);
                         walk_block(cref, nodes, list_level, base, images);
                     } else {
                         collect_element(cref, base, None, &mut inline);
                     }
-                } else if has_descendant(cref, "img") {
-                    // An inline wrapper around an image (`<span><a><img></a></span>`):
-                    // docling's `img` is in its block-tag set, so the wrapper is
-                    // block-walked and the image emits a Picture captioned with its
-                    // `alt` text.
+                } else if has_descendant(cref, "img") || contains_block(cref) {
+                    // An inline wrapper around an image (`<span><a><img></a></span>`
+                    // — docling's `img` is in its block-tag set), or an inline
+                    // element hiding block structure (#284: html5ever follows the
+                    // HTML5 tree-construction spec, so an unclosed `<b>`/`<font>`
+                    // keeps every subsequent block as its child — Python
+                    // docling's parser recovers by reparenting, and parity means
+                    // walking such a wrapper block-wise). The inline formatting
+                    // element's own formatting (`<b>` → bold) still reaches its
+                    // *inline* children through the seeded base — the nested
+                    // blocks themselves render as the reparenting recovery
+                    // would leave them.
                     flush_inline(&mut inline, nodes);
-                    walk_block(cref, nodes, list_level, base, images);
+                    walk_block(cref, nodes, list_level, tag_fmt(name, base), images);
                 } else {
                     collect_element(cref, base, None, &mut inline);
                 }
@@ -973,6 +985,72 @@ fn collect_runs(elem: ElementRef, fmt: Fmt, hyperlink: Option<&str>, runs: &mut 
             }
             _ => {}
         }
+    }
+}
+
+/// Whether an inline element hides *structured* block content (#284). html5ever
+/// follows the HTML5 tree-construction spec, under which an *unclosed* inline
+/// tag (`<a name=…>`, `<b>`, `<font>` — endemic in HTML from older authoring
+/// tools) legally keeps every subsequent block element as its child; walked
+/// as inline content, a swallowed `<table>` flattens into text with its
+/// structure silently gone. Callers block-walk such a wrapper instead.
+///
+/// Deliberately only the blocks whose structure cannot survive inline
+/// flattening — tables, lists, headings, code blocks, figures. Pure text
+/// containers (`div`, `p`, `section`) do NOT trigger: a well-formed
+/// `<a href><div>text</div></a>` keeps rendering as a link around the
+/// flattened text (hyperlink_04 in the corpus), exactly as before.
+fn contains_block(elem: ElementRef) -> bool {
+    elem.descendants().skip(1).any(|n| {
+        n.value().as_element().is_some_and(|e| {
+            matches!(
+                e.name(),
+                "table"
+                    | "ul"
+                    | "ol"
+                    | "dl"
+                    | "pre"
+                    | "figure"
+                    | "blockquote"
+                    | "h1"
+                    | "h2"
+                    | "h3"
+                    | "h4"
+                    | "h5"
+                    | "h6"
+            )
+        })
+    })
+}
+
+/// The inline formatting an element applies to its children — the same tag
+/// set [`collect_element`] matches, for callers that block-walk an inline
+/// wrapper (#284) and still owe the wrapper's formatting to its inline text.
+fn tag_fmt(name: &str, base: Fmt) -> Fmt {
+    match name {
+        "b" | "strong" => Fmt { bold: true, ..base },
+        "i" | "em" | "var" => Fmt {
+            italic: true,
+            ..base
+        },
+        "s" | "del" | "strike" => Fmt {
+            strike: true,
+            ..base
+        },
+        "code" | "kbd" | "samp" => Fmt { code: true, ..base },
+        "u" | "ins" => Fmt {
+            underline: true,
+            ..base
+        },
+        "sub" => Fmt {
+            script: Script::Sub,
+            ..base
+        },
+        "sup" => Fmt {
+            script: Script::Super,
+            ..base
+        },
+        _ => base,
     }
 }
 
@@ -1714,6 +1792,44 @@ mod tests {
     fn convert(html: &str) -> DoclingDocument {
         let src = SourceDocument::from_bytes("t", InputFormat::Html, html.as_bytes().to_vec());
         HtmlBackend.convert(&src).unwrap()
+    }
+
+    /// #284: an *unclosed* inline tag (here `<a name>` + `<b>`) legally
+    /// swallows every subsequent block under HTML5 parsing; the walker must
+    /// still emit the swallowed table/list as structure, not flatten them
+    /// into inline text.
+    #[test]
+    fn unclosed_inline_tag_does_not_swallow_tables() {
+        let doc = convert(
+            r#"<html><body><a name="x"><b>T</b><br>
+               <table><tr><td>A</td><td>B</td></tr><tr><td>1</td><td>2</td></tr></table></body></html>"#,
+        );
+        let tables = doc
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Table(_)))
+            .count();
+        assert_eq!(tables, 1, "the swallowed table must surface as a table");
+        let md = doc.export_to_markdown();
+        assert!(
+            md.contains("**T**"),
+            "the <b> text keeps its formatting: {md}"
+        );
+        assert!(md.contains("|-----"), "table structure survives: {md}");
+    }
+
+    /// The counterpart guard: a *well-formed* anchor around a pure text
+    /// container keeps rendering as a link (hyperlink_04 semantics) — only
+    /// structured blocks (tables, lists, headings…) trigger the block walk.
+    #[test]
+    fn anchor_around_a_div_stays_a_link() {
+        let doc =
+            convert(r#"<html><body><a href="/start.html"><div>Some text.</div></a></body></html>"#);
+        let md = doc.export_to_markdown();
+        assert!(
+            md.contains("[Some text.](/start.html)"),
+            "text-only block content stays inside the link: {md}"
+        );
     }
 
     #[test]

--- a/crates/docling/tests/data/html/expected/unclosed_inline_table.html.json
+++ b/crates/docling/tests/data/html/expected/unclosed_inline_table.html.json
@@ -1,0 +1,246 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "unclosed_inline_table",
+  "origin": {
+    "mimetype": "text/plain",
+    "binary_hash": 13723329870218335913,
+    "filename": "unclosed_inline_table"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/tables/0"
+      },
+      {
+        "$ref": "#/texts/1"
+      },
+      {
+        "$ref": "#/groups/0"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/2"
+        },
+        {
+          "$ref": "#/texts/3"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "**T**",
+      "text": "**T**"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "After the table",
+      "text": "After the table"
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "one",
+      "text": "one",
+      "enumerated": false,
+      "marker": "-"
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "two",
+      "text": "two",
+      "enumerated": false,
+      "marker": "-"
+    }
+  ],
+  "pictures": [],
+  "tables": [
+    {
+      "self_ref": "#/tables/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "table",
+      "prov": [],
+      "captions": [],
+      "references": [],
+      "footnotes": [],
+      "data": {
+        "table_cells": [
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 0,
+            "end_row_offset_idx": 1,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "A",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 0,
+            "end_row_offset_idx": 1,
+            "start_col_offset_idx": 1,
+            "end_col_offset_idx": 2,
+            "text": "B",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 1,
+            "end_row_offset_idx": 2,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "1",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 1,
+            "end_row_offset_idx": 2,
+            "start_col_offset_idx": 1,
+            "end_col_offset_idx": 2,
+            "text": "2",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          }
+        ],
+        "num_rows": 2,
+        "num_cols": 2,
+        "grid": [
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 0,
+              "end_row_offset_idx": 1,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "A",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            },
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 0,
+              "end_row_offset_idx": 1,
+              "start_col_offset_idx": 1,
+              "end_col_offset_idx": 2,
+              "text": "B",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 1,
+              "end_row_offset_idx": 2,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "1",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            },
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 1,
+              "end_row_offset_idx": 2,
+              "start_col_offset_idx": 1,
+              "end_col_offset_idx": 2,
+              "text": "2",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ]
+        ]
+      },
+      "annotations": []
+    }
+  ],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/crates/docling/tests/data/html/expected/unclosed_inline_table.html.md
+++ b/crates/docling/tests/data/html/expected/unclosed_inline_table.html.md
@@ -1,0 +1,10 @@
+**T**
+
+|   A |   B |
+|-----|-----|
+|   1 |   2 |
+
+After the table
+
+- one
+- two

--- a/crates/docling/tests/data/html/expected/unclosed_inline_table.html.strict.md
+++ b/crates/docling/tests/data/html/expected/unclosed_inline_table.html.strict.md
@@ -1,0 +1,10 @@
+**T**
+
+|   A |   B |
+|-----|-----|
+|   1 |   2 |
+
+After the table
+
+- one
+- two

--- a/crates/docling/tests/data/html/sources/unclosed_inline_table.html
+++ b/crates/docling/tests/data/html/sources/unclosed_inline_table.html
@@ -1,0 +1,4 @@
+<html><body><a name="x"><b>T</b><br>
+<table><tr><td>A</td><td>B</td></tr><tr><td>1</td><td>2</td></tr></table>
+<font size="2">After the table <ul><li>one</li><li>two</li></ul>
+</body></html>

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -113,7 +113,7 @@ PyPI; run via `scripts/conformance/conformance.sh <fmt>`), not the committed gro
 |---|---|---|
 | Markdown | `markdown.rs` (pulldown-cmark) | **10/10 exact** |
 | CSV | `csv.rs` (`csv` crate) | **9/9 exact**; `.tsv` routes here too (#208 — the delimiter sniffing already covers tabs; a docling.rs extension, upstream accepts only `.csv`) |
-| HTML | `html.rs` (scraper/html5ever) | **32/32 exact** (`wiki_duck` included — rich table cells, caption run spacing, indicator images, `<footer>` furniture all match docling 2.112) |
+| HTML | `html.rs` (scraper/html5ever) | **32/32 exact** (`wiki_duck` included — rich table cells, caption run spacing, indicator images, `<footer>` furniture all match docling 2.112); #284: an *unclosed* inline tag (`<a name=…>`, `<b>`, `<font>` — endemic in legacy authoring-tool HTML) legally swallows subsequent blocks under html5ever's spec parsing, where Python's parser recovers by reparenting — inline wrappers hiding structured blocks (tables, lists, headings, code, figures) are now block-walked so the structure surfaces; pure text containers under a well-formed `<a href>` keep rendering as links |
 | AsciiDoc | `asciidoc.rs` (regex) | **4/4 exact** |
 | DeepSeek-OCR Markdown | `deepseek.rs` | **3/3 exact** (auto-detected VLM-token variant) |
 | XLSX | `xlsx.rs` (calamine) | **10/10 exact** (incl. chart captions/classification/data grids) |


### PR DESCRIPTION
…nto flat text

html5ever follows the HTML5 tree-construction spec, under which an unclosed inline tag (<a name=...>, <b>, <font> — endemic in HTML from older authoring tools and office-suite exports) legally keeps every subsequent block element as its child. The walker treated such wrappers as pure inline content, so a swallowed <table> flattened into text — cell text intact, row/column structure silently gone (the reporter's real-world document: 11 tables upstream, 0 here). Python docling's parser recovers by reparenting blocks out of the open inline context, so parity means surfacing them.

An inline element that hides *structured* block content — tables, lists, dl, pre, figure, blockquote, headings — is now block-walked (the same treatment inline wrappers around <img> already got), with its own formatting seeded into the inline base so `<b>T<table>` keeps the bold on "T". Pure text containers deliberately do NOT trigger: a well-formed <a href><div>text</div></a> still renders as a link around the flattened text (hyperlink_04 pins that), which also keeps the whole existing HTML/MHTML regression corpus byte-identical — the first broader draft that triggered on div/p moved two fixtures and was narrowed for exactly that reason.

The reporter's minimal repro now produces the expected output verbatim (bold run + 2x2 table). New fixture unclosed_inline_table covers the swallowed table and a font-swallowed list in the regression corpus; unit tests pin both the recovery and the anchor-stays-a-link counterpart.

Closes docling-project/docling.rs#284