### PR TITLE
fix(install): fetch the macOS pdfium build, not a Linux .so

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ instead — same models plus `pdfium.dll` — and see
 
 | Asset | Destination |
 | --- | --- |
-| pdfium (Linux x64) | `.pdfium/lib/libpdfium.so` |
+| pdfium (Linux x64/arm64, macOS arm64/x64) | `.pdfium/lib/libpdfium.so` (`libpdfium.dylib` on macOS) |
 | RT-DETR layout | `.models/layout_heron.onnx` |
 | PP-OCRv3 rec + dictionary, English (the runtime default) | `.models/ocr_rec_en.onnx`, `.models/en_dict.txt` |
 | PP-OCRv3 rec + dictionary, multilingual `ch_` (`DOCLING_RS_OCR_LANG=ch`; the docling-conformance model — weak Latin word spacing) | `.models/ocr_rec.onnx`, `.models/ppocr_keys_v1.txt` |

--- a/crates/docling-node/README.md
+++ b/crates/docling-node/README.md
@@ -220,7 +220,7 @@ call are needed afterwards:
 
 | Asset | Destination |
 | --- | --- |
-| **pdfium** | `.pdfium/lib/libpdfium.so` |
+| **pdfium** | `.pdfium/lib/libpdfium.so` (`libpdfium.dylib` on macOS) |
 | **layout** (`layout_heron.onnx`) | `models/layout_heron.onnx` |
 | **OCR** rec model + dictionary | `models/ocr_rec.onnx`, `models/ppocr_keys_v1.txt` |
 | **TableFormer** | `models/tableformer/{encoder,decoder,bbox}.onnx` |

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -19,7 +19,7 @@
 #
 # Downloads (from https://github.com/docling-project/docling.rs/releases, tag
 # models-v1 by default — override the base with $DOCLING_RS_MODELS_URL):
-#   .pdfium/lib/libpdfium.so                      (Linux x64)
+#   .pdfium/lib/libpdfium.so (libpdfium.dylib on macOS)
 #   .models/layout_heron.onnx
 #   .models/ocr_rec_en.onnx + .models/en_dict.txt   (English PP-OCRv3
 #     recognition — the runtime default; from upstream PP-OCRv3 hosting)
@@ -57,9 +57,10 @@
 # them locally with scripts/install/quantize_models.py.
 #
 # pdfium: the models release hosts the pinned Linux x64 libpdfium.so
-# (the conformance build); on Linux arm64 the bblanchon prebuilt of the
-# same release line is fetched instead (#281). Other platforms (or building
-# the models from source): see scripts/install/pdf_setup.sh.
+# (the conformance build); every other supported platform — Linux arm64 and
+# macOS arm64/x64 — takes the bblanchon prebuilt of the same release line
+# instead (#281). Building the models from source: see
+# scripts/install/pdf_setup.sh.
 #
 # Idempotent: skips files already on disk. Pass --force to re-fetch everything.
 set -eu
@@ -141,35 +142,42 @@ fetch_optional() { # <url> <dest> — ignore a missing/failed asset (sidecar fil
 }
 
 echo "fetching docling.rs ML dependencies from $BASE_URL"
-# pdfium by machine architecture (#281): x64 takes the release's pinned
-# conformance build; arm64 falls back to the bblanchon prebuilt (same source
-# the pinned x64 lib was built from). The tarball unpacks lib/libpdfium.so
-# into .pdfium/ directly.
-case "$(uname -m)" in
-  x86_64 | amd64)
-    fetch "$BASE_URL/libpdfium.so" .pdfium/lib/libpdfium.so
-    ;;
-  aarch64 | arm64)
-    if [ "$FORCE" = false ] && [ -f .pdfium/lib/libpdfium.so ]; then
-      echo "  = .pdfium/lib/libpdfium.so (already present)"
-    else
-      echo "  (arm64: pdfium from the bblanchon prebuilt — the pinned x64 build doesn't apply)"
-      # shellcheck disable=SC2086
-      if curl -fsSL $CURL_TIMEOUTS -o .pdfium/pdfium.tgz \
-          "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-arm64.tgz" 2>/dev/null; then
-        tar xzf .pdfium/pdfium.tgz -C .pdfium lib/libpdfium.so
-        rm -f .pdfium/pdfium.tgz
-        echo "  > .pdfium/lib/libpdfium.so"
-      else
-        rm -f .pdfium/pdfium.tgz
-        echo "  ! pdfium-linux-arm64.tgz not fetched (offline?) — PDF rasterization stays unavailable"
-      fi
-    fi
-    ;;
-  *)
-    echo "  (skipping pdfium: unsupported arch $(uname -m) — see scripts/install/pdf_setup.sh)"
-    ;;
+# pdfium by host platform (#281): Linux x64 takes the release's pinned
+# conformance build; every other platform falls back to the matching bblanchon
+# prebuilt (the same source the pinned x64 lib was built from). Selecting on
+# `uname -m` alone sent macOS down the arm64 branch and installed a *Linux*
+# ELF .so, which dlopen then never found — pdfium-render asks for the
+# platform library name, `libpdfium.dylib` on Darwin — so both the guard and
+# the tar member track $PDFIUM_LIB rather than a hardcoded .so.
+case "$(uname -s)" in
+  Darwin) PDFIUM_OS=mac; PDFIUM_LIB=libpdfium.dylib ;;
+  *) PDFIUM_OS=linux; PDFIUM_LIB=libpdfium.so ;;
 esac
+case "$(uname -m)" in
+  x86_64 | amd64) PDFIUM_ARCH=x64 ;;
+  aarch64 | arm64) PDFIUM_ARCH=arm64 ;;
+  *) PDFIUM_ARCH= ;;
+esac
+
+if [ -z "$PDFIUM_ARCH" ]; then
+  echo "  (skipping pdfium: unsupported arch $(uname -m) — see scripts/install/pdf_setup.sh)"
+elif [ "$PDFIUM_OS" = linux ] && [ "$PDFIUM_ARCH" = x64 ]; then
+  fetch "$BASE_URL/libpdfium.so" .pdfium/lib/libpdfium.so
+elif [ "$FORCE" = false ] && [ -f ".pdfium/lib/$PDFIUM_LIB" ]; then
+  echo "  = .pdfium/lib/$PDFIUM_LIB (already present)"
+else
+  echo "  ($PDFIUM_OS-$PDFIUM_ARCH: pdfium from the bblanchon prebuilt — the pinned Linux x64 build doesn't apply)"
+  # shellcheck disable=SC2086
+  if curl -fsSL $CURL_TIMEOUTS -o .pdfium/pdfium.tgz \
+      "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-$PDFIUM_OS-$PDFIUM_ARCH.tgz" 2>/dev/null; then
+    tar xzf .pdfium/pdfium.tgz -C .pdfium "lib/$PDFIUM_LIB"
+    rm -f .pdfium/pdfium.tgz
+    echo "  > .pdfium/lib/$PDFIUM_LIB"
+  else
+    rm -f .pdfium/pdfium.tgz
+    echo "  ! pdfium-$PDFIUM_OS-$PDFIUM_ARCH.tgz not fetched (offline?) — PDF rasterization stays unavailable"
+  fi
+fi
 fetch "$BASE_URL/layout_heron.onnx" .models/layout_heron.onnx
 fetch "$BASE_URL/ocr_rec.onnx" .models/ocr_rec.onnx
 fetch "$BASE_URL/ppocr_keys_v1.txt" .models/ppocr_keys_v1.txt

--- a/scripts/install/pdf_setup.sh
+++ b/scripts/install/pdf_setup.sh
@@ -4,7 +4,7 @@
 #   scripts/install/pdf_setup.sh
 #
 # Downloads:
-#   - libpdfium (bblanchon prebuilt) -> .pdfium/lib/libpdfium.so
+#   - libpdfium (bblanchon prebuilt) -> .pdfium/lib/libpdfium.{so,dylib}
 #   - PP-OCRv3 recognition model     -> .models/ocr_rec.onnx
 #   - PP-OCR character dictionary     -> .models/ppocr_keys_v1.txt
 # And exports two ONNX model sets (need a Python with torch+onnx; set $PYTHON,
@@ -31,7 +31,13 @@ detect_platform() {
   esac
 }
 PLATFORM="${PDFIUM_PLATFORM:-$(detect_platform)}"
-if [ ! -f .pdfium/lib/libpdfium.so ]; then
+# The mac tarballs ship libpdfium.dylib, never a .so — guarding on the .so
+# re-downloaded on every run and left the correctly fetched dylib unnoticed.
+case "$PLATFORM" in
+  mac-*) PDFIUM_LIB=libpdfium.dylib ;;
+  *) PDFIUM_LIB=libpdfium.so ;;
+esac
+if [ ! -f ".pdfium/lib/$PDFIUM_LIB" ]; then
   echo "→ libpdfium ($PLATFORM)"
   curl -sSL -o /tmp/pdfium.tgz \
     "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-${PLATFORM}.tgz"


### PR DESCRIPTION
download_dependencies.sh selected pdfium on `uname -m` alone, so macOS arm64 fell into the arm64 branch and installed an *ELF* libpdfium.so. pdfium-render asks dlopen for the platform library name — libpdfium.dylib on Darwin — so every PDF failed with "the pdfium library is not installed", while the models (platform-neutral .onnx) looked fine. Branch on `uname -s` too, fetch pdfium-mac-{arm64,x64}.tgz there, and track the library name in $PDFIUM_LIB so the presence guard and the extracted tar member follow the platform instead of a hardcoded .so.

pdf_setup.sh already detected Darwin (os=mac) but guarded on .pdfium/lib/libpdfium.so, which the mac tarballs never produce: it re-downloaded on every run and never saw the dylib it had just fetched. Guard on the platform name there as well.

Linux x64 keeps the release's pinned conformance build and Linux arm64 the bblanchon prebuilt — both paths are unchanged.

Refs #281




Claude-Session: https://claude.ai/code/session_01CgeqJzTADtU81U2nUVtMbY