### PR TITLE
fix(ci): make dependency resolution MSRV-aware

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# MSRV-aware dependency resolution (stable since cargo 1.84): version
+# selection — including the weekly `cargo update` the deps workflow runs —
+# prefers the newest dependency versions whose `rust-version` fits the
+# workspace MSRV (1.88; 1.85 for docling-core), falling back to newer only
+# when nothing compatible exists. Without it the weekly update proposes locks
+# that fail CI's msrv job whenever a dependency raises its floor mid-series
+# (deps PR #305: aes 0.9.2 → 0.9.3 required rustc 1.89 while 0.9.2 still
+# fit). `--locked` builds are unaffected — this only steers what new
+# resolutions pick.
+[resolver]
+incompatible-rust-versions = "fallback"


### PR DESCRIPTION
The weekly deps-update workflow runs a plain `cargo update`, which happily selects dependency versions whose rust-version exceeds the workspace MSRV — this week aes 0.9.2 → 0.9.3 raised the floor to rustc 1.89 (workspace MSRV is 1.88), so the update PR (#305) went red on CI's msrv job with nothing to merge.

Turn on cargo's MSRV-aware resolver (stable since 1.84) via `resolver.incompatible-rust-versions = "fallback"` in .cargo/config.toml: `cargo update` and fresh resolutions now prefer the newest versions whose rust-version fits the workspace floor (verified: with the config, `cargo update --dry-run` reports "Locking N packages to latest Rust 1.85 compatible versions" and leaves aes at 0.9.2), falling back to newer only when nothing compatible exists — in which case the msrv job still catches it, but only when the floor raise is genuinely unavoidable. `--locked` builds (all of CI) are unaffected.

The open deps PR can simply be closed and the deps workflow re-dispatched after this merges — the rolling deps/cargo-update branch force-pushes with a compliant lock.

Refs #305