### PR TITLE
fix(pdf): floor time at 0.3.48 — lopdf 0.44's real minimum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ dependencies = [
  "pdfium-render",
  "regex",
  "tar",
+ "time",
  "tokenizers",
 ]
 

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -65,6 +65,14 @@ flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 regex = { version = "1.11", optional = true }
 lopdf = "0.44"
+# Not used directly — a minimum-version floor for lopdf's under-declared
+# requirement: lopdf 0.44 calls time's `BorrowedFormatItem::StringLiteral`
+# (added in time 0.3.48) while declaring only `time = "0.3"`. The MSRV-aware
+# resolver (.cargo/config.toml) caps versions at docling-core's 1.85 floor
+# and would otherwise select time 0.3.45, which doesn't compile lopdf. Drop
+# when lopdf raises its own minimum. (time 0.3.48+ wants rustc 1.88 — the
+# workspace MSRV; it never enters docling-core's 1.85-only tree.)
+time = { version = "0.3.48", default-features = false }
 fast_image_resize = { version = "5.1.4", optional = true }
 # CodeFormula enrichment decodes its VLM output with the HF tokenizer
 # (.models/code_formula/tokenizer.json) — same crate/features as docling-core's

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.16.0"
+version = "1.20.0"
 dependencies = [
  "calamine",
  "csv",
@@ -722,9 +722,10 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.16.0"
+version = "1.20.0"
 dependencies = [
  "docling-core",
+ "docling-onnx",
  "ort",
  "serde_json",
  "symphonia",
@@ -732,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.16.0"
+version = "1.20.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -741,10 +742,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "docling-pdf"
-version = "1.16.0"
+name = "docling-onnx"
+version = "1.20.0"
 dependencies = [
  "docling-core",
+ "ort",
+]
+
+[[package]]
+name = "docling-pdf"
+version = "1.20.0"
+dependencies = [
+ "docling-core",
+ "docling-onnx",
  "fast_image_resize",
  "flate2",
  "image",
@@ -753,6 +763,7 @@ dependencies = [
  "pdfium-render",
  "regex",
  "tar",
+ "time",
  "tokenizers",
 ]
 


### PR DESCRIPTION
The MSRV-aware resolver (#307) surfaced an under-declared minimum in lopdf: it declares `time = "0.3"` but calls `BorrowedFormatItem::StringLiteral`, which only exists since time 0.3.48. The resolver caps versions at the workspace's lowest member floor (docling-core's 1.85), and time 0.3.46+ requires rustc 1.88 — so the weekly `cargo update` now selects time 0.3.45 and lopdf stops compiling:

  error[E0599]: no variant ... named `StringLiteral` found for enum
  `BorrowedFormatItem<'a>`  (lopdf-0.44.0/src/datetime.rs:103)

Declare the true minimum in docling-pdf (the one lopdf consumer): a floor-only `time = "0.3.48"` dependency, unused directly, droppable once lopdf raises its own requirement. With a requirement no MSRV-compatible version satisfies, the fallback resolver takes the newest instead (0.3.55, rustc 1.88 = exactly the workspace MSRV, so CI's msrv job stays green; docling-core's 1.85 tree never builds time). Verified by simulating the weekly job: `cargo update` now keeps time at 0.3.55 (aes stays at 0.9.2) and the resulting resolution passes `cargo +1.88 check --workspace --locked` — no further under-declared minimums among the 33 packages the MSRV-aware update moves. The docling-py lockfile refresh also picks up the 1.20 workspace version sync.

Refs #305