### PR TITLE
feat(node): expose the remote VLM pipeline in the Node bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,11 +626,20 @@ docling-rs --pipeline vlm \
   paper.pdf
 ```
 
+The same pipeline is exposed by the **Node bindings** as
+`pipeline: 'vlm'` with `vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` /
+`vlmMaxTokens` (see [Node.js / Bun bindings](#nodejs--bun-bindings)); it is not
+plumbed through serve or the Python bindings yet.
+
 `--vlm-endpoint` takes the server's `/v1` base or the full
-`…/chat/completions` URL; `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL` /
-`DOCLING_RS_VLM_PROMPT` / `DOCLING_RS_VLM_API_KEY` (Bearer token) are the env
-equivalents. `--pages A-B` composes (only the window's pages are rendered and
-sent), and `--to md|json|dclx|chunks` plus `--strict` work as usual. Transient
+`…/chat/completions` URL. `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL`
+are the env equivalents of the two flags, and `DOCLING_RS_VLM_PROMPT` /
+`DOCLING_RS_VLM_API_KEY` (Bearer token) are the only way to set those two from
+the CLI — Node exposes them as options too. Selecting the pipeline is always
+explicit: the environment supplies values, it never switches the pipeline on,
+so a stale `DOCLING_RS_VLM_ENDPOINT` can't reroute an ordinary PDF conversion
+over the network. `--pages A-B` composes (only the window's pages are rendered
+and sent), and `--to md|json|dclx|chunks` plus `--strict` work as usual. Transient
 endpoint failures (timeouts, 408/429, 5xx) retry with exponential backoff;
 a page that still fails fails the conversion — no silently dropped pages.
 Output quality is entirely the model's: conversion of the PDF corpus against
@@ -709,8 +718,9 @@ docling.rs ships as an npm package, [**`docling.rs`**](https://www.npmjs.com/pac
 that loads in both Node.js and Bun (Bun implements N-API — same binary, no
 rebuild), exposing the converter with the same knobs as the Rust API: Markdown /
 docling JSON output, `strict` mode, image modes, allowed-format restriction,
-`fetchImages`, sync + async (`Promise`) calls, and a `streamFileMarkdown` async
-generator.
+`fetchImages`, the [remote VLM pipeline](#vlm-pipeline-remote-endpoint)
+(`pipeline: 'vlm'`), sync + async (`Promise`) calls, and a `streamFileMarkdown`
+async generator.
 
 Install — no Rust toolchain needed, the prebuilt binary for your platform (Linux
 x64/arm64, Windows x64) is pulled in automatically:
@@ -734,7 +744,9 @@ const json = await convertFileAsync('report.docx', { to: 'json' })
 Declarative formats (Markdown, HTML, DOCX, XLSX, …) work out of the box. The
 PDF/image pipeline needs pdfium + the ONNX models (not bundled), so it throws
 until you fetch them with `scripts/install/download_dependencies.sh` — see
-[Getting the ML models](#getting-the-ml-models) below.
+[Getting the ML models](#getting-the-ml-models) below. `pipeline: 'vlm'` is the
+exception: it loads no ONNX models, so it needs pdfium alone (and nothing for
+image input).
 
 A reusable `Pipeline` keeps those models warm across many PDFs.
 

--- a/crates/docling-node/Cargo.toml
+++ b/crates/docling-node/Cargo.toml
@@ -27,8 +27,12 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-# `chunking` pulls in the HF-tokenizer-backed HybridChunker for the chunk* API.
-docling = { path = "../docling", version = "1.19.0", features = ["chunking"] }
+# `chunking` pulls in the HF-tokenizer-backed HybridChunker for the chunk* API;
+# `vlm` the remote-endpoint pipeline behind `pipeline: 'vlm'` (#77). Both ride
+# on top of the crate's defaults — `vlm` is listed explicitly because this
+# binding exposes it as a public option, so it must not silently disappear if
+# the library's default set ever changes.
+docling = { path = "../docling", version = "1.19.0", features = ["chunking", "vlm"] }
 # Node-API bindings. `napi4` enables threadsafe functions, used for streaming.
 napi = { version = "2", default-features = false, features = ["napi4"] }
 napi-derive = "2"

--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -43,7 +43,8 @@ npm run build        # release build → docling.rs.<platform>.node + native.js/
 > The addon statically links the ONNX runtime used by the PDF/image pipeline, so
 > the built `.node` is large. Declarative formats (Markdown, HTML, DOCX, …) don't
 > touch it; only PDF/image conversion loads the ML models (downloaded on first
-> use, like the CLI).
+> use, like the CLI) — and not even that under `pipeline: 'vlm'`, which converts
+> through a remote endpoint.
 
 ### GPU (CUDA)
 
@@ -202,6 +203,10 @@ addon — pdfium plus the ONNX models (layout, OCR, TableFormer). Converting a
 PDF/image/METS input **throws** until they're on disk. Fetch them with a
 one-liner from your app's directory (where you'll `npm install docling.rs`):
 
+> The exception is [`pipeline: 'vlm'`](#vlm-pipeline-remote-endpoint), which
+> replaces the ONNX stack with a remote endpoint: it needs **pdfium only** (to
+> rasterize PDF pages), and nothing at all for image input.
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/docling-project/docling.rs/master/scripts/install/download_dependencies.sh | sh
 ```
@@ -249,6 +254,9 @@ call are needed afterwards:
 checkDependencies() // { home, pdfium, layout, ocr, tableformer, chunkTokenizer, ready, missing }
 ```
 
+`ready` describes the **standard** pipeline (`pdfium && layout`); a VLM-only
+install has `ready: false` and still converts.
+
 ### Reusing a warm `Pipeline` (many PDFs)
 
 The one-shot `convertFile` / `convertFileAsync` rebuild the pipeline — reloading
@@ -276,6 +284,54 @@ order as pages finish. Conversions on one instance run one at a time (the
 models are mutable sessions) — overlapping `*Async` calls queue in submission
 order, so batch throughput comes from keeping the models warm, not from
 parallel calls.
+
+`Pipeline` rejects `pipeline: 'vlm'`: that pipeline loads no models, so there
+is nothing to keep warm — use `convertFileAsync` or `DocumentConverter`.
+
+### VLM pipeline (remote endpoint)
+
+`pipeline: 'vlm'` (issue #77) replaces the whole ONNX stack — layout, OCR,
+TableFormer — with a **Vision Language Model**. Each PDF page is rendered with
+pdfium and sent to any OpenAI-compatible vision endpoint (LM Studio, Ollama,
+vLLM, or a hosted service) with docling's page-conversion prompt; the returned
+DocLang/DocTags markup is parsed by the same reader the CLI uses. No ONNX model
+is loaded, so a VLM-only install needs pdfium alone — and nothing at all for
+image input.
+
+```js
+import { convertFileAsync } from 'docling.rs'
+
+const res = await convertFileAsync('paper.pdf', {
+  to: 'markdown',
+  pipeline: 'vlm',
+  vlmEndpoint: 'http://localhost:11434/v1', // or the full …/chat/completions URL
+  vlmModel: 'granite-docling',
+  vlmApiKey: process.env.VLM_API_KEY,       // local servers need none
+})
+```
+
+`vlmEndpoint` / `vlmModel` fall back to `DOCLING_RS_VLM_ENDPOINT` /
+`DOCLING_RS_VLM_MODEL`, `vlmApiKey` and `vlmPrompt` to
+`DOCLING_RS_VLM_API_KEY` / `DOCLING_RS_VLM_PROMPT`, matching the CLI's
+`--pipeline vlm`. Selecting `pipeline: 'vlm'` explicitly is always required —
+the environment supplies values, it never switches the pipeline on, so a stale
+`DOCLING_RS_VLM_ENDPOINT` can't silently route your PDFs over the network.
+
+`pages: 'A-B'` composes (only those pages are rendered and sent), `strict`,
+`compactTables`, `allowedFormats` and `to: 'json'` work as usual, and
+`streamFileMarkdown` yields the document as a single chunk — a VLM answers a
+whole page per request, so there is nothing earlier to emit. PDF and image are
+the only accepted inputs; any other format is rejected rather than silently
+falling back to the standard pipeline.
+
+The `chunk*` functions have **no** VLM path — `ChunkOptions` carries no
+`pipeline`, and they always convert through the ONNX stack. To chunk a
+VLM-converted document, convert to JSON first and chunk that:
+
+```js
+const { content } = await convertFileAsync('paper.pdf', { to: 'json', pipeline: 'vlm', … })
+const chunks = chunkDocument(content, { chunker: 'hybrid' })
+```
 
 ### Images
 
@@ -326,8 +382,8 @@ then `convertFile` / `convert` / `convertFileAsync` / `convertAsync` /
 `DocumentConverter` is the reusable form: `new DocumentConverter(converterOptions)`
 then `convert` / `convertFile` / `convertFileAsync` / `convertAsync` /
 `convertFileStreaming`. Converter config (`strict`, `fetchImages`,
-`allowedFormats`) is set once on the constructor; output options (`to`,
-`imageMode`, `artifactsDir`) are per call.
+`allowedFormats`, `pipeline` + the `vlm*` options) is set once on the
+constructor; output options (`to`, `imageMode`, `artifactsDir`) are per call.
 
 ### Options
 
@@ -350,6 +406,18 @@ then `convert` / `convertFile` / `convertFileAsync` / `convertAsync` /
   (`"auto"` default) for audio/video sources.
 - `videoFrames`: max frames sampled from a video input as timestamped pictures
   (`0` = transcript only; default 8, needs ffmpeg at runtime).
+- `pipeline`: `"standard"` (default) or `"vlm"` — convert PDF/image pages
+  through a remote vision endpoint instead of the ONNX stack (#77). See
+  [VLM pipeline](#vlm-pipeline-remote-endpoint).
+- `vlmEndpoint`: the server's `/v1` base or the full `…/chat/completions` URL.
+  Falls back to `DOCLING_RS_VLM_ENDPOINT`; required for `pipeline: 'vlm'`.
+- `vlmModel`: model name as the server knows it. Falls back to
+  `DOCLING_RS_VLM_MODEL`; required for `pipeline: 'vlm'`.
+- `vlmApiKey`: Bearer token; local servers need none. Falls back to
+  `DOCLING_RS_VLM_API_KEY`.
+- `vlmPrompt`: overrides docling's per-page instruction. Falls back to
+  `DOCLING_RS_VLM_PROMPT`.
+- `vlmMaxTokens`: `max_tokens` per page completion (default `8192`).
 
 ### `ConvertResult`
 

--- a/crates/docling-node/deps.js
+++ b/crates/docling-node/deps.js
@@ -31,6 +31,10 @@ const path = require('path')
 // Formats whose conversion requires the ML models + native libs above.
 const ML_FORMATS = new Set(['pdf', 'image', 'mets_gbs'])
 
+// Of those, the ones the remote VLM pipeline can convert (#77) — `convert_vlm`
+// handles PDF and image only.
+const VLM_FORMATS = new Set(['pdf', 'image'])
+
 // pdfium's shared-library filename, by platform.
 function pdfiumLibName() {
   switch (process.platform) {
@@ -180,7 +184,10 @@ function downloadGuide() {
     'PDFIUM_DYNAMIC_LIB_PATH — see docs/MODELS_NOTICE.md for licensing.',
     '',
     'Declarative formats (md, html, docx, xlsx, …) need none of this — only',
-    'PDF, image and METS conversion do.',
+    'PDF, image and METS conversion do. The remote VLM pipeline needs no ONNX',
+    "models either — pdfium alone, to rasterize PDF pages, and not even that",
+    "for image input — but it is a convert* option (pipeline: 'vlm'); the",
+    'chunk* functions have no VLM path and always need the models.',
   ].join('\n')
 }
 
@@ -189,17 +196,41 @@ function downloadGuide() {
  * dependencies aren't installed. Called before ML conversions; also wires up
  * the `DOCLING_*` / `PDFIUM_DYNAMIC_LIB_PATH` env vars for whatever is present,
  * so a checkout with `scripts/install/download_dependencies.sh` already run just works.
+ *
+ * `options` are the caller's convert options, read only for `pipeline` (#77):
+ * under `pipeline: 'vlm'` a remote endpoint replaces the ONNX stack, so the
+ * layout model is not required — but pdfium still is, because PDF pages are
+ * rasterized locally before being sent. A standalone image is already its own
+ * page and needs neither, so `image` + VLM requires nothing on disk.
  */
-function assertMlReady(format, dir) {
+function assertMlReady(format, dir, options) {
   if (!ML_FORMATS.has(format)) return
+  const pipeline = options && options.pipeline
+  // Validated here, not left to the native side: this guard runs first, so an
+  // unrecognized name would otherwise fall through to the strict ONNX
+  // requirement — telling someone who typed 'VLM' to download hundreds of
+  // megabytes of models to fix a capitalization slip.
+  if (pipeline != null && pipeline !== 'standard' && pipeline !== 'vlm') {
+    throw new Error(`unknown pipeline '${pipeline}' (expected: standard, vlm)`)
+  }
+  const vlm = pipeline === 'vlm'
+  // METS-GBS is an ML format with no VLM path at all, so relaxing the model
+  // requirement for it would only send the user off to fetch a pdfium that
+  // cannot help. Say what's actually wrong instead.
+  if (vlm && !VLM_FORMATS.has(format)) {
+    throw new Error(
+      `the 'vlm' pipeline converts PDF and image inputs; '${format}' needs the standard pipeline.`,
+    )
+  }
   const p = resolvePaths(dir)
   exportEnv(p)
   const status = checkDependencies({ dir })
   // Image needs layout (+OCR), but not pdfium; PDF/METS need both.
   const needPdfium = format !== 'image'
-  const missing = [!status.layout && 'layout_heron.onnx', needPdfium && !status.pdfium && 'pdfium'].filter(
-    Boolean,
-  )
+  const missing = [
+    !vlm && !status.layout && 'layout_heron.onnx',
+    needPdfium && !status.pdfium && 'pdfium',
+  ].filter(Boolean)
   if (missing.length === 0) return
   throw new Error(
     `Converting '${format}' requires the PDF/ML dependencies, which are not installed: ` +

--- a/crates/docling-node/index.d.ts
+++ b/crates/docling-node/index.d.ts
@@ -28,13 +28,17 @@ export { supportedFormats, formatFromName } from './native'
 /** Callback form used by the native streaming API (prefer {@link streamFileMarkdown}). */
 export type StreamCallback = (err: Error | null, chunk: string | undefined | null) => void
 
-/** Convert a file on disk (format detected from the extension). Throws for PDF/image/METS if deps aren't installed. */
+/**
+ * Convert a file on disk (format detected from the extension). Throws for
+ * PDF/image/METS if deps aren't installed — except under `pipeline: 'vlm'`,
+ * which loads no ONNX models and needs only pdfium (nothing for image input).
+ */
 export declare function convertFile(path: string, options?: ConvertOptions | null): ConvertResult
-/** Convert in-memory bytes. Throws for PDF/image/METS if deps aren't installed. */
+/** Convert in-memory bytes. Throws for PDF/image/METS if deps aren't installed (see {@link convertFile}). */
 export declare function convert(input: ConvertInput, options?: ConvertOptions | null): ConvertResult
-/** Async (Promise) file conversion, off the event loop. Rejects for PDF/image/METS if deps aren't installed. */
+/** Async (Promise) file conversion, off the event loop. Rejects for PDF/image/METS if deps aren't installed (see {@link convertFile}). */
 export declare function convertFileAsync(path: string, options?: ConvertOptions | null): Promise<ConvertResult>
-/** Async (Promise) bytes conversion, off the event loop. */
+/** Async (Promise) bytes conversion, off the event loop. Rejects for PDF/image/METS if deps aren't installed (see {@link convertFile}). */
 export declare function convertAsync(input: ConvertInput, options?: ConvertOptions | null): Promise<ConvertResult>
 
 /**
@@ -58,7 +62,10 @@ export declare function chunkDocument(documentJson: string, options?: ChunkOptio
 /** Async (Promise) {@link chunkDocument}. */
 export declare function chunkDocumentAsync(documentJson: string, options?: ChunkOptions | null): Promise<Array<Chunk>>
 
-/** A reusable converter holding config (strict / fetchImages / allowedFormats). */
+/**
+ * A reusable converter holding config (strict / fetchImages / allowedFormats,
+ * and the `pipeline` / `vlm*` selection).
+ */
 export declare class DocumentConverter {
   constructor(options?: ConverterOptions | null)
   convertFile(path: string, options?: OutputOptions | null): ConvertResult
@@ -82,6 +89,9 @@ export interface PipelineStreamOptions {
  * The `*Async` variants run the conversion off the event loop; overlapping
  * calls on one instance queue (the models are mutable sessions), so batch
  * throughput comes from keeping the models warm, not from parallel calls.
+ *
+ * `pipeline: 'vlm'` is rejected here: it loads no models, so there is nothing
+ * to keep warm. Use {@link DocumentConverter} or {@link convertFile} for it.
  */
 export declare class Pipeline {
   constructor(options?: ConverterOptions | null)
@@ -120,7 +130,11 @@ export interface DependencyStatus {
   tableformer: boolean
   /** Hybrid-chunker tokenizer (.models/chunk/tokenizer.json) present. */
   chunkTokenizer: boolean
-  /** True when the minimum for PDF (pdfium + layout) is present. */
+  /**
+   * True when the minimum for PDF (pdfium + layout) is present — that is, for
+   * the *standard* pipeline. `pipeline: 'vlm'` needs `pdfium` alone (and
+   * nothing at all for image input), so it can convert with `ready: false`.
+   */
   ready: boolean
   /** Human-readable list of the missing required assets. */
   missing: string[]
@@ -135,11 +149,13 @@ export declare function checkDependencies(options?: { dir?: string }): Dependenc
 
 // --- streaming --------------------------------------------------------------
 
-/** Options for {@link streamFileMarkdown} (converter config + streamable output). */
-export interface StreamOptions {
-  strict?: boolean
-  fetchImages?: boolean
-  allowedFormats?: string[]
+/**
+ * Options for {@link streamFileMarkdown}: every converter knob (including
+ * `pipeline` / `vlm*` and `pages`) plus the streamable output modes. Extending
+ * `ConverterOptions` rather than restating fields keeps this from drifting as
+ * the native option set grows — the implementation forwards the whole object.
+ */
+export interface StreamOptions extends ConverterOptions {
   imageMode?: 'placeholder' | 'embedded'
   artifactsDir?: string
 }
@@ -148,6 +164,10 @@ export interface StreamOptions {
  * Stream a file's Markdown in chunks, in document order, as conversion
  * progresses — the win for PDF, whose pages convert in parallel. Concatenating
  * the chunks reproduces the buffered `convertFile(path).content` byte-for-byte.
+ *
+ * Under `pipeline: 'vlm'` nothing streams — the endpoint answers a whole page
+ * per request — so the document arrives as a single chunk. The concatenation
+ * contract above still holds.
  */
 export declare function streamFileMarkdown(
   filePath: string,

--- a/crates/docling-node/index.js
+++ b/crates/docling-node/index.js
@@ -68,24 +68,27 @@ async function* chunkStream(start) {
 
 // --- guarded one-shot functions --------------------------------------------
 
+// The guard takes `options` so `pipeline: 'vlm'` can drop the ONNX-model
+// requirement (#77) — see assertMlReady in deps.js. The chunk* functions below
+// take ChunkOptions, which carry no `pipeline`, and always use the ML pipeline.
 function convertFile(path, options) {
-  assertMlReady(mlFormatOf(path))
+  assertMlReady(mlFormatOf(path), undefined, options)
   return native.convertFile(path, options)
 }
 
 function convert(input, options) {
-  assertMlReady(mlFormatOf(input && input.name, input && input.format))
+  assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, options)
   return native.convert(input, options)
 }
 
 // async so a guard failure surfaces as a rejected promise, not a sync throw.
 async function convertFileAsync(path, options) {
-  assertMlReady(mlFormatOf(path))
+  assertMlReady(mlFormatOf(path), undefined, options)
   return native.convertFileAsync(path, options)
 }
 
 async function convertAsync(input, options) {
-  assertMlReady(mlFormatOf(input && input.name, input && input.format))
+  assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, options)
   return native.convertAsync(input, options)
 }
 
@@ -135,31 +138,41 @@ async function chunkDocumentAsync(documentJson, options) {
 
 class DocumentConverter {
   constructor(options) {
+    // Only the pipeline name, not the options object: the guard needs nothing
+    // else, and holding the caller's object would both retain `vlmApiKey` on an
+    // enumerable property (any logger that serializes the instance would print
+    // the token) and let a later mutation of that object desync the guard from
+    // the config the native side already resolved.
+    this._pipeline = options && options.pipeline
     this._inner = new native.DocumentConverter(options)
   }
 
   convertFile(path, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, { pipeline: this._pipeline })
     return this._inner.convertFile(path, options)
   }
 
   convert(input, options) {
-    assertMlReady(mlFormatOf(input && input.name, input && input.format))
+    assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, {
+      pipeline: this._pipeline,
+    })
     return this._inner.convert(input, options)
   }
 
   async convertFileAsync(path, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, { pipeline: this._pipeline })
     return this._inner.convertFileAsync(path, options)
   }
 
   async convertAsync(input, options) {
-    assertMlReady(mlFormatOf(input && input.name, input && input.format))
+    assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, {
+      pipeline: this._pipeline,
+    })
     return this._inner.convertAsync(input, options)
   }
 
   convertFileStreaming(path, callback, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, { pipeline: this._pipeline })
     return this._inner.convertFileStreaming(path, callback, options)
   }
 }
@@ -230,9 +243,20 @@ class Pipeline {
  * @returns {AsyncGenerator<string, void, unknown>}
  */
 async function* streamFileMarkdown(filePath, options = {}) {
-  assertMlReady(mlFormatOf(filePath))
-  const { strict, fetchImages, allowedFormats, imageMode, artifactsDir } = options
-  const converter = new native.DocumentConverter({ strict, fetchImages, allowedFormats })
+  assertMlReady(mlFormatOf(filePath), undefined, options)
+  const { imageMode, artifactsDir } = options
+  // The whole object, not a hand-copied allowlist: napi reads the
+  // `ConverterOptions` fields it knows and ignores the rest (`imageMode`,
+  // `artifactsDir`), so every converter knob reaches the stream instead of the
+  // three that used to be copied by hand. `pages` above all — under
+  // `pipeline: 'vlm'` it decides how many pages are rasterized and POSTed to a
+  // metered endpoint, and dropping it would quietly send the whole document.
+  //
+  // Under `pipeline: 'vlm'` there is nothing to stream — the endpoint answers a
+  // whole page per request — so the document arrives as a single chunk. The
+  // contract holds either way: concatenating the chunks reproduces the buffered
+  // `convertFile(...).content` byte-for-byte.
+  const converter = new native.DocumentConverter(options)
   yield* chunkStream((callback) =>
     converter.convertFileStreaming(filePath, callback, { imageMode, artifactsDir }),
   )

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -81,6 +81,33 @@ pub struct ConverterOptions {
     /// uncaptioned dense-text "picture" regions into paragraphs (the escape
     /// hatch for image-extraction workflows, #173). Default `false`.
     pub no_text_panels: Option<bool>,
+    /// `"standard"` (default) or `"vlm"` (#77): replace the whole ONNX stack —
+    /// layout, OCR, TableFormer — with a remote OpenAI-compatible vision
+    /// endpoint, which converts each rendered page on its own. PDF and image
+    /// inputs only; any other format is rejected rather than silently falling
+    /// back, matching the CLI's `--pipeline vlm`.
+    ///
+    /// Selecting it explicitly is deliberate: the `DOCLING_RS_VLM_*` variables
+    /// below are fallbacks, never triggers. A stale `DOCLING_RS_VLM_ENDPOINT`
+    /// left in the environment must not silently route every PDF over the
+    /// network.
+    pub pipeline: Option<String>,
+    /// VLM server: the base `/v1` URL or the full `…/chat/completions` one —
+    /// the suffix is appended when missing. Falls back to
+    /// `$DOCLING_RS_VLM_ENDPOINT`; required when `pipeline` is `"vlm"`.
+    pub vlm_endpoint: Option<String>,
+    /// VLM model name as the server knows it (e.g. `"granite-docling"`).
+    /// Falls back to `$DOCLING_RS_VLM_MODEL`; required when `pipeline` is `"vlm"`.
+    pub vlm_model: Option<String>,
+    /// Bearer token for the VLM endpoint; local servers (LM Studio, Ollama,
+    /// vLLM) need none. Falls back to `$DOCLING_RS_VLM_API_KEY`.
+    pub vlm_api_key: Option<String>,
+    /// Instruction sent with every page image, overriding docling's
+    /// DocLang-eliciting default. Falls back to `$DOCLING_RS_VLM_PROMPT`.
+    pub vlm_prompt: Option<String>,
+    /// `max_tokens` for each page completion. Default `8192` — a dense page of
+    /// DocLang runs long, and a truncated answer loses the tail of the page.
+    pub vlm_max_tokens: Option<u32>,
     /// Emit cleaner, more conformant Markdown (code-fence languages preserved,
     /// no inline-run spacing artifacts) instead of docling's byte-for-byte
     /// legacy output. Markdown only. Default `false`.
@@ -154,6 +181,22 @@ pub struct ConvertOptions {
     /// Keep every detected picture as a picture: disable text-panel demotion
     /// (#173). Default `false`.
     pub no_text_panels: Option<bool>,
+    /// `"standard"` (default) or `"vlm"` (#77): convert PDF/image pages
+    /// through a remote OpenAI-compatible vision endpoint instead of the ONNX
+    /// stack. See [`ConverterOptions::pipeline`] for the full contract.
+    pub pipeline: Option<String>,
+    /// VLM server, base `/v1` or full `…/chat/completions` URL. Falls back to
+    /// `$DOCLING_RS_VLM_ENDPOINT`.
+    pub vlm_endpoint: Option<String>,
+    /// VLM model name. Falls back to `$DOCLING_RS_VLM_MODEL`.
+    pub vlm_model: Option<String>,
+    /// Bearer token for the VLM endpoint. Falls back to `$DOCLING_RS_VLM_API_KEY`.
+    pub vlm_api_key: Option<String>,
+    /// Per-page instruction, overriding docling's default DocLang prompt.
+    /// Falls back to `$DOCLING_RS_VLM_PROMPT`.
+    pub vlm_prompt: Option<String>,
+    /// `max_tokens` per page completion. Default `8192`.
+    pub vlm_max_tokens: Option<u32>,
     pub allowed_formats: Option<Vec<String>>,
     pub to: Option<String>,
     pub image_mode: Option<String>,
@@ -220,6 +263,10 @@ struct ConvertConfig {
     skip_ocr: bool,
     force_full_page_ocr: bool,
     no_text_panels: bool,
+    /// `Some` only for `pipeline: "vlm"` (#77), already resolved against the
+    /// `DOCLING_RS_VLM_*` environment. Its presence *is* the pipeline switch:
+    /// [`run_convert`] short-circuits the whole ML stack when it is set.
+    vlm: Option<docling::vlm::VlmOptions>,
     allowed_formats: Option<Vec<InputFormat>>,
     to: OutputKind,
     image_mode: ImageMode,
@@ -272,13 +319,14 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         ),
         None => None,
     };
+    let page_range = parse_pages(o.pages.as_deref())?;
     Ok(ConvertConfig {
         strict: o.strict.unwrap_or(false),
         fetch_images: o.fetch_images.unwrap_or(false),
         asr_model: o.asr_model,
         asr_lang: o.asr_lang,
         video_frames: o.video_frames.map(|n| n as usize),
-        page_range: parse_pages(o.pages.as_deref())?,
+        page_range,
         ocr_lang: parse_ocr_lang(o.ocr_lang)?,
         ocr_mode: parse_ocr_mode(o.ocr_mode)?,
         ocr_scale: parse_ocr_scale(o.ocr_scale)?,
@@ -289,11 +337,89 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         skip_ocr: o.skip_ocr.unwrap_or(false),
         force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
         no_text_panels: o.no_text_panels.unwrap_or(false),
+        vlm: resolve_vlm(
+            o.pipeline.as_deref(),
+            o.vlm_endpoint,
+            o.vlm_model,
+            o.vlm_api_key,
+            o.vlm_prompt,
+            o.vlm_max_tokens,
+            page_range,
+        )?,
         allowed_formats: allowed,
         to: parse_output_kind(o.to.as_deref())?,
         image_mode: parse_image_mode(o.image_mode.as_deref())?,
         artifacts_dir: o.artifacts_dir.unwrap_or_else(|| "artifacts".to_string()),
     })
+}
+
+/// Resolve the `pipeline` selection into the VLM options the conversion needs
+/// (#77), or `None` for the standard ONNX pipeline.
+///
+/// [`docling::vlm::VlmOptions::resolve`] does the endpoint/model fallback onto
+/// `DOCLING_RS_VLM_ENDPOINT` / `_MODEL` and reads `_PROMPT` / `_API_KEY` itself,
+/// so going through it — rather than building the struct field by field — is
+/// what makes the environment behave identically from Node and from the CLI.
+/// The explicit options then override whatever the environment supplied.
+///
+/// Resolution happens at option-parsing time, not at conversion time, so a
+/// missing endpoint fails fast on the call (or on the `DocumentConverter`
+/// constructor) instead of after a file has been read.
+fn resolve_vlm(
+    pipeline: Option<&str>,
+    endpoint: Option<String>,
+    model: Option<String>,
+    api_key: Option<String>,
+    prompt: Option<String>,
+    max_tokens: Option<u32>,
+    page_range: Option<(usize, usize)>,
+) -> Result<Option<docling::vlm::VlmOptions>> {
+    // An empty string counts as unset, the way `docling_core::env::nonempty`
+    // treats the variables these options fall back to. `vlmEndpoint:
+    // process.env.VLM_URL ?? ''` is an easy shape to write, and it must reach
+    // the env fallback rather than resolve to an empty endpoint.
+    let set = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
+    match pipeline {
+        None | Some("standard") => Ok(None),
+        Some("vlm") => {
+            let (endpoint, model) = (set(endpoint), set(model));
+            let (api_key, prompt) = (set(api_key), set(prompt));
+            let mut v = docling::vlm::VlmOptions::resolve(endpoint, model).map_err(|e| {
+                // InvalidArg, not GenericFailure: a missing endpoint/model is a
+                // bad call, not a conversion that went wrong.
+                Error::new(Status::InvalidArg, e.to_string())
+            })?;
+            if prompt.is_some() {
+                v.prompt = prompt;
+            }
+            if api_key.is_some() {
+                v.api_key = api_key;
+            }
+            // Validated like `ocrScale`: 0 would have every page come back
+            // empty and surface as "the model's responses contained no
+            // parseable DocLang" — a message pointing at the model, not at the
+            // option. (napi applies JS ToUint32, so a negative number arrives
+            // here as a huge one; the server rejects that on its own terms.)
+            match max_tokens {
+                Some(0) => {
+                    return Err(Error::new(
+                        Status::InvalidArg,
+                        "vlmMaxTokens must be greater than 0",
+                    ))
+                }
+                Some(n) => v.max_tokens = n as usize,
+                None => {}
+            }
+            // `pages` composes with the VLM exactly as with the ML pipeline —
+            // only the selected pages are rendered and sent.
+            v.page_range = page_range;
+            Ok(Some(v))
+        }
+        Some(other) => Err(Error::new(
+            Status::InvalidArg,
+            format!("unknown pipeline '{other}' (expected: standard, vlm)"),
+        )),
+    }
 }
 
 /// Validate an `ocrLang` option (`"en"`/`"ch"`); an unknown id is an error.
@@ -397,9 +523,43 @@ fn render_doc(
     }
 }
 
+/// Enforce the `allowedFormats` restriction. The VLM branches convert without
+/// going through `DocumentConverter`, which is where that check normally lives
+/// — so they have to run it themselves, with the same error the standard path
+/// raises, or the restriction would silently lapse under `pipeline: "vlm"`.
+fn check_allowed(source: &SourceDocument, cfg: &ConvertConfig) -> Result<()> {
+    match &cfg.allowed_formats {
+        Some(allowed) if !allowed.contains(&source.format) => Err(convert_err(
+            docling::ConversionError::UnsupportedFormat(source.format),
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// Run a buffered conversion and render it per the config. Runs off the JS
 /// thread for the async path, so it must stay free of napi/JS types.
 fn run_convert(source: SourceDocument, cfg: &ConvertConfig) -> Result<RawResult> {
+    // #77: the remote VLM replaces the entire ML stack — no ONNX model is
+    // loaded, and every other converter knob (OCR, TableFormer, text panels)
+    // has nothing to act on. `convert_vlm` fails the whole document if a single
+    // page fails, so there is no partial_success to report here.
+    if let Some(vlm) = &cfg.vlm {
+        check_allowed(&source, cfg)?;
+        let format = source.format.as_str().to_string();
+        let mut document = docling::vlm::convert_vlm(&source, vlm).map_err(convert_err)?;
+        // The serializer knobs `DocumentConverter::convert` would have applied
+        // (converter.rs) — this path never reaches it, so they are set here or
+        // they silently lapse under `pipeline: "vlm"`.
+        document.strict_markdown = cfg.strict;
+        document.compact_tables = cfg.compact_tables;
+        return Ok(render_doc(
+            document,
+            cfg,
+            source.name,
+            format,
+            "success".to_string(),
+        ));
+    }
     let converter = build_converter(cfg);
     let result = converter.convert(source).map_err(convert_err)?;
     let format = result.format.as_str().to_string();
@@ -552,6 +712,11 @@ pub struct DocumentConverter {
     skip_ocr: bool,
     force_full_page_ocr: bool,
     no_text_panels: bool,
+    // Resolved once in the constructor and cloned per call: a converter is
+    // configuration, so a missing endpoint should surface at `new`, and the
+    // `DOCLING_RS_VLM_*` environment should be read at the same moment every
+    // other option is.
+    vlm: Option<docling::vlm::VlmOptions>,
     allowed_formats: Option<Vec<InputFormat>>,
 }
 
@@ -568,13 +733,14 @@ impl DocumentConverter {
             ),
             None => None,
         };
+        let page_range = parse_pages(o.pages.as_deref())?;
         Ok(Self {
             strict: o.strict.unwrap_or(false),
             fetch_images: o.fetch_images.unwrap_or(false),
             asr_model: o.asr_model.clone(),
             asr_lang: o.asr_lang.clone(),
             video_frames: o.video_frames.map(|n| n as usize),
-            page_range: parse_pages(o.pages.as_deref())?,
+            page_range,
             ocr_lang: parse_ocr_lang(o.ocr_lang.clone())?,
             ocr_mode: parse_ocr_mode(o.ocr_mode.clone())?,
             ocr_scale: parse_ocr_scale(o.ocr_scale)?,
@@ -585,6 +751,15 @@ impl DocumentConverter {
             skip_ocr: o.skip_ocr.unwrap_or(false),
             force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
             no_text_panels: o.no_text_panels.unwrap_or(false),
+            vlm: resolve_vlm(
+                o.pipeline.as_deref(),
+                o.vlm_endpoint.clone(),
+                o.vlm_model.clone(),
+                o.vlm_api_key.clone(),
+                o.vlm_prompt.clone(),
+                o.vlm_max_tokens,
+                page_range,
+            )?,
             allowed_formats: allowed,
         })
     }
@@ -608,6 +783,7 @@ impl DocumentConverter {
             skip_ocr: self.skip_ocr,
             force_full_page_ocr: self.force_full_page_ocr,
             no_text_panels: self.no_text_panels,
+            vlm: self.vlm.clone(),
             allowed_formats: self.allowed_formats.clone(),
             to: parse_output_kind(out.to.as_deref())?,
             image_mode: parse_image_mode(out.image_mode.as_deref())?,
@@ -670,9 +846,11 @@ impl DocumentConverter {
     ///
     /// `callback` is invoked as `(err, chunk)`: once per Markdown chunk with
     /// `chunk` a string, once with `chunk === null` at the end, or once with a
-    /// non-null `err` on failure. Only `placeholder` / `embedded` image modes
-    /// stream; `referenced` is rejected. Prefer the `streamFileMarkdown`
-    /// async-generator wrapper in JS over calling this directly.
+    /// non-null `err` on failure. Every image mode streams here, `referenced`
+    /// included (its links resolve against `artifactsDir`) — unlike the warm
+    /// [`Pipeline`]'s streaming, which rejects it. Prefer the
+    /// `streamFileMarkdown` async-generator wrapper in JS over calling this
+    /// directly.
     #[napi]
     pub fn convert_file_streaming(
         &self,
@@ -693,6 +871,44 @@ impl DocumentConverter {
                     return;
                 }
             };
+            // #77: nothing streams out of the VLM — a whole page is one request
+            // and the answer only parses once complete, so there is no earlier
+            // moment to emit. Convert buffered and push the document as a single
+            // chunk, which keeps the generator's contract intact (concatenating
+            // the chunks still reproduces the buffered Markdown byte-for-byte).
+            if let Some(vlm) = &cfg.vlm {
+                if let Err(e) = check_allowed(&source, &cfg) {
+                    callback.call(Err(e), ThreadsafeFunctionCallMode::NonBlocking);
+                    return;
+                }
+                let doc = match docling::vlm::convert_vlm(&source, vlm) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        callback.call(Err(convert_err(e)), ThreadsafeFunctionCallMode::NonBlocking);
+                        return;
+                    }
+                };
+                // `with_artifacts`, not `new`: `new` carries a debug_assert
+                // against `Referenced` (it has no artifacts dir), which this
+                // path can reach — `convertFileStreaming` accepts every image
+                // mode, unlike the warm `Pipeline`'s streaming, which rejects
+                // `referenced` up front. Mirrors the buffered branch above,
+                // which honours both `compactTables` and `artifactsDir`.
+                let mut streamer = MarkdownStreamer::with_artifacts(
+                    cfg.strict,
+                    image_mode,
+                    cfg.compact_tables,
+                    &cfg.artifacts_dir,
+                );
+                for chunk in [streamer.push(&doc.nodes, &doc.links), streamer.finish()] {
+                    if !chunk.is_empty() {
+                        callback.call(Ok(Some(chunk)), ThreadsafeFunctionCallMode::NonBlocking);
+                    }
+                }
+                // End-of-stream sentinel.
+                callback.call(Ok(None), ThreadsafeFunctionCallMode::NonBlocking);
+                return;
+            }
             let stream = match converter.convert_streaming_images(source, image_mode) {
                 Ok(s) => s,
                 Err(e) => {
@@ -748,7 +964,29 @@ impl Pipeline {
     /// `fetchImages` / `allowedFormats` don't apply to the PDF/image pipeline.
     #[napi(constructor)]
     pub fn new(options: Option<ConverterOptions>) -> Result<Self> {
-        let strict = options.and_then(|o| o.strict).unwrap_or(false);
+        let options = options.unwrap_or_default();
+        // This class exists to keep the ONNX models warm across calls. The VLM
+        // pipeline loads no models, so there is nothing to keep warm and no
+        // reuse to gain — refuse rather than quietly converting through the
+        // very stack the caller asked to replace (#77).
+        match options.pipeline.as_deref() {
+            None | Some("standard") => {}
+            Some("vlm") => {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    "Pipeline keeps the ONNX models warm; the 'vlm' pipeline loads no models, \
+                     so it has nothing to reuse. Use DocumentConverter (or convertFile / \
+                     convertFileAsync) with pipeline: 'vlm'.",
+                ))
+            }
+            Some(other) => {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    format!("unknown pipeline '{other}' (expected: standard, vlm)"),
+                ))
+            }
+        }
+        let strict = options.strict.unwrap_or(false);
         Ok(Self {
             inner: Arc::new(Mutex::new(RsPipeline::new().map_err(convert_err)?)),
             strict,
@@ -1029,6 +1267,9 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
         skip_ocr: false,
         force_full_page_ocr: false,
         no_text_panels: false,
+        // The warm `Pipeline` is the ONNX-models class; `Pipeline::new` rejects
+        // `pipeline: "vlm"` outright, so nothing reaches here with one set.
+        vlm: None,
         ocr_lang: None,
         ocr_mode: None,
         ocr_scale: None,
@@ -1496,4 +1737,105 @@ fn status_str(status: ConversionStatus) -> String {
 
 fn convert_err(e: impl std::fmt::Display) -> Error {
     Error::new(Status::GenericFailure, e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // napi-derive gates its N-API registration glue behind `cfg(not(test))`, so
+    // the cdylib's lib target still links as an ordinary test binary and the
+    // pure option-resolution helpers can be pinned here. This is the *enforced*
+    // gate for them: `cargo test --workspace` runs these, whereas the Node
+    // smoke test needs a built addon and no workflow invokes it.
+
+    #[test]
+    fn standard_pipeline_needs_no_vlm_options() {
+        for p in [None, Some("standard")] {
+            let got =
+                resolve_vlm(p, None, None, None, None, None, None).expect("standard pipeline");
+            assert!(got.is_none(), "pipeline {p:?} must not build VLM options");
+        }
+    }
+
+    #[test]
+    fn unknown_pipeline_is_rejected() {
+        let err = resolve_vlm(Some("granite"), None, None, None, None, None, None).unwrap_err();
+        assert_eq!(err.status, Status::InvalidArg);
+        assert!(
+            err.reason.contains("unknown pipeline"),
+            "reason: {}",
+            err.reason
+        );
+    }
+
+    /// Every explicit option must land on the resolved struct — including the
+    /// four `resolve_vlm` applies itself on top of `VlmOptions::resolve`
+    /// (api_key, prompt, max_tokens, page_range). Precedence against a *set*
+    /// `DOCLING_RS_VLM_*` is not asserted here: `std::env::set_var` is unsound
+    /// under the parallel test harness.
+    #[test]
+    fn explicit_vlm_options_all_reach_the_resolved_struct() {
+        let got = resolve_vlm(
+            Some("vlm"),
+            Some("http://127.0.0.1:1/v1".into()),
+            Some("granite-docling".into()),
+            Some("sekret".into()),
+            Some("Describe this page.".into()),
+            Some(512),
+            Some((2, 4)),
+        )
+        .expect("vlm pipeline")
+        .expect("vlm pipeline yields options");
+        assert_eq!(got.endpoint, "http://127.0.0.1:1/v1");
+        assert_eq!(got.model, "granite-docling");
+        assert_eq!(got.api_key.as_deref(), Some("sekret"));
+        assert_eq!(got.prompt.as_deref(), Some("Describe this page."));
+        assert_eq!(got.max_tokens, 512);
+        assert_eq!(got.page_range, Some((2, 4)));
+    }
+
+    /// A missing endpoint is a bad call, not a failed conversion — and it has
+    /// to surface while options are parsed, before any file is read.
+    #[test]
+    fn vlm_without_an_endpoint_is_an_invalid_arg() {
+        if std::env::var_os("DOCLING_RS_VLM_ENDPOINT").is_some() {
+            eprintln!("skipping: DOCLING_RS_VLM_ENDPOINT is set in this environment");
+            return;
+        }
+        let err =
+            resolve_vlm(Some("vlm"), None, Some("m".into()), None, None, None, None).unwrap_err();
+        assert_eq!(err.status, Status::InvalidArg);
+        assert!(
+            err.reason.contains("DOCLING_RS_VLM_ENDPOINT"),
+            "reason: {}",
+            err.reason
+        );
+    }
+
+    /// `vlmEndpoint: process.env.VLM_URL ?? ''` must reach the env fallback,
+    /// not resolve to an empty endpoint — the same rule `env::nonempty`
+    /// applies to the variables these options fall back to.
+    #[test]
+    fn blank_vlm_options_count_as_unset() {
+        if std::env::var_os("DOCLING_RS_VLM_ENDPOINT").is_some() {
+            eprintln!("skipping: DOCLING_RS_VLM_ENDPOINT is set in this environment");
+            return;
+        }
+        let err = resolve_vlm(
+            Some("vlm"),
+            Some("   ".into()),
+            Some("m".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.reason.contains("DOCLING_RS_VLM_ENDPOINT"),
+            "reason: {}",
+            err.reason
+        );
+    }
 }

--- a/crates/docling-node/test/smoke.mjs
+++ b/crates/docling-node/test/smoke.mjs
@@ -13,6 +13,7 @@ import {
   chunkDocumentAsync,
   chunkFileAsync,
   convert,
+  convertAsync,
   convertFile,
   convertFileAsync,
   DocumentConverter,
@@ -25,6 +26,11 @@ import {
 } from '../index.js'
 
 let passed = 0
+const failures = []
+// Record and continue instead of rethrowing: a rethrow rejected main(), so the
+// first failing check hid every check below it — most of this file, given one
+// long-standing failure partway down. The checks are independent, so running
+// them all and reporting the full list is strictly more useful.
 const check = (name, fn) => {
   return Promise.resolve()
     .then(fn)
@@ -33,9 +39,9 @@ const check = (name, fn) => {
       console.log(`  ok  ${name}`)
     })
     .catch((err) => {
+      failures.push(name)
       console.error(`fail  ${name}\n      ${err.message}`)
       process.exitCode = 1
-      throw err
     })
 }
 
@@ -182,13 +188,18 @@ async function main() {
       assert.ok(hybrid.length > hier.length, `expected split: hybrid ${hybrid.length} vs hierarchical ${hier.length}`)
       assert.deepEqual(hybrid[0].headings, ['Doc'])
     })
-    await check('hybrid picks up models/chunk/tokenizer.json by default', async () => {
+    await check('hybrid picks up .models/chunk/tokenizer.json by default', async () => {
       const { mkdirSync, copyFileSync, mkdtempSync: mktemp } = await import('node:fs')
       const { tmpdir: osTmp } = await import('node:os')
       const { join: joinPath } = await import('node:path')
       const home = mktemp(joinPath(osTmp(), 'fw-chunk-'))
-      mkdirSync(joinPath(home, 'models', 'chunk'), { recursive: true })
-      copyFileSync(TOKENIZER, joinPath(home, 'models', 'chunk', 'tokenizer.json'))
+      // `.models`, not `models`: deps.js's homeDir() only adopts the cwd as the
+      // install home when it holds `.models/` (or `.pdfium/`). The plain
+      // `models/` layout is the one internal to ~/.cache/docling.rs, reachable
+      // through DOCLING_RS_HOME — never by chdir alone, which is what this
+      // check does. (Long-standing failure; unrelated to the VLM work.)
+      mkdirSync(joinPath(home, '.models', 'chunk'), { recursive: true })
+      copyFileSync(TOKENIZER, joinPath(home, '.models', 'chunk', 'tokenizer.json'))
       const prevCwd = process.cwd()
       process.chdir(home) // deps.js resolves the install home from the cwd
       try {
@@ -252,6 +263,307 @@ async function main() {
   } else {
     console.log('  --  ML deps installed; skipping guard checks')
   }
+
+  // --- VLM pipeline (#77) ----------------------------------------------------
+  //
+  // `pipeline: 'vlm'` replaces the ONNX stack with a remote OpenAI-compatible
+  // endpoint, so every check here runs with no models on disk. They all use
+  // image input on purpose: an image is already its own page, so this leg needs
+  // neither the layout model nor pdfium and runs in any environment — the same
+  // reasoning as `vlm_converts_an_image_without_pdfium` in
+  // crates/docling/tests/vlm.rs.
+
+  // A 1x1 PNG. `convert_vlm` forwards image bytes untouched, but a real file
+  // keeps the fixture honest if that ever changes.
+  const PNG = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64',
+  )
+
+  // A mock of an OpenAI-compatible /chat/completions endpoint, the JS
+  // counterpart of crates/docling/tests/vlm.rs's `mock_openai`. Node's own
+  // http module — no dependency. `onRequest` sees each parsed request body; a
+  // throw from it answers 400, which `convert_vlm` treats as fatal (only
+  // transport errors, 408/429 and 5xx retry), so an assertion failure surfaces
+  // immediately instead of after the retry backoff.
+  const mockVlm = async (content, onRequest) => {
+    const { createServer } = await import('node:http')
+    const state = { served: 0 }
+    const server = createServer((req, res) => {
+      const body = []
+      req.on('data', (d) => body.push(d))
+      req.on('end', () => {
+        state.served++
+        try {
+          if (onRequest) onRequest(JSON.parse(Buffer.concat(body).toString('utf8')), req)
+        } catch (err) {
+          res.writeHead(400).end(err.message)
+          return
+        }
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ choices: [{ message: { role: 'assistant', content } }] }))
+      })
+    })
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    return {
+      url: `http://127.0.0.1:${server.address().port}/v1`,
+      // How many requests actually reached the endpoint — the only way to tell
+      // "rejected before converting" from "converted anyway".
+      get served() {
+        return state.served
+      },
+      // close() in a finally: a live listener keeps the process alive past
+      // main(), and closed keep-alive sockets would too.
+      close: () => {
+        server.closeAllConnections?.()
+        server.close()
+      },
+    }
+  }
+
+  // Assertions on request defaults only hold when the ambient environment isn't
+  // supplying them — `VlmOptions::resolve` seeds the prompt from
+  // DOCLING_RS_VLM_PROMPT, and DOCLING_RS_VLM_EXTRA_BODY is merged over the
+  // body. A VLM developer very plausibly has these exported.
+  const vlmEnv = (name) => !!process.env[`DOCLING_RS_VLM_${name}`]
+
+  await check('unknown pipeline name is rejected', () => {
+    assert.throws(
+      () => convert({ name: 'x.md', data: Buffer.from(MD) }, { pipeline: 'magic' }),
+      /unknown pipeline/,
+    )
+  })
+
+  await check("Pipeline (the warm-ONNX class) refuses pipeline: 'vlm'", () => {
+    assert.throws(() => new Pipeline({ pipeline: 'vlm' }), /loads no models/)
+  })
+
+  await check('Pipeline rejects an unknown pipeline name too', () => {
+    assert.throws(() => new Pipeline({ pipeline: 'magic' }), /unknown pipeline/)
+  })
+
+  await check('a misspelled pipeline name reports the typo, not a missing model', () => {
+    // The JS guard runs before native option parsing, so it has to recognize a
+    // bad name itself — otherwise a capitalization slip falls through to the
+    // strict ONNX requirement and reads as "download hundreds of MB of models".
+    assert.throws(
+      () =>
+        convert(
+          { name: 'doc.pdf', data: Buffer.from('%PDF-1.4') },
+          { pipeline: 'VLM', vlmEndpoint: 'http://127.0.0.1:1/v1', vlmModel: 'm' },
+        ),
+      (e) => /unknown pipeline 'VLM'/.test(e.message) && !/download_dependencies/.test(e.message),
+    )
+  })
+
+  await check('mets_gbs under vlm says what is wrong instead of asking for pdfium', () => {
+    // METS-GBS is an ML format with no VLM path; fetching pdfium can't help.
+    assert.throws(
+      () =>
+        convert(
+          { name: 'scans.tar.gz', data: Buffer.from([0]) },
+          { pipeline: 'vlm', vlmEndpoint: 'http://127.0.0.1:1/v1', vlmModel: 'm' },
+        ),
+      (e) =>
+        /converts PDF and image inputs/.test(e.message) &&
+        !/download_dependencies/.test(e.message),
+    )
+  })
+
+  await check('vlmMaxTokens: 0 is rejected at option-parse time', () => {
+    assert.throws(
+      () =>
+        convert(
+          { name: 'scan.png', data: PNG },
+          {
+            pipeline: 'vlm',
+            vlmEndpoint: 'http://127.0.0.1:1/v1',
+            vlmModel: 'm',
+            vlmMaxTokens: 0,
+          },
+        ),
+      /vlmMaxTokens must be greater than 0/,
+    )
+  })
+
+  if (!checkDependencies().pdfium) {
+    await check("pipeline: 'vlm' still requires pdfium for PDF input", () => {
+      // The other half of the relaxed guard: the layout model must NOT be
+      // demanded, but pdfium must — VLM rasterizes PDF pages locally before
+      // sending them. Skipped when pdfium is installed (nothing to assert, and
+      // the call would then spend the endpoint's retry backoff failing).
+      assert.throws(
+        () =>
+          convert(
+            { name: 'doc.pdf', data: Buffer.from('%PDF-1.4') },
+            { pipeline: 'vlm', vlmEndpoint: 'http://127.0.0.1:1/v1', vlmModel: 'm' },
+          ),
+        (e) => /pdfium/.test(e.message) && !/layout_heron/.test(e.message),
+      )
+    })
+  } else {
+    console.log('  --  pdfium installed; skipping the VLM pdfium-requirement check')
+  }
+
+  if (!process.env.DOCLING_RS_VLM_ENDPOINT) {
+    await check("pipeline: 'vlm' skips the ML guard and fails on the missing endpoint", () => {
+      // Reaching the endpoint error at all is the assertion: under the standard
+      // pipeline this same call demands layout_heron.onnx (see the guard checks
+      // above), so a download_dependencies hint here would mean the VLM
+      // exemption in deps.js never fired.
+      assert.throws(
+        () => convert({ name: 'scan.png', data: PNG }, { pipeline: 'vlm' }),
+        /DOCLING_RS_VLM_ENDPOINT/,
+      )
+    })
+  } else {
+    console.log('  --  DOCLING_RS_VLM_ENDPOINT set; skipping the missing-endpoint check')
+  }
+
+  await check("pipeline: 'vlm' converts an image through the endpoint", async () => {
+    let seen = null
+    const mock = await mockVlm('<text>Hello from the VLM.</text>', (body, req) => {
+      seen = { body, auth: req.headers.authorization }
+    })
+    try {
+      // Async, not sync: a sync convert would block the event loop the mock
+      // server answers on, and the request would only ever time out.
+      const res = await convertAsync(
+        { name: 'scan.png', data: PNG, format: 'image' },
+        {
+          pipeline: 'vlm',
+          vlmEndpoint: mock.url,
+          vlmModel: 'mock-docling',
+          vlmMaxTokens: 512,
+          vlmApiKey: 'sekret',
+        },
+      )
+      assert.equal(res.status, 'success')
+      assert.equal(res.format, 'image')
+      assert.match(res.content, /Hello from the VLM\./)
+    } finally {
+      mock.close()
+    }
+    // The wire shape the CLI's --pipeline vlm sends too.
+    assert.equal(seen.body.model, 'mock-docling')
+    const image = seen.body.messages[0].content.find((c) => c.type === 'image_url')
+    assert.ok(image.image_url.url.startsWith('data:image/png;base64,'))
+    // vlmApiKey travels as a Bearer header, not in the body — the only place
+    // that plumbing is observable.
+    assert.equal(seen.auth, 'Bearer sekret')
+    if (!vlmEnv('EXTRA_BODY')) assert.equal(seen.body.max_tokens, 512)
+    if (!vlmEnv('PROMPT')) {
+      assert.equal(seen.body.messages[0].content[0].text, 'Convert this page to docling.')
+    }
+  })
+
+  await check("pipeline: 'vlm' honours to: 'json'", async () => {
+    const mock = await mockVlm('<heading level="1">Doc</heading><text>Body.</text>')
+    try {
+      const res = await convertAsync(
+        { name: 'scan.png', data: PNG, format: 'image' },
+        { pipeline: 'vlm', vlmEndpoint: mock.url, vlmModel: 'm', to: 'json' },
+      )
+      const doc = JSON.parse(res.content)
+      assert.equal(doc.schema_name, 'DoclingDocument')
+      assert.ok(JSON.stringify(doc.texts).includes('Body.'))
+    } finally {
+      mock.close()
+    }
+  })
+
+  await check('vlmPrompt overrides the default page instruction', async () => {
+    let seen = null
+    const mock = await mockVlm('<text>ok</text>', (body) => {
+      seen = body
+    })
+    try {
+      await convertAsync(
+        { name: 'scan.png', data: PNG, format: 'image' },
+        { pipeline: 'vlm', vlmEndpoint: mock.url, vlmModel: 'm', vlmPrompt: 'Describe this page.' },
+      )
+    } finally {
+      mock.close()
+    }
+    assert.equal(seen.messages[0].content[0].text, 'Describe this page.')
+  })
+
+  await check('DocumentConverter carries the vlm pipeline across calls', async () => {
+    const mock = await mockVlm('<text>Reused.</text>')
+    try {
+      const converter = new DocumentConverter({
+        pipeline: 'vlm',
+        vlmEndpoint: mock.url,
+        vlmModel: 'm',
+      })
+      const a = await converter.convertAsync({ name: 'a.png', data: PNG, format: 'image' })
+      const b = await converter.convertAsync({ name: 'b.png', data: PNG, format: 'image' })
+      assert.match(a.content, /Reused\./)
+      assert.equal(a.content, b.content)
+    } finally {
+      mock.close()
+    }
+  })
+
+  await check('allowedFormats still applies under the vlm pipeline', async () => {
+    const mock = await mockVlm('<text>never asked</text>')
+    try {
+      const converter = new DocumentConverter({
+        allowedFormats: ['pdf'],
+        pipeline: 'vlm',
+        vlmEndpoint: mock.url,
+        vlmModel: 'm',
+      })
+      // The VLM branch converts without going through the Rust
+      // DocumentConverter, where this restriction normally lives — so it has to
+      // re-check, or allowedFormats would lapse exactly under `pipeline: 'vlm'`.
+      await assert.rejects(
+        converter.convertAsync({ name: 'scan.png', data: PNG, format: 'image' }),
+        /no backend implemented yet for format 'image'/,
+      )
+      // The message alone doesn't prove it: the standard path emits the same
+      // text. What pins the VLM branch is that the endpoint was never called.
+      assert.equal(mock.served, 0, 'the VLM must not be contacted for a disallowed format')
+    } finally {
+      mock.close()
+    }
+  })
+
+  await check('vlm rejects a non-visual format instead of falling back', async () => {
+    const mock = await mockVlm('<text>never asked</text>')
+    try {
+      await assert.rejects(
+        convertAsync(
+          { name: 'x.md', data: Buffer.from(MD) },
+          { pipeline: 'vlm', vlmEndpoint: mock.url, vlmModel: 'm' },
+        ),
+        /vlm pipeline converts PDF and image/,
+      )
+    } finally {
+      mock.close()
+    }
+  })
+
+  await check('streamFileMarkdown under vlm reproduces the buffered Markdown', async () => {
+    const { writeFileSync: wf, mkdtempSync: mt } = await import('node:fs')
+    const { tmpdir: tmp } = await import('node:os')
+    const { join: jn } = await import('node:path')
+    const png = jn(mt(jn(tmp(), 'fw-vlm-')), 'scan.png')
+    wf(png, PNG)
+    const mock = await mockVlm('<heading level="1">Streamed</heading><text>Body.</text>')
+    try {
+      const opts = { pipeline: 'vlm', vlmEndpoint: mock.url, vlmModel: 'm' }
+      let streamed = ''
+      for await (const c of streamFileMarkdown(png, opts)) streamed += c
+      // Nothing streams out of a VLM — the document arrives as one chunk — but
+      // the generator's contract still holds: the concatenation is the buffered
+      // output, byte for byte.
+      assert.equal(streamed, (await convertFileAsync(png, opts)).content)
+      assert.match(streamed, /# Streamed/)
+    } finally {
+      mock.close()
+    }
+  })
 
   // File-based sync + async + streaming, using a temp Markdown file.
   const { writeFileSync, mkdtempSync } = await import('node:fs')
@@ -334,6 +646,9 @@ async function main() {
   }
 
   console.log(`\n${passed} checks passed`)
+  if (failures.length > 0) {
+    console.error(`${failures.length} failed:\n  - ${failures.join('\n  - ')}`)
+  }
 }
 
 main().catch(() => {

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -469,7 +469,9 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   --vlm-model NAME` renders pages via pdfium, converts them through any
   OpenAI-compatible vision endpoint (LM Studio / Ollama / vLLM / hosted) and
   parses the returned DocLang with the existing reader — see the README's
-  "VLM pipeline" section. (**Audio/ASR is now done** — see §2; Opus and AVI,
+  "VLM pipeline" section. Also on the Node bindings as `pipeline: 'vlm'`
+  (`vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` / `vlmMaxTokens`);
+  serve and the Python bindings don't carry it yet. (**Audio/ASR is now done** — see §2; Opus and AVI,
   which symphonia cannot decode, use the optional ffmpeg fallback. The **enrichment
   models are now done** too: DocumentFigureClassifier-v2.5 for
   `do_picture_classification` and CodeFormulaV2 — an Idefics3-class VLM,
@@ -537,7 +539,9 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   with swappable embedders (Ollama/Gemini/local ONNX), stores
   (SQLite+sqlite-vec / PostgreSQL+pgvector), LLM, sources and queues, plus an
   eval harness and a REST API. See the crate README.
-- **`docling-node`** — Node.js/Bun N-API bindings (npm package).
+- **`docling-node`** — Node.js/Bun N-API bindings (npm package): the full
+  converter surface plus the chunkers, Markdown/chunk streaming, a warm
+  `Pipeline` for many PDFs, and the remote VLM pipeline (`pipeline: 'vlm'`).
 - **`docling-wasm`** — WebAssembly bindings: the declarative converters (and
   digital PDFs via the opt-in `pdf-text` text-layer feature — the same
   extraction as `--no-ocr`, no pdfium/ONNX) run fully client-side in the


### PR DESCRIPTION
The remote VLM pipeline (#77) was CLI-only, so converting through an
OpenAI-compatible vision endpoint from Node meant driving the `docling-rs` binary as
a subprocess — losing `ConvertResult`, `to: 'json'`, the image artifacts and the
streaming generator, and leaving the npm package not self-sufficient.

`pipeline: 'vlm'` plus `vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` /
`vlmMaxTokens` now sit on both `ConverterOptions` (the reusable `DocumentConverter`)
and `ConvertOptions` (the one-shot functions), resolved through
`docling::vlm::VlmOptions::resolve` rather than by rebuilding the struct field by
field — so the `DOCLING_RS_VLM_*` fallbacks behave from Node exactly as under
`--pipeline vlm`. Selecting the pipeline stays explicit: the environment supplies
values, it never switches the pipeline on, so a stale `DOCLING_RS_VLM_ENDPOINT`
cannot reroute an ordinary PDF conversion over the network.

`run_convert` is the single chokepoint for every buffered path (sync, async, both
classes), so one branch there covers them all. Four places needed handling of their
own:

- **The JS dependency guard.** `assertMlReady` demanded `layout_heron.onnx` for every
  PDF, so a VLM conversion threw before reaching Rust. It now takes the convert
  options: under `pipeline: 'vlm'` only pdfium is required, and nothing at all for
  image input. It also validates the pipeline name and rejects METS-GBS up front —
  that format has no VLM path, so relaxing the model requirement for it would only
  have sent the user to fetch a pdfium that cannot help.
- **`convertFileStreaming`** would silently have used the ONNX stack. A VLM answers a
  whole page per request, so it emits the document as one chunk; the generator's
  concatenation contract holds either way. It builds the streamer with
  `MarkdownStreamer::with_artifacts`, not `new` — `new` carries a `debug_assert`
  against `Referenced`, which this path can reach.
- **The VLM branches bypass the Rust `DocumentConverter`**, where `allowedFormats` and
  the `compactTables` / `strict` serializer flags are applied, so they apply them
  themselves.
- **`streamFileMarkdown`** rebuilt its converter from a hand-copied option allowlist,
  which dropped `pages` — under VLM that decides how many pages are rasterized and
  POSTed to a metered endpoint. It now forwards the whole options object, and
  `StreamOptions` extends `ConverterOptions` so the type cannot drift again.

`Pipeline` rejects `pipeline: 'vlm'` rather than accepting it: it exists to keep ONNX
models warm, and the VLM loads none.

**Tests.** Five `#[cfg(test)]` cases pin `resolve_vlm`. napi-derive gates its
registration glue behind `cfg(not(test))`, so the cdylib links as an ordinary test
binary and these run under `cargo test --workspace` — the only enforced gate here,
since no workflow invokes the Node smoke test. Fifteen smoke checks cover the rest
against a `node:http` mock of an OpenAI-compatible endpoint, all on the image leg so
they need neither pdfium nor models.

Two incidental test-harness fixes were needed to make any of that observable:
`check()` reported a failure by rethrowing, which rejected `main()` and hid every
check below it; and the long-standing `hybrid picks up models/chunk/tokenizer.json`
failure sat above the new ones — it built its temp home as `models/` when `homeDir()`
only adopts a cwd holding `.models/`. `npm test` now runs green end to end.

**What I ran** (CI never executes the JS side):

- `cargo fmt --all --check`
- `cargo clippy -p docling-node --all-targets -- -D warnings`
- `cargo test -p docling-node --lib` — 5/5
- `cargo check --workspace --locked`
- `cd crates/docling-node && npm run build:debug && npm test` — 44/44, exit 0

No conformance numbers move: the change is confined to the Node binding, and the
PDF/declarative corpora are untouched.

**Not covered.** This leaves the pipeline plumbed through the CLI and Node but not
through `docling-serve` or the Python bindings. For serve that is not a mechanical
addition — a caller-supplied `vlm_endpoint` is the same outbound-request exposure that
`allow_url_fetch` already gates behind an explicit opt-in, and the response is parsed
back into the returned document — so it wants a deliberate decision. The Python
binding has no such objection and would be a straightforward follow-up. The `chunk*`
family also has no VLM path (`ChunkOptions` carries no `pipeline`); the README
documents the `convertFileAsync({to:'json'})` → `chunkDocument` workaround.

Closes #290
