### PR TITLE
fix(py): install the platform's pdfium in download_models(), not the …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,9 @@ cargo check -p docling --no-default-features --features pdf-text \
 ## Runtime assets & env
 
 - `.models/` (repo root): layout, TableFormer, OCR, ASR (`.models/asr/`,
-  presets in subdirs), enrichment, embedder. `.pdfium/lib/libpdfium.so` for
-  page rendering. Fetch: `scripts/install/download_dependencies.sh`.
+  presets in subdirs), enrichment, embedder. `.pdfium/lib/libpdfium.so`
+  (`libpdfium.dylib` on macOS, #298/#299) for page rendering. Fetch:
+  `scripts/install/download_dependencies.sh`.
 - Resolution is CWD-relative, then `$DOCLING_RS_MODELS_DIR` for `.models/…`
   paths (#285 — whole-dir override keeping the engine's own selection logic,
   e.g. the OCR en/ch pair; the py bindings point it at their cache), then

--- a/crates/docling-py/python/docling_rs/models.py
+++ b/crates/docling-py/python/docling_rs/models.py
@@ -101,8 +101,42 @@ _FALLBACK_URLS = {
         "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx"
     ),
 }
-# pdfium rasterizer (Linux x64, matching what the release hosts).
-_PDFIUM = {"libpdfium.so": ".pdfium/lib/libpdfium.so"}
+# pdfium rasterizer, selected by host platform (#299 — the mirror of the
+# shell installers' #298 fix): Linux x64 takes the release's pinned
+# conformance build; Linux arm64 and macOS arm64/x64 take the matching
+# bblanchon prebuilt (the source the pinned build comes from), whose tarball
+# ships `lib/libpdfium.so` / `lib/libpdfium.dylib`. Anything else skips with
+# a note — a wrong-platform binary that "installs fine" and fails at dlopen
+# time is exactly the failure mode this exists to avoid.
+_PDFIUM_TGZ_BASE = "https://github.com/bblanchon/pdfium-binaries/releases/latest/download"
+
+
+def _pdfium_plan(system: "str | None" = None, machine: "str | None" = None):
+    """The pdfium install plan for a host: ``("release", lib)`` (pinned asset
+    from the models release), ``("tarball", url, lib)`` (bblanchon prebuilt),
+    or ``None`` (unsupported — skip). Parameters exist for tests; they default
+    to the running host."""
+    import platform as _platform
+
+    system = system if system is not None else _platform.system()
+    machine = (machine if machine is not None else _platform.machine()).lower()
+    arch = {"x86_64": "x64", "amd64": "x64", "aarch64": "arm64", "arm64": "arm64"}.get(machine)
+    if arch is None:
+        return None
+    if system == "Darwin":
+        return ("tarball", f"{_PDFIUM_TGZ_BASE}/pdfium-mac-{arch}.tgz", "libpdfium.dylib")
+    if system == "Linux" and arch == "x64":
+        return ("release", "libpdfium.so")
+    if system == "Linux":
+        return ("tarball", f"{_PDFIUM_TGZ_BASE}/pdfium-linux-{arch}.tgz", "libpdfium.so")
+    return None
+
+
+def _pdfium_lib_name() -> str:
+    """The platform pdfium library filename (what pdfium-render dlopens);
+    ``libpdfium.so`` for unsupported hosts so path displays stay sensible."""
+    plan = _pdfium_plan()
+    return plan[-1] if plan else "libpdfium.so"
 
 
 def cache_dir() -> Path:
@@ -148,8 +182,9 @@ def download_models(
     root = Path(dest) if dest else cache_dir()
     if progress:
         print(f"docling.rs: fetching models to {root}", file=sys.stderr, flush=True)
-    for name, rel in {**_REQUIRED, **_PDFIUM}.items():
+    for name, rel in _REQUIRED.items():
         _fetch(f"{BASE_URL}/{name}", root / rel, optional=False, progress=progress, force=force)
+    _fetch_pdfium(root, progress=progress, force=force)
     for name, rel in {**_OPTIONAL, **_ENRICH}.items():
         if not _fetch(
             f"{BASE_URL}/{name}", root / rel, optional=True, progress=progress, force=force
@@ -162,6 +197,56 @@ def download_models(
     if not (root / _ENRICH["cf_decoder_kv_int8.onnx"]).exists():
         _fetch(f"{BASE_URL}/{name}", root / rel, optional=True, progress=progress, force=force)
     return root
+
+
+def _fetch_pdfium(root: Path, progress: bool, force: bool) -> None:
+    """Install the *platform's* pdfium into ``<root>/.pdfium/lib`` (#299).
+
+    Linux x64 downloads the pinned release ``libpdfium.so`` like any other
+    required asset; the tarball platforms extract just their ``lib/<name>``
+    member (stdlib ``tarfile``). Idempotent like ``_fetch``; an unsupported
+    host prints a note and skips instead of installing a binary that could
+    never load."""
+    plan = _pdfium_plan()
+    if plan is None:
+        import platform as _platform
+
+        print(
+            f"docling.rs: skipping pdfium ({_platform.system()}/{_platform.machine()} has no "
+            "prebuilt); PDF/image rasterization needs PDFIUM_DYNAMIC_LIB_PATH",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if plan[0] == "release":
+        _fetch(
+            f"{BASE_URL}/{plan[1]}",
+            root / ".pdfium/lib" / plan[1],
+            optional=False,
+            progress=progress,
+            force=force,
+        )
+        return
+    _, url, lib = plan
+    dest = root / ".pdfium/lib" / lib
+    if dest.exists() and not force:
+        return
+    import io
+    import tarfile
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if progress:
+        print(f"  > {dest}", file=sys.stderr, flush=True)
+    with urllib.request.urlopen(url) as r:
+        data = r.read()
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        member = tar.extractfile(f"lib/{lib}")
+        if member is None:
+            raise RuntimeError(f"{url}: tarball has no lib/{lib}")
+        tmp = dest.with_suffix(dest.suffix + ".download")
+        with open(tmp, "wb") as f:
+            f.write(member.read())
+        tmp.rename(dest)
 
 
 def _point_at(var: str, local: "list[str]", cached: Path) -> None:
@@ -262,5 +347,14 @@ def ensure_env(dest: "str | Path | None" = None) -> Path:
         _local(["models/code_formula"]),
         m / "code_formula",
     )
-    _point_at("PDFIUM_DYNAMIC_LIB_PATH", [".pdfium/lib"], root / ".pdfium/lib")
+    # The env var names the *directory*, but what must exist in it is the
+    # *platform's* library (#299 — `libpdfium.dylib` on macOS): checking the
+    # bare directory kept pointing macOS at a cache holding only a stale
+    # Linux `.so`, which pdfium-render then never found.
+    if (
+        "PDFIUM_DYNAMIC_LIB_PATH" not in os.environ
+        and not Path(".pdfium/lib").exists()
+        and (root / ".pdfium/lib" / _pdfium_lib_name()).exists()
+    ):
+        os.environ["PDFIUM_DYNAMIC_LIB_PATH"] = str(root / ".pdfium/lib")
     return root

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -328,3 +328,96 @@ def test_ensure_env_still_respects_explicit_ocr_pins(tmp_path, monkeypatch):
 
     assert os.environ["DOCLING_OCR_REC_ONNX"] == "/custom/rec.onnx"
     assert os.environ["DOCLING_OCR_DICT"] == "/custom/dict.txt"
+
+
+def test_pdfium_plan_selects_by_platform():
+    """#299: pdfium is selected by host platform, mirroring #298's shell fix —
+    Linux x64 keeps the pinned release build, everything else takes the
+    matching bblanchon prebuilt with the *platform's* library name, unknown
+    hosts skip."""
+    from docling_rs import models as m
+
+    assert m._pdfium_plan("Linux", "x86_64") == ("release", "libpdfium.so")
+    assert m._pdfium_plan("Linux", "amd64") == ("release", "libpdfium.so")
+    assert m._pdfium_plan("Linux", "aarch64") == (
+        "tarball",
+        f"{m._PDFIUM_TGZ_BASE}/pdfium-linux-arm64.tgz",
+        "libpdfium.so",
+    )
+    assert m._pdfium_plan("Darwin", "arm64") == (
+        "tarball",
+        f"{m._PDFIUM_TGZ_BASE}/pdfium-mac-arm64.tgz",
+        "libpdfium.dylib",
+    )
+    assert m._pdfium_plan("Darwin", "x86_64") == (
+        "tarball",
+        f"{m._PDFIUM_TGZ_BASE}/pdfium-mac-x64.tgz",
+        "libpdfium.dylib",
+    )
+    assert m._pdfium_plan("Linux", "riscv64") is None
+    assert m._pdfium_plan("Windows", "AMD64") is None
+
+
+def test_fetch_pdfium_extracts_the_platform_member(tmp_path, monkeypatch):
+    """The tarball path extracts exactly `lib/<platform lib>` into the cache
+    (#299) — exercised with an in-memory tgz and a mocked Darwin host, so no
+    network and no real platform dependence."""
+    import io
+    import tarfile
+
+    from docling_rs import models as m
+
+    payload = b"mach-o bytes"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo("lib/libpdfium.dylib")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        m, "_pdfium_plan", lambda *a: ("tarball", "https://example.invalid/p.tgz", "libpdfium.dylib")
+    )
+    monkeypatch.setattr(
+        m.urllib.request, "urlopen", lambda url: FakeResponse(buf.getvalue())
+    )
+    m._fetch_pdfium(tmp_path, progress=False, force=False)
+    dest = tmp_path / ".pdfium/lib/libpdfium.dylib"
+    assert dest.read_bytes() == payload
+
+    # Idempotent: a second run must not re-download (urlopen would explode).
+    monkeypatch.setattr(m.urllib.request, "urlopen", None)
+    m._fetch_pdfium(tmp_path, progress=False, force=False)
+
+
+def test_ensure_env_requires_the_platform_pdfium_lib(tmp_path, monkeypatch):
+    """#299: PDFIUM_DYNAMIC_LIB_PATH is only exported when the cache holds the
+    *platform's* library — a cache with just a wrong-platform binary is
+    treated as not installed instead of being handed to dlopen."""
+    import os
+
+    from docling_rs import models as m
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PDFIUM_DYNAMIC_LIB_PATH", raising=False)
+
+    cache = tmp_path / "cache"
+    libdir = cache / ".pdfium/lib"
+    libdir.mkdir(parents=True)
+
+    # Wrong-platform library only (a dylib on this Linux host): stays unset.
+    wrong = "libpdfium.dylib" if m._pdfium_lib_name() == "libpdfium.so" else "libpdfium.so"
+    (libdir / wrong).write_bytes(b"x")
+    m.ensure_env(cache)
+    assert "PDFIUM_DYNAMIC_LIB_PATH" not in os.environ
+
+    # The platform's library appears: the directory is exported.
+    (libdir / m._pdfium_lib_name()).write_bytes(b"x")
+    m.ensure_env(cache)
+    assert os.environ["PDFIUM_DYNAMIC_LIB_PATH"] == str(libdir)


### PR DESCRIPTION
…Linux .so

The Python bindings' mirror of #298: download_models() fetched the models release's Linux x64 libpdfium.so unconditionally, so on macOS the documented download_models()+ensure_env() setup "succeeded" with an ELF in the cache, ensure_env() pointed PDFIUM_DYNAMIC_LIB_PATH at it, and pdfium-render — which resolves the *platform* library name, libpdfium.dylib on Darwin — failed later with a missing-pdfium error far from the actual cause.

- _pdfium_plan() selects by platform.system()/machine(), the same matrix as the shell installers after #298: Linux x64 keeps the pinned conformance build from the models release, Linux arm64 and macOS arm64/x64 take the matching bblanchon prebuilt (pdfium-{linux,mac}-{arm64,x64}.tgz — the tarballs ship exactly lib/libpdfium.{so,dylib}, verified in #298), anything else skips with a note instead of installing a binary that could never load. The tarball path extracts just its lib/<name> member with stdlib tarfile, with _fetch's idempotency/force semantics.

- ensure_env() exports PDFIUM_DYNAMIC_LIB_PATH only when the cache holds the *platform's* library: the old bare-directory check kept handing macOS a cache containing only a stale Linux .so. The env var still names the directory (that is the contract); the existence check names the file.

Tests: the platform→plan matrix is pinned as a pure function (all five supported combos + riscv64/Windows skips), the tarball extraction runs against an in-memory tgz with a mocked host (no network, no platform dependence, idempotency asserted), and ensure_env's platform-lib gate is exercised both ways on the real host. CLAUDE.md's asset line gets the dylib parenthetical the READMEs got in #298.

Closes docling-project/docling.rs#299