### PR TITLE
feat(serve): observability — request logs, Prometheus /metrics, opt-i…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,11 +1581,17 @@ dependencies = [
  "http-body-util",
  "libc",
  "object_store",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "ureq",
  "url",
 ]
@@ -2396,6 +2402,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3586,6 +3605,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.20",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,6 +3868,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -4016,6 +4117,38 @@ checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5847,6 +5980,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5854,9 +6035,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5934,6 +6118,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -226,6 +226,16 @@ output as `<stem>.<ext>` under the prefix and answers with a
 `RemoteTargetResult` acknowledgment; everything outbound sits behind
 `--allow-url-fetch`. See the `s3_pipeline` example in `/openapi.yaml`.
 
+Observability (#297, mirroring Python docling-serve's posture — metrics on by
+default, traces opt-in): every request logs through `tracing` (`RUST_LOG`
+filters, default `info`), and `GET /metrics` serves Prometheus text —
+request counts by status class, an in-flight gauge, a request-latency
+histogram, and per-outcome conversion counts (`/metrics`, `/health` and
+`/ready` probes excluded). Building with the opt-in `otel` cargo feature and
+setting `OTEL_EXPORTER_OTLP_ENDPOINT` additionally ships the request spans
+over OTLP/gRPC (`OTEL_SERVICE_NAME` defaults to `docling-serve`); without the
+env var the feature is inert.
+
 ## In the browser — `docling-wasm`
 
 The declarative converters (everything except the PDF/image/audio ML

--- a/crates/docling-serve/Cargo.toml
+++ b/crates/docling-serve/Cargo.toml
@@ -25,6 +25,16 @@ heif = ["docling/heif"]
 tensorrt = ["docling/tensorrt"]
 directml = ["docling/directml"]
 coreml = ["docling/coreml"]
+# OpenTelemetry trace export (#297): request/conversion spans shipped over
+# OTLP when OTEL_EXPORTER_OTLP_ENDPOINT is set at runtime. Off by default —
+# the OTel SDK stack is heavy; structured tracing logs and the Prometheus
+# /metrics endpoint need no feature at all.
+otel = [
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
@@ -46,6 +56,19 @@ ureq = { version = "3", default-features = false, features = ["rustls", "gzip"] 
 # Parse URL-fetch inputs to validate the host against the SSRF IP block-list
 # before connecting (already in the graph via ureq).
 url = "2"
+# Structured logs + spans (#297): every request logs through `tracing`
+# (RUST_LOG-filtered, default info) and the same spans feed the optional
+# OTel export below.
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+# OTLP trace export, behind the opt-in `otel` feature (versions move in
+# lockstep — tracing-opentelemetry 0.33 pairs with opentelemetry 0.32).
+tracing-opentelemetry = { version = "0.33.0", optional = true }
+opentelemetry = { version = "0.32.0", optional = true }
+opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"], optional = true }
+# OTLP/gRPC only (the Python default transport); the default http-proto
+# transport would pull a second HTTP client stack (reqwest) into the graph.
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["trace", "grpc-tonic"], optional = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -13,6 +13,7 @@
 //! | GET    | `/v1/config`  | server capabilities (`{"allow_url_fetch": bool}`)  |
 //! | GET    | `/health`     | liveness probe                                     |
 //! | GET    | `/ready`      | readiness probe (200 once models are warm)         |
+//! | GET    | `/metrics`    | Prometheus metrics (#297, see [`o11y`])            |
 //! | GET    | `/openapi.yaml` | OpenAPI 3.1 description of the API               |
 //! | GET    | `/logo.svg`   | the playground's logo                              |
 //!
@@ -140,6 +141,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::Semaphore;
 
+pub mod o11y;
 mod passthrough;
 
 /// Server configuration (see the binary's `--help` for the flag spellings).
@@ -290,18 +292,25 @@ pub fn router(cfg: ServeConfig) -> Router {
         )
         .route("/health", get(|| async { Json(json!({"status": "ok"})) }))
         .route("/ready", get(ready))
+        .route("/metrics", get(o11y::metrics_endpoint))
         .route("/v1/config", get(config))
         .route("/v1/convert", post(convert))
         .route("/v1/convert/async", post(convert_async))
         .route("/v1/status/{id}", get(job_status))
         .route("/v1/result/{id}", get(job_result))
         .layer(DefaultBodyLimit::max(cfg.max_body_bytes))
+        // Request span/log + metrics (#297) — outermost, so it times the whole
+        // request including body-limit rejections.
+        .layer(axum::middleware::from_fn(o11y::track))
         .with_state(state)
 }
 
 /// Bind and serve until SIGINT/SIGTERM; in-flight requests finish (graceful
 /// shutdown).
 pub async fn serve(cfg: ServeConfig) -> Result<(), String> {
+    // Logging/tracing first (#297): startup diagnostics below already flow
+    // through a configured subscriber this way.
+    o11y::init();
     let addr = cfg.addr.clone();
     let app = router(cfg);
     let listener = tokio::net::TcpListener::bind(&addr)
@@ -323,10 +332,13 @@ pub async fn serve(cfg: ServeConfig) -> Result<(), String> {
             eprintln!("docling-serve: model {:<20} {} (MISSING)", m.stage, m.path);
         }
     }
-    axum::serve(listener, app)
+    let result = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await
-        .map_err(|e| format!("server error: {e}"))
+        .map_err(|e| format!("server error: {e}"));
+    // Flush batched OTLP spans (#297) — a no-op unless export is active.
+    o11y::shutdown();
+    result
 }
 
 async fn shutdown_signal() {
@@ -1821,8 +1833,22 @@ fn fetch_url(
 }
 
 /// Convert to a [`DoclingDocument`], routing PDF/image through the warm
-/// pipeline and everything else through the declarative converter.
+/// pipeline and everything else through the declarative converter. Every
+/// buffered conversion — sync, batch item, async job, cloud target — funnels
+/// through here, which makes it the one place the per-outcome conversion
+/// metric is recorded (#297; the declarative *streaming* path bypasses this
+/// and records at stream end).
 fn convert_document(
+    state: &AppState,
+    source: SourceDocument,
+    options: &ConvertOptions,
+) -> Result<DoclingDocument, ApiError> {
+    let result = convert_document_inner(state, source, options);
+    o11y::record_conversion(result.is_ok());
+    result
+}
+
+fn convert_document_inner(
     state: &AppState,
     source: SourceDocument,
     options: &ConvertOptions,
@@ -2075,6 +2101,11 @@ async fn stream_markdown(
                         return;
                     }
                 };
+                // The streaming path bypasses `convert_document`, so the
+                // conversion metric (#297) is recorded here: success once the
+                // stream drains, failure on a conversion error (a client that
+                // disconnects mid-stream abandons the conversion and counts as
+                // neither).
                 match converter.convert_streaming_images(source, image_mode) {
                     Ok(stream) => {
                         for chunk in stream {
@@ -2085,13 +2116,16 @@ async fn stream_markdown(
                                     }
                                 }
                                 Err(e) => {
+                                    o11y::record_conversion(false);
                                     send(Err(e.to_string()));
                                     return;
                                 }
                             }
                         }
+                        o11y::record_conversion(true);
                     }
                     Err(e) => {
+                        o11y::record_conversion(false);
                         send(Err(e.to_string()));
                     }
                 }

--- a/crates/docling-serve/src/o11y.rs
+++ b/crates/docling-serve/src/o11y.rs
@@ -1,0 +1,330 @@
+//! Observability (#297): structured request logging, Prometheus metrics, and
+//! optional OpenTelemetry trace export — the Rust counterpart of Python
+//! docling-serve's OTel integration, with the same posture: Prometheus-style
+//! metrics on by default, OTLP traces opt-in.
+//!
+//! Three layers, in increasing weight:
+//!
+//! 1. **Structured logs** (always on): every request runs inside a `tracing`
+//!    span and emits one `info` event with method, path, status and latency.
+//!    `RUST_LOG` filters (default `info`); output goes to stderr next to the
+//!    existing startup diagnostics.
+//! 2. **`GET /metrics`** (always compiled, no dependencies): Prometheus text
+//!    exposition of request counts/latency, in-flight gauge, and per-outcome
+//!    conversion counts — hand-rolled counters like the rest of this
+//!    workspace's lean-dependency choices. `/metrics`, `/health` and
+//!    `/ready` probes are not counted (mirroring Python docling-serve's
+//!    health-endpoint sampling exclusion).
+//! 3. **OTLP trace export** (cargo feature `otel`, runtime-gated): with the
+//!    feature compiled in *and* `OTEL_EXPORTER_OTLP_ENDPOINT` set, the same
+//!    request spans ship over OTLP/gRPC. Service name comes from
+//!    `OTEL_SERVICE_NAME` (default `docling-serve`, matching Python's
+//!    `otel_service_name`). Without the env var the feature is inert.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// Latency histogram buckets (seconds). Conversions run from milliseconds
+/// (declarative) to minutes (large PDFs through the ML pipeline), so the
+/// buckets stretch far right of a typical web service's.
+const BUCKETS: [f64; 12] = [
+    0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 15.0, 60.0, 300.0, 900.0,
+];
+
+#[derive(Default)]
+struct Histogram {
+    buckets: [AtomicU64; 12],
+    count: AtomicU64,
+    /// Sum in microseconds — atomics can't hold floats, and µs keeps a year
+    /// of accumulated latency well inside u64.
+    sum_micros: AtomicU64,
+}
+
+impl Histogram {
+    fn observe(&self, seconds: f64) {
+        for (i, b) in BUCKETS.iter().enumerate() {
+            if seconds <= *b {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.sum_micros
+            .fetch_add((seconds * 1e6) as u64, Ordering::Relaxed);
+    }
+
+    fn render(&self, out: &mut String, name: &str) {
+        use std::fmt::Write;
+        for (i, b) in BUCKETS.iter().enumerate() {
+            let _ = writeln!(
+                out,
+                "{name}_bucket{{le=\"{b}\"}} {}",
+                self.buckets[i].load(Ordering::Relaxed)
+            );
+        }
+        let _ = writeln!(
+            out,
+            "{name}_bucket{{le=\"+Inf\"}} {}",
+            self.count.load(Ordering::Relaxed)
+        );
+        // No label braces on _sum/_count: an empty `{}` is invalid OpenMetrics.
+        let _ = writeln!(
+            out,
+            "{name}_sum {}",
+            self.sum_micros.load(Ordering::Relaxed) as f64 / 1e6
+        );
+        let _ = writeln!(out, "{name}_count {}", self.count.load(Ordering::Relaxed));
+    }
+}
+
+/// The process-wide metrics registry. Label cardinality is deliberately tiny
+/// and fixed — status *class* (2xx/4xx/5xx), not per-path/per-status — so a
+/// scraper can never be blown up by request-derived label values.
+#[derive(Default)]
+pub struct Metrics {
+    requests_2xx: AtomicU64,
+    requests_4xx: AtomicU64,
+    requests_5xx: AtomicU64,
+    in_flight: AtomicI64,
+    latency: Histogram,
+    conversions_success: AtomicU64,
+    conversions_failure: AtomicU64,
+}
+
+fn metrics() -> &'static Metrics {
+    static M: std::sync::OnceLock<Metrics> = std::sync::OnceLock::new();
+    M.get_or_init(Metrics::default)
+}
+
+/// Record a finished conversion item (one per document — a batch counts each
+/// item). Called from the conversion paths, not the HTTP layer, so async
+/// jobs count when they *run*, not when they're submitted.
+pub fn record_conversion(success: bool) {
+    let m = metrics();
+    if success {
+        m.conversions_success.fetch_add(1, Ordering::Relaxed);
+    } else {
+        m.conversions_failure.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Endpoints excluded from request metrics and request logs: scrapes and
+/// liveness probes would otherwise dominate every counter (and, under OTel,
+/// every trace) — the same exclusion Python docling-serve applies to its
+/// health endpoint.
+fn is_probe(path: &str) -> bool {
+    matches!(path, "/metrics" | "/health" | "/ready")
+}
+
+/// Axum middleware: wrap the request in a `tracing` span, log its outcome,
+/// and record the metrics above.
+pub async fn track(req: Request<Body>, next: Next) -> Response {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    if is_probe(&path) {
+        return next.run(req).await;
+    }
+    let m = metrics();
+    m.in_flight.fetch_add(1, Ordering::Relaxed);
+    let started = Instant::now();
+    let span = tracing::info_span!("request", %method, path = %path);
+    let response = {
+        let _enter = span.enter();
+        next.run(req).await
+    };
+    let elapsed = started.elapsed().as_secs_f64();
+    m.in_flight.fetch_sub(1, Ordering::Relaxed);
+    let status = response.status();
+    match status.as_u16() {
+        200..=399 => m.requests_2xx.fetch_add(1, Ordering::Relaxed),
+        400..=499 => m.requests_4xx.fetch_add(1, Ordering::Relaxed),
+        _ => m.requests_5xx.fetch_add(1, Ordering::Relaxed),
+    };
+    m.latency.observe(elapsed);
+    tracing::info!(
+        parent: &span,
+        status = status.as_u16(),
+        elapsed_ms = (elapsed * 1e3) as u64,
+        "request"
+    );
+    response
+}
+
+/// `GET /metrics` — Prometheus text exposition (version 0.0.4).
+pub async fn metrics_endpoint() -> Response {
+    use std::fmt::Write;
+    let m = metrics();
+    let mut out = String::with_capacity(2048);
+    let _ = writeln!(
+        out,
+        "# HELP docling_serve_requests_total HTTP requests handled, by status class.\n\
+         # TYPE docling_serve_requests_total counter"
+    );
+    for (class, v) in [
+        ("2xx", &m.requests_2xx),
+        ("4xx", &m.requests_4xx),
+        ("5xx", &m.requests_5xx),
+    ] {
+        let _ = writeln!(
+            out,
+            "docling_serve_requests_total{{class=\"{class}\"}} {}",
+            v.load(Ordering::Relaxed)
+        );
+    }
+    let _ = writeln!(
+        out,
+        "# HELP docling_serve_requests_in_flight Requests currently being handled.\n\
+         # TYPE docling_serve_requests_in_flight gauge\n\
+         docling_serve_requests_in_flight {}",
+        m.in_flight.load(Ordering::Relaxed)
+    );
+    let _ = writeln!(
+        out,
+        "# HELP docling_serve_request_duration_seconds End-to-end request latency.\n\
+         # TYPE docling_serve_request_duration_seconds histogram"
+    );
+    m.latency
+        .render(&mut out, "docling_serve_request_duration_seconds");
+    let _ = writeln!(
+        out,
+        "# HELP docling_serve_conversions_total Converted documents, by outcome (batch items count individually; async jobs count when they run).\n\
+         # TYPE docling_serve_conversions_total counter"
+    );
+    for (outcome, v) in [
+        ("success", &m.conversions_success),
+        ("failure", &m.conversions_failure),
+    ] {
+        let _ = writeln!(
+            out,
+            "docling_serve_conversions_total{{outcome=\"{outcome}\"}} {}",
+            v.load(Ordering::Relaxed)
+        );
+    }
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        out,
+    )
+        .into_response()
+}
+
+/// Install the global `tracing` subscriber: an env-filtered (`RUST_LOG`,
+/// default `info`) stderr logger, plus — with the `otel` cargo feature and
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` set — an OTLP span exporter. Idempotent and
+/// quiet when a subscriber already exists (tests, embedding applications).
+pub fn init() {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let fmt = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+    let registry = tracing_subscriber::registry().with(filter).with(fmt);
+
+    #[cfg(feature = "otel")]
+    {
+        if let Some(exporter) = otel_layer() {
+            let _ = registry.with(exporter).try_init();
+            return;
+        }
+    }
+    let _ = registry.try_init();
+}
+
+/// Flush and stop the OTLP exporter (batched spans would otherwise be lost on
+/// SIGTERM). A no-op without the `otel` feature or with export inactive.
+pub fn shutdown() {
+    #[cfg(feature = "otel")]
+    if let Some(provider) = OTEL_PROVIDER.get() {
+        if let Err(e) = provider.shutdown() {
+            eprintln!("docling-serve: OTLP shutdown flush failed: {e}");
+        }
+    }
+}
+
+/// The live tracer provider, kept for the graceful-shutdown flush above.
+#[cfg(feature = "otel")]
+static OTEL_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
+
+/// The OTLP export layer, when configured. `None` without
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` — compiling the feature in must not change
+/// behavior until the operator points it somewhere.
+#[cfg(feature = "otel")]
+fn otel_layer<S>(
+) -> Option<tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    use opentelemetry::trace::TracerProvider as _;
+
+    docling_core::env::nonempty("OTEL_EXPORTER_OTLP_ENDPOINT")?;
+    let exporter = match opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("docling-serve: OTLP exporter init failed ({e}); traces disabled");
+            return None;
+        }
+    };
+    let service = docling_core::env::nonempty("OTEL_SERVICE_NAME")
+        .unwrap_or_else(|| "docling-serve".to_string());
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(
+            opentelemetry_sdk::Resource::builder()
+                .with_service_name(service)
+                .build(),
+        )
+        .build();
+    let tracer = provider.tracer("docling-serve");
+    let _ = OTEL_PROVIDER.set(provider.clone());
+    opentelemetry::global::set_tracer_provider(provider);
+    eprintln!("docling-serve: OTLP trace export enabled (OTEL_EXPORTER_OTLP_ENDPOINT)");
+    Some(tracing_opentelemetry::layer().with_tracer(tracer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The probe exclusion (scrapes and liveness checks must not dominate the
+    /// counters) is exact-match on the three fixed paths — API traffic that
+    /// merely resembles them still counts.
+    #[test]
+    fn probe_paths_are_excluded_exactly() {
+        for p in ["/metrics", "/health", "/ready"] {
+            assert!(is_probe(p), "{p} is a probe");
+        }
+        for p in ["/", "/v1/convert", "/healthz", "/metrics/x", "/ready2"] {
+            assert!(!is_probe(p), "{p} is API traffic");
+        }
+    }
+
+    /// Cumulative-bucket semantics: an observation lands in every bucket at or
+    /// above its value, `+Inf` equals the count, and the sum round-trips
+    /// through the microsecond storage.
+    #[test]
+    fn histogram_buckets_are_cumulative() {
+        let h = Histogram::default();
+        h.observe(0.05); // > 0.025, ≤ 0.1
+        h.observe(30.0); // > 15, ≤ 60
+        let mut out = String::new();
+        h.render(&mut out, "t");
+        assert!(out.contains("t_bucket{le=\"0.025\"} 0"));
+        assert!(out.contains("t_bucket{le=\"0.1\"} 1"));
+        assert!(out.contains("t_bucket{le=\"15\"} 1"));
+        assert!(out.contains("t_bucket{le=\"60\"} 2"));
+        assert!(out.contains("t_bucket{le=\"+Inf\"} 2"));
+        assert!(out.contains("t_count 2"));
+        assert!(out.contains("t_sum 30.05"));
+    }
+}

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -340,6 +340,22 @@ paths:
                 properties:
                   status: { type: string, const: loading }
 
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      operationId: metrics
+      description: >
+        Prometheus text exposition (version 0.0.4) of request counts by status
+        class, an in-flight gauge, a request-latency histogram, and per-outcome
+        conversion counts. Scrapes of `/metrics`, `/health` and `/ready` are
+        excluded from the request metrics.
+      responses:
+        "200":
+          description: Current metric values.
+          content:
+            text/plain:
+              schema: { type: string }
+
   /openapi.yaml:
     get:
       summary: This document

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -953,3 +953,73 @@ async fn explicit_inbody_target_answers_in_the_body() {
     let v: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
     assert_eq!(v["schema_name"], "DoclingDocument");
 }
+
+/// Scrape `/metrics` and read one metric line's value by its exact prefix
+/// (name + labels).
+async fn metric_value(line_prefix: &str) -> f64 {
+    let response = app()
+        .oneshot(Request::get("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let text = body_string(response).await;
+    text.lines()
+        .find(|l| l.starts_with(line_prefix))
+        .unwrap_or_else(|| panic!("no metric line starts with {line_prefix:?} in:\n{text}"))
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn metrics_endpoint_serves_prometheus_text() {
+    let response = app()
+        .oneshot(Request::get("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "text/plain; version=0.0.4; charset=utf-8"
+    );
+    let text = body_string(response).await;
+    for needle in [
+        "# TYPE docling_serve_requests_total counter",
+        "# TYPE docling_serve_requests_in_flight gauge",
+        "# TYPE docling_serve_request_duration_seconds histogram",
+        "docling_serve_request_duration_seconds_bucket{le=\"+Inf\"}",
+        "# TYPE docling_serve_conversions_total counter",
+        "docling_serve_conversions_total{outcome=\"success\"}",
+        "docling_serve_conversions_total{outcome=\"failure\"}",
+    ] {
+        assert!(text.contains(needle), "missing {needle:?} in:\n{text}");
+    }
+}
+
+/// The registry is process-global and tests run in parallel, so this asserts
+/// monotonic growth caused by its own requests rather than absolute values.
+#[tokio::test]
+async fn requests_and_conversions_are_counted() {
+    let requests_before = metric_value("docling_serve_requests_total{class=\"2xx\"}").await;
+    let ok_before = metric_value("docling_serve_conversions_total{outcome=\"success\"}").await;
+    let failed_before = metric_value("docling_serve_conversions_total{outcome=\"failure\"}").await;
+
+    // `to=json` buffers through `convert_document`, so both counters have
+    // moved by the time the response exists (no streaming race).
+    let (ct, body) = multipart("a.csv", b"a,b\n1,2\n", &[("to", "json")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    // An unconvertible upload counts as a failed conversion.
+    let (ct, body) = multipart("broken.docx", b"not a zip", &[("to", "json")]);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let requests_after = metric_value("docling_serve_requests_total{class=\"2xx\"}").await;
+    let ok_after = metric_value("docling_serve_conversions_total{outcome=\"success\"}").await;
+    let failed_after = metric_value("docling_serve_conversions_total{outcome=\"failure\"}").await;
+    assert!(requests_after >= requests_before + 1.0);
+    assert!(ok_after >= ok_before + 1.0);
+    assert!(failed_after >= failed_before + 1.0);
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -454,6 +454,22 @@ These are deliberate or unavoidable divergences, not bugs.
     cloud kinds parse and answer a clear rebuild-with-`--features cloud`
     error.
 
+16. **Serve observability** (#297, Python docling-serve's OTel
+    integration): the same *posture* — Prometheus-style metrics on by
+    default, OTLP traces opt-in, `/metrics`+`/health`+`/ready` excluded
+    from request telemetry, `OTEL_SERVICE_NAME` defaulting to
+    `docling-serve` — but not the same mechanism. Requests log through
+    `tracing` (`RUST_LOG`, default `info`); `GET /metrics` serves
+    hand-rolled dependency-free counters (requests by status class,
+    in-flight gauge, latency histogram with buckets stretched to
+    minutes-long ML conversions, conversions by outcome) instead of
+    Python's OTel-SDK `PrometheusMetricReader`, so metric *names* differ
+    from a Python deployment's. OTLP/gRPC span export sits behind the
+    opt-in `otel` cargo feature and activates only when
+    `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Not covered: OTLP *metric* and
+    *log* export (Prometheus scrape and stderr logs stand in), and
+    Python's `OTEL_*` sampler knobs.
+
 ---
 
 ## 5. Not migrated / out of scope


### PR DESCRIPTION
…n OTLP traces

Bring docling-serve's observability to parity with Python docling-serve's posture (metrics on by default, traces opt-in), in three layers of increasing weight:

1. Structured logs (always on): every request runs inside a `tracing` span and emits one info event with method, path, status and latency; RUST_LOG filters (default `info`), output on stderr next to the existing startup diagnostics.
2. GET /metrics (always compiled, dependency-free): hand-rolled Prometheus text exposition — request counts by status class (fixed label cardinality, no request-derived values), an in-flight gauge, a request-latency histogram with buckets stretched to minutes-long ML conversions, and per-outcome conversion counts (batch items count individually; async jobs count when they run). /metrics, /health and /ready probes are excluded from request telemetry, mirroring Python's health-endpoint sampling exclusion.
3. OTLP/gRPC trace export behind the new opt-in `otel` cargo feature (tracing-opentelemetry + opentelemetry-otlp with grpc-tonic only — no second HTTP stack), runtime-gated on OTEL_EXPORTER_OTLP_ENDPOINT with OTEL_SERVICE_NAME defaulting to "docling-serve" like Python's otel_service_name; without the env var the compiled feature is inert. Batched spans flush on graceful shutdown.

Closes docling-project/docling.rs#297