### PR TITLE
docs(node): pin the `vlm*` ignore without `pipeline: 'vlm'` as intentional

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,10 @@ are the env equivalents of the two flags, and `DOCLING_RS_VLM_PROMPT` /
 the CLI — Node exposes them as options too. Selecting the pipeline is always
 explicit: the environment supplies values, it never switches the pipeline on,
 so a stale `DOCLING_RS_VLM_ENDPOINT` can't reroute an ordinary PDF conversion
-over the network. `--pages A-B` composes (only the window's pages are rendered
+over the network. The `--vlm-*` flags are inert on their own for the same
+reason — without `--pipeline vlm` they are parsed and ignored, never a pipeline
+switch of their own — and the Node bindings ignore stray `vlm*` options
+identically. `--pages A-B` composes (only the window's pages are rendered
 and sent), and `--to md|json|dclx|chunks` plus `--strict` work as usual. Transient
 endpoint failures (timeouts, 408/429, 5xx) retry with exponential backoff;
 a page that still fails fails the conversion — no silently dropped pages.

--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -317,6 +317,15 @@ const res = await convertFileAsync('paper.pdf', {
 the environment supplies values, it never switches the pipeline on, so a stale
 `DOCLING_RS_VLM_ENDPOINT` can't silently route your PDFs over the network.
 
+> **The `vlm*` options are only read under `pipeline: 'vlm'`.** Passing
+> `vlmEndpoint` / `vlmModel` without it is not an error and does not switch
+> pipelines: the options are ignored and the conversion runs through the
+> standard ONNX pipeline — the same way the CLI parses a stray
+> `--vlm-endpoint` given without `--pipeline vlm` and drops it. An option
+> configures the VLM; `pipeline` alone selects it. So if a call is loading the
+> ML models (or failing on missing ones) when you expected the endpoint to be
+> contacted, the missing piece is `pipeline: 'vlm'`.
+
 `pages: 'A-B'` composes (only those pages are rendered and sent), `strict`,
 `compactTables`, `allowedFormats` and `to: 'json'` work as usual, and
 `streamFileMarkdown` yields the document as a single chunk — a VLM answers a
@@ -408,7 +417,8 @@ constructor; output options (`to`, `imageMode`, `artifactsDir`) are per call.
   (`0` = transcript only; default 8, needs ffmpeg at runtime).
 - `pipeline`: `"standard"` (default) or `"vlm"` — convert PDF/image pages
   through a remote vision endpoint instead of the ONNX stack (#77). See
-  [VLM pipeline](#vlm-pipeline-remote-endpoint).
+  [VLM pipeline](#vlm-pipeline-remote-endpoint). The five `vlm*` options below
+  take effect **only** under `"vlm"`; without it they are silently ignored.
 - `vlmEndpoint`: the server's `/v1` base or the full `…/chat/completions` URL.
   Falls back to `DOCLING_RS_VLM_ENDPOINT`; required for `pipeline: 'vlm'`.
 - `vlmModel`: model name as the server knows it. Falls back to

--- a/crates/docling-node/src/lib.rs
+++ b/crates/docling-node/src/lib.rs
@@ -91,6 +91,12 @@ pub struct ConverterOptions {
     /// below are fallbacks, never triggers. A stale `DOCLING_RS_VLM_ENDPOINT`
     /// left in the environment must not silently route every PDF over the
     /// network.
+    ///
+    /// By the same rule the `vlm_*` options below are read **only** under
+    /// `"vlm"`. Passing them with the standard pipeline is not an error and
+    /// does not switch pipelines — they are ignored, exactly as the CLI drops
+    /// a stray `--vlm-endpoint` given without `--pipeline vlm`. They configure
+    /// the VLM; `pipeline` alone selects it.
     pub pipeline: Option<String>,
     /// VLM server: the base `/v1` URL or the full `…/chat/completions` one —
     /// the suffix is appended when missing. Falls back to
@@ -183,7 +189,9 @@ pub struct ConvertOptions {
     pub no_text_panels: Option<bool>,
     /// `"standard"` (default) or `"vlm"` (#77): convert PDF/image pages
     /// through a remote OpenAI-compatible vision endpoint instead of the ONNX
-    /// stack. See [`ConverterOptions::pipeline`] for the full contract.
+    /// stack. The `vlm_*` options below take effect only under `"vlm"` and are
+    /// ignored otherwise. See [`ConverterOptions::pipeline`] for the full
+    /// contract.
     pub pipeline: Option<String>,
     /// VLM server, base `/v1` or full `…/chat/completions` URL. Falls back to
     /// `$DOCLING_RS_VLM_ENDPOINT`.
@@ -365,6 +373,13 @@ fn build_config(o: ConvertOptions) -> Result<ConvertConfig> {
 /// Resolution happens at option-parsing time, not at conversion time, so a
 /// missing endpoint fails fast on the call (or on the `DocumentConverter`
 /// constructor) instead of after a file has been read.
+///
+/// The standard branch drops the `vlm_*` arguments instead of rejecting them:
+/// an option configures the VLM, only `pipeline` selects it, and that is one
+/// rule shared with the CLI — which parses `--vlm-endpoint` / `--vlm-model`
+/// and ignores them without `--pipeline vlm`. Pinned by
+/// `standard_pipeline_ignores_vlm_options` below and by the Node-side smoke
+/// check, so the ignore stays a decision rather than resurfacing as a bug.
 fn resolve_vlm(
     pipeline: Option<&str>,
     endpoint: Option<String>,
@@ -380,6 +395,7 @@ fn resolve_vlm(
     // the env fallback rather than resolve to an empty endpoint.
     let set = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
     match pipeline {
+        // Intentionally without inspecting the `vlm_*` arguments: see above.
         None | Some("standard") => Ok(None),
         Some("vlm") => {
             let (endpoint, model) = (set(endpoint), set(model));
@@ -1749,12 +1765,30 @@ mod tests {
     // gate for them: `cargo test --workspace` runs these, whereas the Node
     // smoke test needs a built addon and no workflow invokes it.
 
+    /// The standard pipeline builds no VLM options — and stays that way with
+    /// *every* `vlm_*` argument set, rather than failing the call. The ignore
+    /// is CLI parity (a stray `--vlm-endpoint` is parsed and dropped there
+    /// too); pinning it here keeps it a decision instead of a regression
+    /// someone files later. Its caller-side twin is the "vlm* options without
+    /// pipeline: 'vlm' are ignored" check in `test/smoke.mjs`.
     #[test]
-    fn standard_pipeline_needs_no_vlm_options() {
+    fn standard_pipeline_ignores_vlm_options() {
         for p in [None, Some("standard")] {
             let got =
                 resolve_vlm(p, None, None, None, None, None, None).expect("standard pipeline");
             assert!(got.is_none(), "pipeline {p:?} must not build VLM options");
+
+            let got = resolve_vlm(
+                p,
+                Some("http://127.0.0.1:1/v1".into()),
+                Some("granite-docling".into()),
+                Some("sekret".into()),
+                Some("Describe this page.".into()),
+                Some(512),
+                Some((2, 4)),
+            )
+            .expect("vlm options must not fail the standard pipeline");
+            assert!(got.is_none(), "pipeline {p:?} must ignore the vlm options");
         }
     }
 

--- a/crates/docling-node/test/smoke.mjs
+++ b/crates/docling-node/test/smoke.mjs
@@ -338,6 +338,37 @@ async function main() {
     assert.throws(() => new Pipeline({ pipeline: 'vlm' }), /loads no models/)
   })
 
+  // The ignore is deliberate, not an oversight: an option configures the VLM,
+  // only `pipeline` selects it — the same rule as the CLI, which parses a
+  // stray `--vlm-endpoint` without `--pipeline vlm` and drops it. Pinned from
+  // the caller's side (the `resolve_vlm` unit test pins the resolution side):
+  // with an endpoint that *would* answer, nothing reaches it. Markdown input
+  // keeps the check environment-independent — the standard path converts it
+  // with no models on disk.
+  await check("vlm* options without pipeline: 'vlm' are ignored, not an error", async () => {
+    const mock = await mockVlm('<text>never asked</text>')
+    try {
+      for (const pipeline of [undefined, 'standard']) {
+        const res = await convertAsync(
+          { name: 'notes.md', data: Buffer.from(MD) },
+          {
+            pipeline,
+            vlmEndpoint: mock.url,
+            vlmModel: 'granite-docling',
+            vlmApiKey: 'sekret',
+            vlmPrompt: 'Describe this page.',
+            vlmMaxTokens: 512,
+          },
+        )
+        assert.equal(res.status, 'success')
+        assert.match(res.content, /# Title/)
+        assert.equal(mock.served, 0, `pipeline ${pipeline} must not contact the VLM`)
+      }
+    } finally {
+      mock.close()
+    }
+  })
+
   await check('Pipeline rejects an unknown pipeline name too', () => {
     assert.throws(() => new Pipeline({ pipeline: 'magic' }), /unknown pipeline/)
   })


### PR DESCRIPTION
Closes #295. Answers point 1 of the #291 review:
https://github.com/docling-project/docling.rs/pull/291#issuecomment-5461070748

## The choice

`vlm*` options passed without `pipeline: 'vlm'` convert through the standard
pipeline and never reach the endpoint. The review offered two resolutions:
return `InvalidArg` when any `vlm*` option is present on the standard branch,
or keep CLI parity and make the ignore explicit. **This PR takes the second.**

Two reasons:

- **Parity.** The CLI parses `--vlm-endpoint` / `--vlm-model` unconditionally
  and only builds `VlmOptions` under `--pipeline vlm`, so a stray flag is
  dropped there too. Erroring in the Node bindings alone would make the two
  surfaces disagree on the same option set.
- **One rule.** An option configures the VLM; `pipeline` alone selects it.
  That is already the rule for `DOCLING_RS_VLM_ENDPOINT` / `_MODEL` —
  fallbacks, never triggers, so a stale export can't reroute an ordinary PDF
  conversion over the network. An error on explicit options would add a
  second, softer "presence means intent" rule right beside it.

No behaviour changes: docs and tests only.

## What's in it

**Docs** — the contract is now stated where the caller meets it:

- `ConverterOptions::pipeline` (full rationale) and `ConvertOptions::pipeline`
  (short form) doc comments, so it reaches the generated `native.d.ts` and the
  editor tooltip.
- `crates/docling-node/README.md`: a callout in the *VLM pipeline* section and
  a clause on the `pipeline` bullet in the option list.
- Root `README.md`: the same for `--vlm-*`, in the CLI paragraph that already
  explains why the env vars don't switch pipelines.
- `resolve_vlm`'s doc comment and its `None | Some("standard")` arm say the
  drop is deliberate and name the tests that hold it.

The docs also point at the diagnosis: if a call is loading the ML models when
you expected the endpoint, the missing piece is `pipeline: 'vlm'`.

**Tests** — pinned from both sides, so the ignore reads as a decision rather
than resurfacing as a bug report:

- `standard_pipeline_ignores_vlm_options` (renamed from
  `standard_pipeline_needs_no_vlm_options`) now feeds *every* `vlm_*` argument
  — endpoint, model, api key, prompt, max tokens, page range — to both `None`
  and `Some("standard")` and asserts `resolve_vlm` neither builds options nor
  errors. This is the enforced gate: `cargo test` runs it.
- A smoke check, `vlm* options without pipeline: 'vlm' are ignored, not an
  error`, converts Markdown with a fully configured **live** mock endpoint and
  asserts `mock.served === 0` for both `undefined` and `'standard'`. Markdown
  input keeps it environment-independent — the standard path converts it with
  no models on disk, so the check runs anywhere the rest of the suite does.

## Tests run

```
cargo test -p docling-node --lib          # 5 passed (incl. the extended test)
cargo clippy -p docling-node --lib --tests # no warnings from docling-node
cargo fmt --all -- --check                 # clean
node test/smoke.mjs                        # 45 checks passed (44 before)
```

Limits worth stating: the smoke run used the addon already built from `master`
in this checkout, not a rebuild — legitimate here because the Rust change is
doc comments plus the `#[cfg(test)]` module, so the addon's behaviour is
byte-identical either way. The clippy warnings visible in that run all come
from the `docling` dependency crate and are pre-existing (local toolchain
1.98; CI lints on 1.96).

Point 2 of the review — asserting the `vlmApiKey` bearer header in an existing
VLM check — is deliberately left out of this PR to keep it to the one
decision; happy to add it here or in a follow-up, whichever you prefer.
