### PR TITLE
chore: add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4",
+      "integrity": "sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "docling-rs",
+	"image": "mcr.microsoft.com/devcontainers/rust:2-1-trixie",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:2": {
+			"nodeGypDependencies": true,
+			"version": "lts",
+			"npmVersion": "lts",
+			"pnpmVersion": "none",
+			"nvmVersion": "latest"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"anthropic.claude-code"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Closes #292.

Adds `.devcontainer/devcontainer.json` and `.devcontainer/devcontainer-lock.json`: the
`mcr.microsoft.com/devcontainers/rust:2-1-trixie` image with the `github-cli` and `node`
(LTS) features, feature digests pinned in the lock file.

No `postCreateCommand`: models and pdfium stay an opt-in
`scripts/install/download_dependencies.sh` away, so the image stays small and the
declarative test suite is green out of the box.

**Verified in the container built from this config**: `rustc 1.98.0` (above the 1.88
MSRV), `node v24.20.0`, `gh 2.98.0`; `cargo check -p docling-core` clean.

Config-only change — no crate source touched, so the release job publishes nothing.
