### PR TITLE
feat(node): expose the remote VLM pipeline (pipeline: 'vlm') in the N…

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,11 @@ docling-rs --pipeline vlm \
 `--vlm-endpoint` takes the server's `/v1` base or the full
 `…/chat/completions` URL; `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL` /
 `DOCLING_RS_VLM_PROMPT` / `DOCLING_RS_VLM_API_KEY` (Bearer token) are the env
-equivalents. `--pages A-B` composes (only the window's pages are rendered and
+equivalents. The [Node bindings](./crates/docling-node) expose the same
+pipeline (#290): `pipeline: 'vlm'` plus `vlmEndpoint` / `vlmModel` /
+`vlmApiKey` / `vlmPrompt` / `vlmMaxTokens` on the convert options (explicit
+opt-in — the env vars fill in details but never switch the pipeline), with
+the dependency guard relaxed to pdfium-for-PDF only. `--pages A-B` composes (only the window's pages are rendered and
 sent), and `--to md|json|dclx|chunks` plus `--strict` work as usual. Transient
 endpoint failures (timeouts, 408/429, 5xx) retry with exponential backoff;
 a page that still fails fails the conversion — no silently dropped pages.

--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -350,6 +350,30 @@ then `convert` / `convertFile` / `convertFileAsync` / `convertAsync` /
   (`"auto"` default) for audio/video sources.
 - `videoFrames`: max frames sampled from a video input as timestamped pictures
   (`0` = transcript only; default 8, needs ffmpeg at runtime).
+- `pipeline`: `"standard"` (default) or `"vlm"` (#290) — convert PDF/image
+  input through a remote **OpenAI-compatible** vision endpoint returning
+  DocLang (issue #77) instead of the local ML stack. Explicit opt-in only:
+  the `DOCLING_RS_VLM_*` env vars fill in connection details but never
+  switch the pipeline by themselves. No ONNX models are needed (a PDF still
+  rasterizes locally through pdfium; an image is sent as-is); prefer the
+  async API — the endpoint round-trips dominate — and note there is no
+  streaming for this pipeline.
+- `vlmEndpoint` / `vlmModel`: the server's `/v1` base (or full
+  `…/chat/completions`) URL and model name; env fallbacks
+  `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL`. Required (with those
+  fallbacks) when `pipeline: "vlm"`.
+- `vlmApiKey` / `vlmPrompt` / `vlmMaxTokens`: Bearer token, per-page
+  instruction, and per-page `max_tokens` (default 8192); env fallbacks
+  `DOCLING_RS_VLM_API_KEY` / `DOCLING_RS_VLM_PROMPT`.
+
+```js
+const res = await convertFileAsync('paper.pdf', {
+  to: 'markdown',
+  pipeline: 'vlm',
+  vlmEndpoint: 'http://localhost:11434/v1',
+  vlmModel: 'granite-docling',
+})
+```
 
 ### `ConvertResult`
 

--- a/crates/docling-node/deps.js
+++ b/crates/docling-node/deps.js
@@ -190,11 +190,23 @@ function downloadGuide() {
  * the `DOCLING_*` / `PDFIUM_DYNAMIC_LIB_PATH` env vars for whatever is present,
  * so a checkout with `scripts/install/download_dependencies.sh` already run just works.
  */
-function assertMlReady(format, dir) {
+function assertMlReady(format, dir, pipeline) {
   if (!ML_FORMATS.has(format)) return
   const p = resolvePaths(dir)
   exportEnv(p)
   const status = checkDependencies({ dir })
+  if (pipeline === 'vlm') {
+    // #290: the remote VLM replaces the local ML stack — no layout/OCR
+    // models. A PDF still rasterizes its pages locally through pdfium; a
+    // standalone image is sent to the endpoint as-is and needs nothing.
+    if (format !== 'image' && !status.pdfium) {
+      throw new Error(
+        `Converting '${format}' with pipeline 'vlm' requires pdfium (page rasterization), ` +
+          `which is not installed.\n\n${downloadGuide()}`,
+      )
+    }
+    return
+  }
   // Image needs layout (+OCR), but not pdfium; PDF/METS need both.
   const needPdfium = format !== 'image'
   const missing = [!status.layout && 'layout_heron.onnx', needPdfium && !status.pdfium && 'pdfium'].filter(

--- a/crates/docling-node/index.js
+++ b/crates/docling-node/index.js
@@ -69,23 +69,23 @@ async function* chunkStream(start) {
 // --- guarded one-shot functions --------------------------------------------
 
 function convertFile(path, options) {
-  assertMlReady(mlFormatOf(path))
+  assertMlReady(mlFormatOf(path), undefined, options && options.pipeline)
   return native.convertFile(path, options)
 }
 
 function convert(input, options) {
-  assertMlReady(mlFormatOf(input && input.name, input && input.format))
+  assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, options && options.pipeline)
   return native.convert(input, options)
 }
 
 // async so a guard failure surfaces as a rejected promise, not a sync throw.
 async function convertFileAsync(path, options) {
-  assertMlReady(mlFormatOf(path))
+  assertMlReady(mlFormatOf(path), undefined, options && options.pipeline)
   return native.convertFileAsync(path, options)
 }
 
 async function convertAsync(input, options) {
-  assertMlReady(mlFormatOf(input && input.name, input && input.format))
+  assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, options && options.pipeline)
   return native.convertAsync(input, options)
 }
 
@@ -136,30 +136,33 @@ async function chunkDocumentAsync(documentJson, options) {
 class DocumentConverter {
   constructor(options) {
     this._inner = new native.DocumentConverter(options)
+    // #290: the ML dependency guard is pipeline-aware — VLM conversions need
+    // pdfium at most, never the layout/OCR models.
+    this._pipeline = options && options.pipeline
   }
 
   convertFile(path, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, this._pipeline)
     return this._inner.convertFile(path, options)
   }
 
   convert(input, options) {
-    assertMlReady(mlFormatOf(input && input.name, input && input.format))
+    assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, this._pipeline)
     return this._inner.convert(input, options)
   }
 
   async convertFileAsync(path, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, this._pipeline)
     return this._inner.convertFileAsync(path, options)
   }
 
   async convertAsync(input, options) {
-    assertMlReady(mlFormatOf(input && input.name, input && input.format))
+    assertMlReady(mlFormatOf(input && input.name, input && input.format), undefined, this._pipeline)
     return this._inner.convertAsync(input, options)
   }
 
   convertFileStreaming(path, callback, options) {
-    assertMlReady(mlFormatOf(path))
+    assertMlReady(mlFormatOf(path), undefined, this._pipeline)
     return this._inner.convertFileStreaming(path, callback, options)
   }
 }

--- a/crates/docling-node/package.json
+++ b/crates/docling-node/package.json
@@ -57,7 +57,7 @@
     "artifacts": "napi artifacts",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "version": "napi version",
-    "test": "node test/smoke.mjs",
+    "test": "node test/smoke.mjs && node test/vlm.mjs",
     "example": "npm --prefix examples install && node examples/node-basic.mjs",
     "example:bun": "npm --prefix examples install && bun run examples/bun-basic.ts"
   },

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -92,6 +92,30 @@ pub struct ConverterOptions {
     /// Restrict the converter to these formats (ids like `"md"`, `"pdf"`, or
     /// extensions like `".html"`); anything else is rejected. Default: accept all.
     pub allowed_formats: Option<Vec<String>>,
+    /// Which pipeline converts PDF/image input (#290): `"standard"` (default —
+    /// the local ML stack) or `"vlm"` — render pages and convert them through
+    /// a remote OpenAI-compatible vision endpoint returning DocLang (#77).
+    /// Explicit opt-in only: the `DOCLING_RS_VLM_*` env vars fill in
+    /// connection details but never switch the pipeline by themselves.
+    pub pipeline: Option<String>,
+    /// VLM: base URL of the OpenAI-compatible server (e.g.
+    /// `http://localhost:11434/v1`) or the full `…/chat/completions` URL;
+    /// falls back to `DOCLING_RS_VLM_ENDPOINT`. Required (with that fallback)
+    /// when `pipeline` is `"vlm"`.
+    pub vlm_endpoint: Option<String>,
+    /// VLM: model name as the server knows it (e.g. `"granite-docling"`);
+    /// falls back to `DOCLING_RS_VLM_MODEL`. Required (with that fallback)
+    /// when `pipeline` is `"vlm"`.
+    pub vlm_model: Option<String>,
+    /// VLM: bearer token, if the endpoint wants one (local servers don't);
+    /// falls back to `DOCLING_RS_VLM_API_KEY`.
+    pub vlm_api_key: Option<String>,
+    /// VLM: the per-page instruction; falls back to `DOCLING_RS_VLM_PROMPT`,
+    /// else docling's DocLang-eliciting default prompt.
+    pub vlm_prompt: Option<String>,
+    /// VLM: `max_tokens` per page completion. Default 8192 — a dense DocLang
+    /// page runs long.
+    pub vlm_max_tokens: Option<u32>,
 }
 
 /// Per-call output options (how to render the converted document).
@@ -155,6 +179,20 @@ pub struct ConvertOptions {
     /// (#173). Default `false`.
     pub no_text_panels: Option<bool>,
     pub allowed_formats: Option<Vec<String>>,
+    /// Which pipeline converts PDF/image input (#290): `"standard"` (default)
+    /// or `"vlm"` (remote OpenAI-compatible vision endpoint, #77). Explicit
+    /// opt-in only — env vars never switch the pipeline by themselves.
+    pub pipeline: Option<String>,
+    /// VLM: endpoint base URL; falls back to `DOCLING_RS_VLM_ENDPOINT`.
+    pub vlm_endpoint: Option<String>,
+    /// VLM: model name; falls back to `DOCLING_RS_VLM_MODEL`.
+    pub vlm_model: Option<String>,
+    /// VLM: bearer token; falls back to `DOCLING_RS_VLM_API_KEY`.
+    pub vlm_api_key: Option<String>,
+    /// VLM: per-page instruction; falls back to `DOCLING_RS_VLM_PROMPT`.
+    pub vlm_prompt: Option<String>,
+    /// VLM: `max_tokens` per page completion (default 8192).
+    pub vlm_max_tokens: Option<u32>,
     pub to: Option<String>,
     pub image_mode: Option<String>,
     pub artifacts_dir: Option<String>,
@@ -221,6 +259,9 @@ struct ConvertConfig {
     force_full_page_ocr: bool,
     no_text_panels: bool,
     allowed_formats: Option<Vec<InputFormat>>,
+    /// `Some` = the remote-VLM pipeline replaces the whole ML stack for
+    /// PDF/image input (#290, #77). Resolved once by [`build_vlm`].
+    vlm: Option<docling::vlm::VlmOptions>,
     to: OutputKind,
     image_mode: ImageMode,
     artifacts_dir: String,
@@ -272,13 +313,23 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         ),
         None => None,
     };
+    let page_range = parse_pages(o.pages.as_deref())?;
+    let vlm = build_vlm(
+        o.pipeline.as_deref(),
+        o.vlm_endpoint,
+        o.vlm_model,
+        o.vlm_api_key,
+        o.vlm_prompt,
+        o.vlm_max_tokens,
+        page_range,
+    )?;
     Ok(ConvertConfig {
         strict: o.strict.unwrap_or(false),
         fetch_images: o.fetch_images.unwrap_or(false),
         asr_model: o.asr_model,
         asr_lang: o.asr_lang,
         video_frames: o.video_frames.map(|n| n as usize),
-        page_range: parse_pages(o.pages.as_deref())?,
+        page_range,
         ocr_lang: parse_ocr_lang(o.ocr_lang)?,
         ocr_mode: parse_ocr_mode(o.ocr_mode)?,
         ocr_scale: parse_ocr_scale(o.ocr_scale)?,
@@ -290,10 +341,68 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
         force_full_page_ocr: o.force_full_page_ocr.unwrap_or(false),
         no_text_panels: o.no_text_panels.unwrap_or(false),
         allowed_formats: allowed,
+        vlm,
         to: parse_output_kind(o.to.as_deref())?,
         image_mode: parse_image_mode(o.image_mode.as_deref())?,
         artifacts_dir: o.artifacts_dir.unwrap_or_else(|| "artifacts".to_string()),
     })
+}
+
+/// Resolve the `pipeline` / `vlm*` options into [`docling::vlm::VlmOptions`]
+/// (#290). `None` unless `pipeline: "vlm"` is explicitly selected — the
+/// `DOCLING_RS_VLM_*` env vars fill in connection details (endpoint, model,
+/// prompt, api key) but never auto-switch the pipeline. Conversely, `vlm*`
+/// options without the pipeline selection are a configuration error, not
+/// silently dead weight.
+fn build_vlm(
+    pipeline: Option<&str>,
+    endpoint: Option<String>,
+    model: Option<String>,
+    api_key: Option<String>,
+    prompt: Option<String>,
+    max_tokens: Option<u32>,
+    page_range: Option<(usize, usize)>,
+) -> Result<Option<docling::vlm::VlmOptions>> {
+    let selected = match pipeline {
+        None | Some("standard") => false,
+        Some("vlm") => true,
+        Some(other) => {
+            return Err(Error::from_reason(format!(
+                "pipeline {other:?} is not standard|vlm"
+            )))
+        }
+    };
+    if !selected {
+        if endpoint.is_some()
+            || model.is_some()
+            || api_key.is_some()
+            || prompt.is_some()
+            || max_tokens.is_some()
+        {
+            return Err(Error::from_reason(
+                "vlmEndpoint/vlmModel/vlmApiKey/vlmPrompt/vlmMaxTokens are set but `pipeline` \
+                 is not \"vlm\" — select the pipeline explicitly (env vars never switch it)",
+            ));
+        }
+        return Ok(None);
+    }
+    let mut opts = docling::vlm::VlmOptions::resolve(endpoint, model)
+        .map_err(|e| Error::from_reason(e.to_string()))?;
+    // Explicit options outrank the env-var fallbacks `resolve` filled in.
+    if prompt.is_some() {
+        opts.prompt = prompt;
+    }
+    if api_key.is_some() {
+        opts.api_key = api_key;
+    }
+    if let Some(m) = max_tokens {
+        if m == 0 {
+            return Err(Error::from_reason("vlmMaxTokens must be positive"));
+        }
+        opts.max_tokens = m as usize;
+    }
+    opts.page_range = page_range;
+    Ok(Some(opts))
 }
 
 /// Validate an `ocrLang` option (`"en"`/`"ch"`); an unknown id is an error.
@@ -400,6 +509,30 @@ fn render_doc(
 /// Run a buffered conversion and render it per the config. Runs off the JS
 /// thread for the async path, so it must stay free of napi/JS types.
 fn run_convert(source: SourceDocument, cfg: &ConvertConfig) -> Result<RawResult> {
+    // #290: the remote-VLM pipeline replaces the whole ML stack (#77);
+    // output rendering below is shared with the standard path. `allowedFormats`
+    // still applies — the pipeline choice must not widen what converts.
+    if let Some(vlm) = &cfg.vlm {
+        if let Some(allowed) = &cfg.allowed_formats {
+            if !allowed.contains(&source.format) {
+                return Err(Error::from_reason(format!(
+                    "format {:?} is not in allowedFormats",
+                    source.format.as_str()
+                )));
+            }
+        }
+        let format = source.format.as_str().to_string();
+        let input_name = source.name.clone();
+        let mut document = docling::vlm::convert_vlm(&source, vlm).map_err(convert_err)?;
+        document.strict_markdown = cfg.strict;
+        return Ok(render_doc(
+            document,
+            cfg,
+            input_name,
+            format,
+            "success".to_string(),
+        ));
+    }
     let converter = build_converter(cfg);
     let result = converter.convert(source).map_err(convert_err)?;
     let format = result.format.as_str().to_string();
@@ -553,6 +686,7 @@ pub struct DocumentConverter {
     force_full_page_ocr: bool,
     no_text_panels: bool,
     allowed_formats: Option<Vec<InputFormat>>,
+    vlm: Option<docling::vlm::VlmOptions>,
 }
 
 #[napi]
@@ -568,13 +702,24 @@ impl DocumentConverter {
             ),
             None => None,
         };
+        let page_range = parse_pages(o.pages.as_deref())?;
+        let vlm = build_vlm(
+            o.pipeline.as_deref(),
+            o.vlm_endpoint.clone(),
+            o.vlm_model.clone(),
+            o.vlm_api_key.clone(),
+            o.vlm_prompt.clone(),
+            o.vlm_max_tokens,
+            page_range,
+        )?;
         Ok(Self {
             strict: o.strict.unwrap_or(false),
             fetch_images: o.fetch_images.unwrap_or(false),
             asr_model: o.asr_model.clone(),
             asr_lang: o.asr_lang.clone(),
             video_frames: o.video_frames.map(|n| n as usize),
-            page_range: parse_pages(o.pages.as_deref())?,
+            page_range,
+            vlm,
             ocr_lang: parse_ocr_lang(o.ocr_lang.clone())?,
             ocr_mode: parse_ocr_mode(o.ocr_mode.clone())?,
             ocr_scale: parse_ocr_scale(o.ocr_scale)?,
@@ -609,6 +754,7 @@ impl DocumentConverter {
             force_full_page_ocr: self.force_full_page_ocr,
             no_text_panels: self.no_text_panels,
             allowed_formats: self.allowed_formats.clone(),
+            vlm: self.vlm.clone(),
             to: parse_output_kind(out.to.as_deref())?,
             image_mode: parse_image_mode(out.image_mode.as_deref())?,
             artifacts_dir: out.artifacts_dir.unwrap_or_else(|| "artifacts".to_string()),
@@ -680,6 +826,13 @@ impl DocumentConverter {
         callback: ThreadsafeFunction<Option<String>, ErrorStrategy::CalleeHandled>,
         options: Option<OutputOptions>,
     ) -> Result<()> {
+        // #290: no page streaming for the VLM pipeline — the remote endpoint
+        // is the bottleneck (same as the CLI); the buffered paths cover it.
+        if self.vlm.is_some() {
+            return Err(Error::from_reason(
+                "pipeline \"vlm\" has no streaming path — use convertFile/convertFileAsync",
+            ));
+        }
         let cfg = self.config(options)?;
         let converter = build_converter(&cfg);
         let image_mode = cfg.image_mode;
@@ -748,6 +901,15 @@ impl Pipeline {
     /// `fetchImages` / `allowedFormats` don't apply to the PDF/image pipeline.
     #[napi(constructor)]
     pub fn new(options: Option<ConverterOptions>) -> Result<Self> {
+        // #290: this class exists to keep warm ONNX models across calls — the
+        // remote VLM pipeline has none, so selecting it here is a mistake, not
+        // a no-op.
+        if options.as_ref().and_then(|o| o.pipeline.as_deref()) == Some("vlm") {
+            return Err(Error::from_reason(
+                "Pipeline keeps warm ONNX models, which the remote VLM pipeline doesn't use — \
+                 convert with pipeline: \"vlm\" through convertFile/DocumentConverter instead",
+            ));
+        }
         let strict = options.and_then(|o| o.strict).unwrap_or(false);
         Ok(Self {
             inner: Arc::new(Mutex::new(RsPipeline::new().map_err(convert_err)?)),
@@ -1033,6 +1195,7 @@ fn output_config(out: Option<OutputOptions>, strict: bool) -> Result<ConvertConf
         ocr_mode: None,
         ocr_scale: None,
         allowed_formats: None,
+        vlm: None,
         to: parse_output_kind(out.to.as_deref())?,
         image_mode: parse_image_mode(out.image_mode.as_deref())?,
         artifacts_dir: out.artifacts_dir.unwrap_or_else(|| "artifacts".to_string()),

--- a/crates/docling-node/test/vlm.mjs
+++ b/crates/docling-node/test/vlm.mjs
@@ -1,0 +1,145 @@
+// #290: the remote-VLM pipeline through the Node bindings, end-to-end against
+// a local OpenAI-compatible stub — no models, no pdfium, no network beyond
+// loopback (an image input is sent to the endpoint as-is, so nothing else is
+// needed). Also pins the option-validation surface: explicit pipeline
+// selection is required, unknown pipelines fail, and the warm Pipeline class
+// refuses the VLM pipeline outright.
+//
+// Run with `node test/vlm.mjs` (part of `npm test`).
+
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { convert, convertAsync, DocumentConverter, Pipeline } from '../index.js'
+
+let passed = 0
+const check = (name, fn) => {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++
+      console.log(`  ok  ${name}`)
+    })
+    .catch((err) => {
+      console.error(`fail  ${name}\n      ${err.message}`)
+      process.exitCode = 1
+      throw err
+    })
+}
+
+// A minimal chat-completions stub answering every request with well-formed
+// DocLang (the granite-docling contract). Captures requests for assertions.
+const requests = []
+const server = createServer((req, res) => {
+  let body = ''
+  req.on('data', (d) => (body += d))
+  req.on('end', () => {
+    requests.push({ url: req.url, auth: req.headers.authorization, body: JSON.parse(body) })
+    res.setHeader('content-type', 'application/json')
+    res.end(
+      JSON.stringify({
+        choices: [
+          { message: { content: '<heading level="2">Sec</heading>\n<text>Para from VLM.</text>' } },
+        ],
+      }),
+    )
+  })
+})
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+const endpoint = `http://127.0.0.1:${server.address().port}/v1`
+
+// Any bytes work: an image input is posted to the endpoint verbatim.
+const input = { name: 'page.png', data: Buffer.from('not-a-real-png') }
+
+try {
+  // Endpoint-hitting checks must be async: the stub server shares this
+  // process's event loop, and a *sync* convert would block it — the request
+  // could never be accepted (that's also the honest guidance for users:
+  // prefer the async API with pipeline: 'vlm').
+  await check('vlm pipeline converts through the endpoint', async () => {
+    const res = await convertAsync(input, {
+      pipeline: 'vlm',
+      vlmEndpoint: endpoint,
+      vlmModel: 'granite-docling',
+      vlmApiKey: 'sekret',
+      vlmPrompt: 'Custom prompt.',
+      vlmMaxTokens: 4096,
+    })
+    assert.equal(res.status, 'success')
+    assert.match(res.content, /## Sec/)
+    assert.match(res.content, /Para from VLM\./)
+    const r = requests.at(-1)
+    assert.equal(r.url, '/v1/chat/completions', 'endpoint suffix appended')
+    assert.equal(r.auth, 'Bearer sekret', 'api key forwarded')
+    assert.equal(r.body.model, 'granite-docling')
+    assert.equal(r.body.max_tokens, 4096)
+    assert.match(JSON.stringify(r.body.messages), /Custom prompt\./)
+  })
+
+  await check('vlm pipeline works async and renders JSON', async () => {
+    const res = await convertAsync(input, {
+      pipeline: 'vlm',
+      vlmEndpoint: endpoint,
+      vlmModel: 'granite-docling',
+      to: 'json',
+    })
+    const doc = JSON.parse(res.content)
+    assert.equal(doc.schema_name, 'DoclingDocument')
+    assert.match(res.content, /Para from VLM\./)
+  })
+
+  await check('DocumentConverter class carries the vlm config', async () => {
+    const conv = new DocumentConverter({
+      pipeline: 'vlm',
+      vlmEndpoint: endpoint,
+      vlmModel: 'granite-docling',
+    })
+    const res = await conv.convertAsync(input)
+    assert.match(res.content, /## Sec/)
+  })
+
+  // Config-validation negatives use a non-ML input: the JS dependency guard
+  // (which runs first) only fires for PDF/image, and the native validation
+  // must reject these regardless of format.
+  const mdInput = { name: 'x.md', data: Buffer.from('# t') }
+
+  await check('vlm options without pipeline: "vlm" are an error, not dead weight', () => {
+    assert.throws(
+      () => convert(mdInput, { vlmEndpoint: endpoint }),
+      /pipeline.*is not "vlm"/,
+    )
+  })
+
+  await check('unknown pipeline id is an error', () => {
+    assert.throws(() => convert(mdInput, { pipeline: 'quantum' }), /not standard\|vlm/)
+  })
+
+  await check('vlm without endpoint/model names the missing piece', () => {
+    delete process.env.DOCLING_RS_VLM_ENDPOINT
+    assert.throws(() => convert(input, { pipeline: 'vlm' }), /no endpoint/)
+  })
+
+  await check('warm Pipeline refuses the vlm pipeline', () => {
+    assert.throws(
+      () => new Pipeline({ pipeline: 'vlm' }),
+      /warm ONNX models/,
+    )
+  })
+
+  await check('streaming refuses the vlm pipeline', () => {
+    const conv = new DocumentConverter({
+      pipeline: 'vlm',
+      vlmEndpoint: endpoint,
+      vlmModel: 'granite-docling',
+    })
+    // An image path: the (pipeline-aware) deps guard needs nothing for
+    // image+vlm, so the native streaming rejection is what surfaces.
+    assert.throws(
+      () => conv.convertFileStreaming('x.png', () => {}),
+      /no streaming path/,
+    )
+  })
+} finally {
+  server.close()
+}
+
+console.log(`vlm: ${passed} checks passed`)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -469,7 +469,11 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   --vlm-model NAME` renders pages via pdfium, converts them through any
   OpenAI-compatible vision endpoint (LM Studio / Ollama / vLLM / hosted) and
   parses the returned DocLang with the existing reader — see the README's
-  "VLM pipeline" section. (**Audio/ASR is now done** — see §2; Opus and AVI,
+  "VLM pipeline" section. The Node bindings expose it too (#290:
+  `pipeline: 'vlm'` + `vlmEndpoint`/`vlmModel`/`vlmApiKey`/`vlmPrompt`/
+  `vlmMaxTokens`, explicit opt-in, pipeline-aware dependency guard);
+  docling-serve and the Python bindings still don't — separate design
+  work, per the issue. (**Audio/ASR is now done** — see §2; Opus and AVI,
   which symphonia cannot decode, use the optional ffmpeg fallback. The **enrichment
   models are now done** too: DocumentFigureClassifier-v2.5 for
   `do_picture_classification` and CodeFormulaV2 — an Idefics3-class VLM,


### PR DESCRIPTION
…ode bindings

The remote-VLM pipeline (#77) was CLI-only; the npm package had no pipeline option, so Node consumers shelled out to the CLI and lost the structured ConvertResult, JSON output and image artifacts. Now, exactly as the issue laid out:

- ConverterOptions and ConvertOptions take pipeline ("standard"|"vlm"), vlmEndpoint, vlmModel, vlmApiKey, vlmPrompt and vlmMaxTokens (default 8192), resolved once through docling::vlm::VlmOptions::resolve so the DOCLING_RS_VLM_* env fallbacks apply — but the pipeline switch itself is explicit opt-in: env vars never auto-switch it, and vlm* options without pipeline: "vlm" are a configuration error rather than dead weight. Explicit options outrank the env fallbacks; pages composes with the VLM path like everywhere else, and allowedFormats still applies.

- run_convert routes pipeline: "vlm" through docling::vlm::convert_vlm and shares the existing output rendering (markdown/json, strict), so sync, async, bytes and file variants plus the DocumentConverter class all work unchanged. Streaming is refused with a clear error (the remote endpoint is the bottleneck — same stance as the CLI), and the warm Pipeline class rejects pipeline: "vlm" outright: it exists to keep ONNX models loaded, which the VLM pipeline doesn't have.

- The JS dependency guard (deps.js assertMlReady) is pipeline-aware: with pipeline "vlm" nothing demands layout_heron.onnx — a PDF needs only pdfium (local page rasterization) and an image needs nothing at all. The module-level wrappers and the DocumentConverter wrapper class pass the pipeline through to the guard.

test/vlm.mjs runs the pipeline end-to-end against a local OpenAI-compatible stub (no models, loopback only): DocLang response parsed into real structure, endpoint suffix appended, bearer token / model / max_tokens / custom prompt forwarded, JSON rendering, plus the whole validation surface (unknown pipeline, vlm options without the pipeline, missing endpoint, Pipeline and streaming refusals). The endpoint-hitting checks are async by necessity AND by guidance: a sync convert blocks the event loop. npm test now runs both test files. TypeScript types come along for free — index.d.ts re-exports the generated native option types.

docling-serve and the Python bindings still don't expose VLM (separate design work, per the issue) — recorded in MIGRATION.md.

Closes docling-project/docling.rs#290