### PR TITLE
feat(serve,py): plumb the remote VLM pipeline through serve and the P…

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,12 @@ Options per request: `to=md|json|dclx|chunks|images`, `strict`, `images=placehol
 `no_ocr`, `skip_ocr`, `no_table_former`, `no_text_panels`, `heading_hierarchy`, `force_full_page_ocr`, `pages`,
 `ocr_lang`, `ocr_mode`, `ocr_scale`, `scale`, `asr_model`, `asr_lang`, `video_frames`, `fetch_images`,
 `chunker=hierarchical|hybrid`, `chunk_tokenizer`, `chunk_max_tokens`, `chunk_merge_peers` (#256:
-per-request `to=chunks` configuration; the tokenizer is a server-local relative path) — as query
+per-request `to=chunks` configuration; the tokenizer is a server-local relative path),
+`pipeline=standard|vlm` + `vlm_endpoint`, `vlm_model`, `vlm_api_key`, `vlm_prompt`,
+`vlm_max_tokens` (#304: the remote [VLM pipeline](#vlm-pipeline-remote-endpoint); a
+request-supplied `vlm_endpoint` needs `--allow-url-fetch` and passes the same SSRF
+check as URL inputs — pin it server-side via `DOCLING_RS_VLM_*` instead for the safer
+operator-controlled mode) — as query
 parameters, multipart fields, or JSON keys (body wins). Server flags: `--addr`,
 `--concurrency`, `--max-body-mb`, `--queue-size`, `--result-ttl`, `--warmup`,
 `--allow-url-fetch`, `--no-url-fetch`, `--strict`, `--max-memory-mb` (#263:
@@ -655,8 +660,37 @@ docling-rs --pipeline vlm \
 
 The same pipeline is exposed by the **Node bindings** as
 `pipeline: 'vlm'` with `vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` /
-`vlmMaxTokens` (see [Node.js / Bun bindings](#nodejs--bun-bindings)); it is not
-plumbed through serve or the Python bindings yet.
+`vlmMaxTokens` (see [Node.js / Bun bindings](#nodejs--bun-bindings)), by the
+**Python bindings** as constructor kwargs with the same snake_case names
+(#304; a bad configuration raises `ValueError` at construction):
+
+```python
+from docling_rs import DocumentConverter
+
+conv = DocumentConverter(pipeline="vlm",
+                         vlm_endpoint="http://localhost:11434/v1",
+                         vlm_model="granite-docling")
+doc = conv.convert("paper.pdf").document
+```
+
+and by **`docling-rs serve`** as the per-request options
+`pipeline=vlm` + `vlm_endpoint` / `vlm_model` / `vlm_api_key` / `vlm_prompt` /
+`vlm_max_tokens` (#304). On serve, a *request-supplied* `vlm_endpoint` is
+outbound traffic steered by the caller, so it requires `--allow-url-fetch` and
+passes the same SSRF resolution check as URL inputs (private/loopback
+endpoints are refused; `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` for local
+development). The safer default is the **operator-pinned mode**: set
+`DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL` (and optionally
+`_API_KEY` / `_PROMPT`) on the server and have requests send just
+`pipeline=vlm` — callers pick the pipeline, the operator picks where it talks
+to, and no gate is needed:
+
+```bash
+curl -F file=@paper.pdf 'localhost:8000/v1/convert?pipeline=vlm'
+```
+
+A VLM failure (unreachable endpoint, non-200, unparseable answer) fails that
+request with a clear error; the server itself is unaffected.
 
 `--vlm-endpoint` takes the server's `/v1` base or the full
 `…/chat/completions` URL. `DOCLING_RS_VLM_ENDPOINT` / `DOCLING_RS_VLM_MODEL`

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "calamine",
  "csv",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "docling-core",
  "docling-onnx",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "docling-onnx"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "docling-core",
  "docling-onnx",

--- a/crates/docling-py/README.md
+++ b/crates/docling-py/README.md
@@ -139,7 +139,7 @@ PY
 
 | docling.rs | docling counterpart | notes |
 |---|---|---|
-| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, force_full_page_ocr=False, no_text_panels=False, heading_hierarchy=False, do_picture_classification=False, do_code_enrichment=False, do_formula_enrichment=False, fetch_images=False, use_web_browser=False, artifacts_path=None, ocr_lang=None, asr_lang=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
+| `DocumentConverter(format_options=None, *, allowed_formats=None, do_ocr=True, do_table_structure=True, force_full_page_ocr=False, no_text_panels=False, heading_hierarchy=False, do_picture_classification=False, do_code_enrichment=False, do_formula_enrichment=False, fetch_images=False, use_web_browser=False, artifacts_path=None, ocr_lang=None, asr_lang=None, pipeline=None, vlm_endpoint=None, vlm_model=None, vlm_api_key=None, vlm_prompt=None, vlm_max_tokens=None)` | `DocumentConverter(allowed_formats=…, format_options=…)` | Pass `{InputFormat.PDF: PdfFormatOption(pipeline_options=PdfPipelineOptions(…))}` or the shorthand kwargs; `allowed_formats` restricts conversion; `artifacts_path` overrides the model cache dir. |
 | `.convert(path \| DocumentStream) -> ConversionResult` | `.convert(source)` | str / `pathlib.Path` / `DocumentStream`. Releases the GIL during conversion. |
 | `.convert_all(sources, raises_on_error=True) -> Iterator[ConversionResult]` | same | lazily converts many sources; `raises_on_error=False` yields a `failure` result instead of raising |
 | `.initialize_pipeline(format=None)` | same | pre-loads the PDF/image ML models so the first conversion isn't slow and later PDFs reuse the warm pipeline (no-op for non-ML formats; needs the models available) |
@@ -275,8 +275,14 @@ Errors (a bad tokenizer path, malformed document JSON) surface on the first
 
 ## Not covered (yet)
 
-The full-VLM conversion pipeline (SmolDocling) and per-format *backend*
-selection. GPU inference is engine-side only: compiled in via cargo features
+The *local in-process* full-VLM conversion pipeline (SmolDocling) and
+per-format *backend* selection. The **remote** VLM pipeline (#304) *is*
+covered: `DocumentConverter(pipeline="vlm", vlm_endpoint=…, vlm_model=…)`
+(plus optional `vlm_api_key` / `vlm_prompt` / `vlm_max_tokens`, all falling
+back to the `DOCLING_RS_VLM_*` environment) sends each PDF page / image to
+any OpenAI-compatible vision endpoint instead of running the local ML stack —
+no models needed; a bad configuration raises `ValueError` at construction and
+a failed conversion raises the catchable `ConversionError`. GPU inference is engine-side only: compiled in via cargo features
 (#74) and selected with `DOCLING_RS_EP`, not via `accelerator_options.device`,
 and absent from the prebuilt CPU wheels. The document carries rendered text for
 inline formatting rather than structured `formatting` fields — see

--- a/crates/docling-py/python/docling_rs/__init__.py
+++ b/crates/docling-py/python/docling_rs/__init__.py
@@ -158,6 +158,15 @@ class DocumentConverter:
     * ``asr_lang`` — transcription language for audio/video: a Whisper code
       (``"en"``, ``"de"``, …) or ``"auto"`` (default) to detect it from the
       first 30 seconds (docling 2.116 parity).
+    * ``pipeline`` — ``"standard"`` (default) or ``"vlm"`` (#304): convert
+      PDF / image inputs by sending each page to a remote OpenAI-compatible
+      vision model instead of the local ML stack (no models needed). The
+      ``vlm_*`` kwargs mirror the Node bindings' options and fall back to the
+      ``DOCLING_RS_VLM_*`` environment: ``vlm_endpoint`` and ``vlm_model``
+      are required (a missing one raises ``ValueError`` here, at
+      construction); ``vlm_api_key`` (Bearer token), ``vlm_prompt`` and
+      ``vlm_max_tokens`` (default 8192) are optional. With
+      ``pipeline="standard"`` the ``vlm_*`` kwargs are ignored, not rejected.
     * ``artifacts_path`` — override the model cache dir (docling's
       ``artifacts_path``); defaults to ``~/.cache/docling.rs``.
     """
@@ -183,40 +192,46 @@ class DocumentConverter:
         skip_empty_cells: bool = False,
         compact_tables: bool = False,
         asr_lang: Optional[str] = None,
+        pipeline: Optional[str] = None,
+        vlm_endpoint: Optional[str] = None,
+        vlm_model: Optional[str] = None,
+        vlm_api_key: Optional[str] = None,
+        vlm_prompt: Optional[str] = None,
+        vlm_max_tokens: Optional[int] = None,
         artifacts_path=None,
     ):
         ensure_env(artifacts_path)
 
         # A PDF/IMAGE PdfFormatOption overrides the shorthand kwargs.
-        pipeline = _pdf_pipeline_options(format_options)
-        if pipeline is not None:
-            do_ocr = pipeline.do_ocr
-            do_table_structure = pipeline.do_table_structure
+        pdf_opts = _pdf_pipeline_options(format_options)
+        if pdf_opts is not None:
+            do_ocr = pdf_opts.do_ocr
+            do_table_structure = pdf_opts.do_table_structure
             # docling proper carries the flag on ocr_options; accept both the
             # direct field and docling-shaped ocr_options.force_full_page_ocr.
             force_full_page_ocr = getattr(
-                pipeline, "force_full_page_ocr", force_full_page_ocr
+                pdf_opts, "force_full_page_ocr", force_full_page_ocr
             ) or getattr(
-                getattr(pipeline, "ocr_options", None), "force_full_page_ocr", False
+                getattr(pdf_opts, "ocr_options", None), "force_full_page_ocr", False
             )
-            no_text_panels = getattr(pipeline, "no_text_panels", no_text_panels)
-            hh = getattr(pipeline, "heading_hierarchy_options", None)
+            no_text_panels = getattr(pdf_opts, "no_text_panels", no_text_panels)
+            hh = getattr(pdf_opts, "heading_hierarchy_options", None)
             if hh is not None:
                 heading_hierarchy = bool(getattr(hh, "enabled", heading_hierarchy))
             do_picture_classification = getattr(
-                pipeline, "do_picture_classification", do_picture_classification
+                pdf_opts, "do_picture_classification", do_picture_classification
             )
             do_code_enrichment = getattr(
-                pipeline, "do_code_enrichment", do_code_enrichment
+                pdf_opts, "do_code_enrichment", do_code_enrichment
             )
             do_formula_enrichment = getattr(
-                pipeline, "do_formula_enrichment", do_formula_enrichment
+                pdf_opts, "do_formula_enrichment", do_formula_enrichment
             )
             # Map docling's ocr_options.lang (a list of language ids) onto the
             # engine's en/ch recognition-model switch. First entry wins;
             # anything that isn't recognisably English/Chinese is ignored with
             # a warning (the engine default — English — applies).
-            ocr_opts = getattr(pipeline, "ocr_options", None)
+            ocr_opts = getattr(pdf_opts, "ocr_options", None)
             # docling 2.116's OcrMode / OcrOptions.scale (#254). An enum mode
             # collapses to its string value; the direct kwargs stay the
             # fallback, matching the pipeline-overrides-shorthand rule above.
@@ -239,7 +254,7 @@ class DocumentConverter:
                         f"ocr_options.lang={langs!r} is ignored",
                         stacklevel=2,
                     )
-            acc = getattr(pipeline, "accelerator_options", None)
+            acc = getattr(pdf_opts, "accelerator_options", None)
             if acc is not None:
                 # Map docling's device to the engine's DOCLING_RS_EP (resolved
                 # once per process, so this must run before the first
@@ -279,6 +294,12 @@ class DocumentConverter:
             skip_empty_cells=skip_empty_cells,
             compact_tables=compact_tables,
             asr_lang=asr_lang,
+            pipeline=pipeline,
+            vlm_endpoint=vlm_endpoint,
+            vlm_model=vlm_model,
+            vlm_api_key=vlm_api_key,
+            vlm_prompt=vlm_prompt,
+            vlm_max_tokens=vlm_max_tokens,
             allowed_formats=(
                 [InputFormat(f).value for f in allowed_formats]
                 if allowed_formats is not None

--- a/crates/docling-py/src/lib.rs
+++ b/crates/docling-py/src/lib.rs
@@ -44,8 +44,7 @@ where
         let _ = tx.send(work());
     });
     loop {
-        let received =
-            py.detach(|| rx.lock().unwrap().recv_timeout(Duration::from_millis(100)));
+        let received = py.detach(|| rx.lock().unwrap().recv_timeout(Duration::from_millis(100)));
         match received {
             Ok(result) => return result,
             Err(RecvTimeoutError::Timeout) => py.check_signals()?,
@@ -94,6 +93,10 @@ struct PyDocumentConverter {
     ocr_mode: Option<docling::OcrMode>,
     ocr_scale: Option<f32>,
     page_range: Option<(usize, usize)>,
+    /// `pipeline="vlm"` (#304): resolved once in `new` (a bad configuration
+    /// raises there, not mid-conversion); `convert` then routes PDF/image
+    /// through the remote VLM instead of the local ML stack.
+    vlm: Option<docling::vlm::VlmOptions>,
 }
 
 #[pymethods]
@@ -146,6 +149,14 @@ impl PyDocumentConverter {
     /// * `asr_lang` — transcription language for audio/video: a Whisper code
     ///   (`"en"`, `"de"`, …) or `"auto"` (default) to detect it from the
     ///   first 30 seconds (docling 2.116 parity).
+    /// * `pipeline` — `"standard"` (default) or `"vlm"` (#304): convert PDF /
+    ///   image inputs by sending each page to a remote OpenAI-compatible
+    ///   vision model instead of the local ML stack. The `vlm_*` kwargs
+    ///   mirror the Node bindings' options and fall back to the
+    ///   `DOCLING_RS_VLM_*` environment (`vlm_endpoint`, `vlm_model` — both
+    ///   required; `vlm_api_key`, `vlm_prompt`; `vlm_max_tokens` defaults to
+    ///   8192). With `pipeline="standard"` the `vlm_*` kwargs are ignored,
+    ///   not rejected.
     ///
     /// Markdown flavour is chosen at export time by docling-core, so there is no
     /// `strict` knob here.
@@ -174,6 +185,12 @@ impl PyDocumentConverter {
         skip_empty_cells = false,
         compact_tables = false,
         ebcdic_layout = None,
+        pipeline = None,
+        vlm_endpoint = None,
+        vlm_model = None,
+        vlm_api_key = None,
+        vlm_prompt = None,
+        vlm_max_tokens = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -200,7 +217,22 @@ impl PyDocumentConverter {
         skip_empty_cells: bool,
         compact_tables: bool,
         ebcdic_layout: Option<String>,
+        pipeline: Option<String>,
+        vlm_endpoint: Option<String>,
+        vlm_model: Option<String>,
+        vlm_api_key: Option<String>,
+        vlm_prompt: Option<String>,
+        vlm_max_tokens: Option<usize>,
     ) -> PyResult<Self> {
+        let vlm = resolve_vlm(
+            pipeline.as_deref(),
+            vlm_endpoint,
+            vlm_model,
+            vlm_api_key,
+            vlm_prompt,
+            vlm_max_tokens,
+            page_range,
+        )?;
         // `allowed_formats` (docling's converter arg) restricts which input
         // formats convert; an unknown name is an error so typos surface early.
         let base = match allowed_formats {
@@ -300,6 +332,7 @@ impl PyDocumentConverter {
             ocr_mode: ocr_mode_choice,
             ocr_scale,
             page_range,
+            vlm,
         })
     }
 
@@ -314,7 +347,9 @@ impl PyDocumentConverter {
             Some(f) => matches!(f, "pdf" | "image"),
             None => true,
         };
-        if !is_ml {
+        // `pipeline="vlm"` loads no local models — warming would pay the ML
+        // model-load cost for a pipeline that never runs (#304).
+        if !is_ml || self.vlm.is_some() {
             return Ok(());
         }
         let slot = std::sync::Arc::clone(&self.pdf_pipeline);
@@ -338,9 +373,7 @@ impl PyDocumentConverter {
                     .no_ocr(no_ocr)
                     .skip_ocr(skip_ocr)
                     .no_text_panels(no_text_panels)
-                    .heading_hierarchy(docling::HeadingHierarchyOptions::enabled(
-                        heading_hierarchy,
-                    ))
+                    .heading_hierarchy(docling::HeadingHierarchyOptions::enabled(heading_hierarchy))
                     // The warm path used to drop the converter's OCR knobs and
                     // page window on the floor (#254) — prime it with the full
                     // option set the transient path honors.
@@ -393,6 +426,21 @@ impl PyDocumentConverter {
     /// pipeline when `initialize_pipeline` has primed it (otherwise the transient
     /// `inner` path, which reloads models per call).
     fn convert_source(&self, py: Python<'_>, src: SourceDocument) -> PyResult<PyNativeResult> {
+        // `pipeline="vlm"` (#304) is a sibling path: the remote model does the
+        // reading, so neither the warm pipeline nor the declarative converter
+        // applies. A conversion failure raises `ConversionError`, docling's
+        // catchable exception — never a crash.
+        if let Some(vlm) = self.vlm.clone() {
+            return run_interruptible(py, move || {
+                let doc = docling::vlm::convert_vlm(&src, &vlm)
+                    .map_err(|e| ConversionError::new_err(e.to_string()))?;
+                Ok(PyNativeResult {
+                    status: "success".to_string(),
+                    input_name: src.name,
+                    document_json: doc.export_to_json(),
+                })
+            });
+        }
         if src.format == docling::InputFormat::Pdf && self.pdf_pipeline.lock().unwrap().is_some() {
             let slot = std::sync::Arc::clone(&self.pdf_pipeline);
             return run_interruptible(py, move || {
@@ -417,6 +465,64 @@ impl PyDocumentConverter {
                 .map_err(|e| ConversionError::new_err(e.to_string()))?;
             Ok(native_result(result))
         })
+    }
+}
+
+/// Resolve the `pipeline` / `vlm_*` kwargs (#304) into
+/// [`docling::vlm::VlmOptions`], or `None` for the standard pipeline — the
+/// same contract as the Node bindings' `resolve_vlm`: `pipeline` absent or
+/// `"standard"` intentionally ignores stray `vlm_*` kwargs, blank strings
+/// count as unset (reaching the `DOCLING_RS_VLM_*` env fallbacks), and a bad
+/// configuration is a `ValueError` at construction, not a mid-conversion
+/// failure.
+fn resolve_vlm(
+    pipeline: Option<&str>,
+    endpoint: Option<String>,
+    model: Option<String>,
+    api_key: Option<String>,
+    prompt: Option<String>,
+    max_tokens: Option<usize>,
+    page_range: Option<(usize, usize)>,
+) -> PyResult<Option<docling::vlm::VlmOptions>> {
+    let set = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
+    match pipeline {
+        None | Some("standard") => Ok(None),
+        Some("vlm") => {
+            let mut v =
+                docling::vlm::VlmOptions::resolve(set(endpoint), set(model)).map_err(|e| {
+                    // The library's message names the CLI flags; this
+                    // surface's spelling is the kwargs.
+                    PyValueError::new_err(
+                        e.to_string()
+                            .replace("pass --vlm-endpoint", "pass vlm_endpoint")
+                            .replace("pass --vlm-model", "pass vlm_model"),
+                    )
+                })?;
+            if let Some(p) = set(prompt) {
+                v.prompt = Some(p);
+            }
+            if let Some(k) = set(api_key) {
+                v.api_key = Some(k);
+            }
+            // Validated like the Node bindings' `vlmMaxTokens`: 0 would have
+            // every page come back empty and surface as a model error.
+            match max_tokens {
+                Some(0) => {
+                    return Err(PyValueError::new_err(
+                        "vlm_max_tokens must be greater than 0",
+                    ))
+                }
+                Some(n) => v.max_tokens = n,
+                None => {}
+            }
+            // `page_range` composes with the VLM exactly as with the ML
+            // pipeline — only the selected pages are rendered and sent.
+            v.page_range = page_range;
+            Ok(Some(v))
+        }
+        Some(other) => Err(PyValueError::new_err(format!(
+            "unknown pipeline {other:?} (expected: standard, vlm)"
+        ))),
     }
 }
 

--- a/crates/docling-py/tests/test_config.py
+++ b/crates/docling-py/tests/test_config.py
@@ -421,3 +421,113 @@ def test_ensure_env_requires_the_platform_pdfium_lib(tmp_path, monkeypatch):
     (libdir / m._pdfium_lib_name()).write_bytes(b"x")
     m.ensure_env(cache)
     assert os.environ["PDFIUM_DYNAMIC_LIB_PATH"] == str(libdir)
+
+
+# --- #304: remote VLM pipeline ----------------------------------------------
+
+# 1x1 red PNG: the VLM image leg needs no pdfium and no models.
+_PNG = bytes(
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00,
+        0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+        0x00, 0x00, 0x03, 0x00, 0x01, 0x6E, 0x2C, 0xDC, 0x33, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ]
+)
+
+
+def test_vlm_requires_an_endpoint_at_construction(monkeypatch):
+    from docling_rs import DocumentConverter
+
+    monkeypatch.delenv("DOCLING_RS_VLM_ENDPOINT", raising=False)
+    with pytest.raises(ValueError, match="vlm_endpoint"):
+        DocumentConverter(pipeline="vlm")
+
+
+def test_unknown_pipeline_is_a_value_error():
+    from docling_rs import DocumentConverter
+
+    with pytest.raises(ValueError, match="unknown pipeline"):
+        DocumentConverter(pipeline="magic")
+
+
+def test_vlm_max_tokens_zero_is_a_value_error():
+    from docling_rs import DocumentConverter
+
+    with pytest.raises(ValueError, match="vlm_max_tokens"):
+        DocumentConverter(
+            pipeline="vlm",
+            vlm_endpoint="http://localhost:11434/v1",
+            vlm_model="granite-docling",
+            vlm_max_tokens=0,
+        )
+
+
+def test_standard_pipeline_ignores_stray_vlm_kwargs(tmp_path):
+    """The Node bindings' contract: without pipeline="vlm" the vlm_* kwargs
+    are ignored, not rejected — and conversions stay fully local."""
+    from docling_rs import DocumentConverter
+
+    conv = DocumentConverter(
+        vlm_endpoint="http://localhost:1/v1", vlm_model="nope"
+    )
+    doc = tmp_path / "d.md"
+    doc.write_text("# hi\n")
+    result = conv.convert(doc)
+    assert "hi" in result.document.export_to_markdown()
+
+
+def test_vlm_converts_an_image_through_a_stub_endpoint(tmp_path):
+    """End-to-end over a local OpenAI-compatible stub (the counterpart of
+    crates/docling/tests/vlm.rs::mock_openai): a PNG page goes out, the
+    stub's answer comes back as the document text."""
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    from docling_rs import DocumentConverter
+
+    seen = {}
+
+    class Stub(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+            seen["path"] = self.path
+            seen["body"] = json.loads(body)
+            payload = json.dumps(
+                {"choices": [{"message": {"role": "assistant",
+                                          "content": "Hello from the VLM"}}]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):  # keep pytest output clean
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Stub)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conv = DocumentConverter(
+            pipeline="vlm",
+            vlm_endpoint=f"http://127.0.0.1:{server.server_port}/v1",
+            vlm_model="mock-docling",
+            vlm_api_key="sk-test",
+            vlm_max_tokens=512,
+        )
+        png = tmp_path / "page.png"
+        png.write_bytes(_PNG)
+        result = conv.convert(png)
+    finally:
+        server.shutdown()
+        thread.join()
+
+    assert "Hello from the VLM" in result.document.export_to_markdown()
+    assert seen["path"] == "/v1/chat/completions"
+    assert seen["body"]["model"] == "mock-docling"
+    assert seen["body"]["max_tokens"] == 512

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -467,6 +467,26 @@ struct ConvertOptions {
     /// Hybrid peer-merging for `to=chunks` (docling's `merge_peers`, default
     /// true, #256).
     chunk_merge_peers: Option<bool>,
+    /// Conversion pipeline (#304): `standard` (default) or `vlm` — every PDF
+    /// page / image goes to a remote OpenAI-compatible vision model instead of
+    /// the local ML stack. With `standard` the `vlm_*` options below are
+    /// ignored, not rejected (the Node bindings' contract).
+    pipeline: Option<String>,
+    /// VLM endpoint for `pipeline=vlm`. A request-supplied endpoint is an
+    /// outbound-URL/SSRF surface: it needs `--allow-url-fetch` and passes the
+    /// same private-address check as URL inputs. Unset falls back to the
+    /// operator-pinned `DOCLING_RS_VLM_ENDPOINT` — the safer default: callers
+    /// pick the pipeline, the operator picks where it talks to.
+    vlm_endpoint: Option<String>,
+    /// VLM model name; falls back to `DOCLING_RS_VLM_MODEL`.
+    vlm_model: Option<String>,
+    /// Bearer token for the endpoint; falls back to `DOCLING_RS_VLM_API_KEY`.
+    vlm_api_key: Option<String>,
+    /// Per-page instruction; falls back to `DOCLING_RS_VLM_PROMPT`, else
+    /// docling's DocLang-eliciting default prompt.
+    vlm_prompt: Option<String>,
+    /// `max_tokens` per completion (default 8192).
+    vlm_max_tokens: Option<usize>,
 }
 
 impl ConvertOptions {
@@ -498,6 +518,12 @@ impl ConvertOptions {
             chunk_tokenizer: self.chunk_tokenizer.or(base.chunk_tokenizer),
             chunk_max_tokens: self.chunk_max_tokens.or(base.chunk_max_tokens),
             chunk_merge_peers: self.chunk_merge_peers.or(base.chunk_merge_peers),
+            pipeline: self.pipeline.or(base.pipeline),
+            vlm_endpoint: self.vlm_endpoint.or(base.vlm_endpoint),
+            vlm_model: self.vlm_model.or(base.vlm_model),
+            vlm_api_key: self.vlm_api_key.or(base.vlm_api_key),
+            vlm_prompt: self.vlm_prompt.or(base.vlm_prompt),
+            vlm_max_tokens: self.vlm_max_tokens.or(base.vlm_max_tokens),
         }
     }
 }
@@ -794,6 +820,9 @@ async fn convert(
 ) -> Result<Response, ApiError> {
     let (sources, options, target) = parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    // #304: bad pipeline/vlm options are a 400/422 up front (no DNS here —
+    // the endpoint's SSRF resolution check runs on the blocking pool).
+    resolve_vlm_options(&state, &options, false)?;
     validate_target(&to, target.as_ref())?;
     // Admission control (#263): shed load before taking a conversion slot.
     if let Some(msg) = state.overloaded() {
@@ -919,6 +948,8 @@ async fn convert_async(
     let (mut sources, options, target) =
         parse_convert_request(&state, query, headers, body).await?;
     let (to, image_mode) = validate_output(&options)?;
+    // #304: fail an async submission fast instead of parking a doomed job.
+    resolve_vlm_options(&state, &options, false)?;
     validate_target(&to, target.as_ref())?;
     // Admission control (#263) applies to async submissions too — a queued
     // job holds its upload bytes and will run into the same ceiling.
@@ -1551,6 +1582,19 @@ async fn read_multipart(
                 })?);
             }
             "ebcdic_layout" => body_opts.ebcdic_layout = Some(text_field(field).await?),
+            "pipeline" => body_opts.pipeline = Some(text_field(field).await?),
+            "vlm_endpoint" => body_opts.vlm_endpoint = Some(text_field(field).await?),
+            "vlm_model" => body_opts.vlm_model = Some(text_field(field).await?),
+            "vlm_api_key" => body_opts.vlm_api_key = Some(text_field(field).await?),
+            "vlm_prompt" => body_opts.vlm_prompt = Some(text_field(field).await?),
+            "vlm_max_tokens" => {
+                let v = text_field(field).await?;
+                body_opts.vlm_max_tokens = Some(v.parse().map_err(|_| {
+                    ApiError::Bad(format!(
+                        "vlm_max_tokens must be a positive integer, got {v:?}"
+                    ))
+                })?);
+            }
             "chunker" => body_opts.chunker = Some(text_field(field).await?),
             "chunk_tokenizer" => body_opts.chunk_tokenizer = Some(text_field(field).await?),
             "chunk_max_tokens" => {
@@ -1749,22 +1793,19 @@ fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
     }
 }
 
-/// Fetch a URL input (blocking; run on the blocking pool). The name comes
-/// from `file_name` or the URL path's last segment.
-fn fetch_url(
-    url: &str,
-    file_name: Option<&str>,
-    headers: &[(String, String)],
-) -> Result<SourceDocument, ApiError> {
+/// SSRF pre-check shared by every request-supplied outbound URL — URL inputs
+/// and the `vlm_endpoint` request option (#304): http(s) scheme only, then
+/// resolve the host and reject if it maps to a private/loopback/link-local
+/// address (fetches additionally forbid redirects — a public URL could
+/// 30x-bounce to an internal target, defeating this pre-check). This is a
+/// best-effort mitigation — a DNS-rebinding race between this resolution and
+/// the eventual connect remains theoretically possible; the deployment-level
+/// control is to leave URL fetch disabled unless the network is trusted.
+/// Blocking (DNS) — call on the blocking pool.
+fn check_outbound_url(url: &str) -> Result<(), ApiError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(ApiError::Bad(format!("unsupported URL scheme in '{url}'")));
     }
-    // SSRF guard: resolve the host and reject if it maps to a private/loopback/
-    // link-local address, and forbid redirects (a public URL could 30x-bounce
-    // to an internal target, defeating this pre-check). This is a best-effort
-    // mitigation — a DNS-rebinding race between this resolution and ureq's own
-    // connect remains theoretically possible; the deployment-level control is
-    // to leave URL fetch disabled unless the network is trusted.
     let parsed =
         url::Url::parse(url).map_err(|e| ApiError::Bad(format!("bad URL '{url}': {e}")))?;
     let host = parsed
@@ -1788,6 +1829,17 @@ fn fetch_url(
             }
         }
     }
+    Ok(())
+}
+
+/// Fetch a URL input (blocking; run on the blocking pool). The name comes
+/// from `file_name` or the URL path's last segment.
+fn fetch_url(
+    url: &str,
+    file_name: Option<&str>,
+    headers: &[(String, String)],
+) -> Result<SourceDocument, ApiError> {
+    check_outbound_url(url)?;
     // Bounded in time as well as size: without timeouts a slow-drip URL pins
     // one spawn_blocking worker indefinitely, and a handful of them starves
     // the pool. Generous global cap — legitimate fetches may be ~256 MiB.
@@ -1855,11 +1907,95 @@ fn convert_document(
     result
 }
 
+/// Resolve the request's `pipeline` / `vlm_*` options (#304) into
+/// [`docling::vlm::VlmOptions`], or `None` for the standard pipeline. The
+/// contract mirrors the Node bindings: `pipeline` absent or `standard`
+/// intentionally ignores stray `vlm_*` options; blank strings count as unset
+/// (reaching the `DOCLING_RS_VLM_*` env fallbacks, the operator-pinned mode).
+/// A request-supplied `vlm_endpoint` is the same outbound/SSRF surface as a
+/// URL input: it needs `--allow-url-fetch`, and — when `check_ip` (call it on
+/// the blocking pool: DNS) — the [`check_outbound_url`] resolution check.
+fn resolve_vlm_options(
+    state: &AppState,
+    options: &ConvertOptions,
+    check_ip: bool,
+) -> Result<Option<docling::vlm::VlmOptions>, ApiError> {
+    let set = |s: &Option<String>| s.clone().filter(|v| !v.trim().is_empty());
+    match options.pipeline.as_deref() {
+        None | Some("standard") => Ok(None),
+        Some("vlm") => {
+            let endpoint = set(&options.vlm_endpoint);
+            if let Some(url) = endpoint.as_deref() {
+                if !state.cfg.allow_url_fetch {
+                    return Err(ApiError::Unsupported(
+                        "request-supplied vlm_endpoint is disabled; start docling-serve \
+                         with --allow-url-fetch (SSRF surface — see docs/SECURITY.md), \
+                         or pin the endpoint server-side via DOCLING_RS_VLM_ENDPOINT"
+                            .into(),
+                    ));
+                }
+                if check_ip {
+                    check_outbound_url(url)?;
+                }
+            }
+            let mut v = docling::vlm::VlmOptions::resolve(endpoint, set(&options.vlm_model))
+                .map_err(|e| {
+                    // The library's message names the CLI flags; this surface's
+                    // spelling is the request options.
+                    ApiError::Bad(
+                        e.to_string()
+                            .replace("pass --vlm-endpoint", "pass vlm_endpoint")
+                            .replace("pass --vlm-model", "pass vlm_model"),
+                    )
+                })?;
+            if let Some(p) = set(&options.vlm_prompt) {
+                v.prompt = Some(p);
+            }
+            if let Some(k) = set(&options.vlm_api_key) {
+                v.api_key = Some(k);
+            }
+            // Validated like the Node bindings' `vlmMaxTokens`: 0 would have
+            // every page come back empty and surface as a model error.
+            match options.vlm_max_tokens {
+                Some(0) => {
+                    return Err(ApiError::Bad(
+                        "vlm_max_tokens must be greater than 0".into(),
+                    ))
+                }
+                Some(n) => v.max_tokens = n,
+                None => {}
+            }
+            // `pages` composes with the VLM exactly as with the ML pipeline —
+            // only the selected pages are rendered and sent.
+            v.page_range = options
+                .pages
+                .as_deref()
+                .map(docling::parse_page_range)
+                .transpose()
+                .map_err(|e| ApiError::Bad(format!("pages: {e}")))?;
+            Ok(Some(v))
+        }
+        Some(other) => Err(ApiError::Bad(format!(
+            "unknown pipeline '{other}' (expected: standard, vlm)"
+        ))),
+    }
+}
+
 fn convert_document_inner(
     state: &AppState,
     source: SourceDocument,
     options: &ConvertOptions,
 ) -> Result<DoclingDocument, ApiError> {
+    // #304: the VLM pipeline is a sibling path — the remote model does the
+    // reading, none of the local ML options apply. Resolved here (on the
+    // blocking pool, where the endpoint's DNS check belongs) so every
+    // buffered surface — sync, batch item, async job, cloud target — and the
+    // streaming path's buffered branch pick it up in one place. A VLM failure
+    // is a per-request error like any other, never a server crash.
+    if let Some(vlm) = resolve_vlm_options(state, options, true)? {
+        return docling::vlm::convert_vlm(&source, &vlm)
+            .map_err(|e| ApiError::Unsupported(e.to_string()));
+    }
     match source.format {
         InputFormat::Pdf | InputFormat::Image => {
             // Recover from a poisoned lock instead of propagating the panic: a
@@ -2081,66 +2217,69 @@ async fn stream_markdown(
             // The receiver disappearing means the client went away — stop.
             tx.blocking_send(item).is_ok()
         };
-        match source.format {
-            InputFormat::Pdf | InputFormat::Image => {
-                // Buffered document → streamed serialization is pointless for
-                // images (one step); PDFs stream page by page through the
-                // warm pipeline's converter equivalent: convert, then stream
-                // the serializer output. (True page-by-page pipeline
-                // streaming holds the model mutex anyway, so the wall-clock
-                // is the same; the client still gets incremental output.)
-                match convert_document(&st, source, &options) {
-                    Ok(mut doc) => {
-                        doc.strict_markdown = options.strict.unwrap_or(st.cfg.strict);
-                        let md = match image_mode {
-                            ImageMode::Placeholder => doc.export_to_markdown(),
-                            _ => {
-                                doc.export_to_markdown_with_images(image_mode, "artifacts")
-                                    .0
-                            }
-                        };
-                        send(Ok((md, confidence_header(&doc))));
-                    }
-                    Err(e) => {
-                        send(Err(api_error_message(e)));
-                    }
+        // #304: the VLM pipeline buffers whatever the input format — it is a
+        // per-page remote conversion, and its "wrong input format" rejection
+        // must reach the client instead of the declarative streamer running a
+        // standard conversion the caller didn't ask for.
+        let buffered = options.pipeline.as_deref() == Some("vlm")
+            || matches!(source.format, InputFormat::Pdf | InputFormat::Image);
+        if buffered {
+            // Buffered document → streamed serialization is pointless for
+            // images (one step); PDFs stream page by page through the
+            // warm pipeline's converter equivalent: convert, then stream
+            // the serializer output. (True page-by-page pipeline
+            // streaming holds the model mutex anyway, so the wall-clock
+            // is the same; the client still gets incremental output.)
+            match convert_document(&st, source, &options) {
+                Ok(mut doc) => {
+                    doc.strict_markdown = options.strict.unwrap_or(st.cfg.strict);
+                    let md = match image_mode {
+                        ImageMode::Placeholder => doc.export_to_markdown(),
+                        _ => {
+                            doc.export_to_markdown_with_images(image_mode, "artifacts")
+                                .0
+                        }
+                    };
+                    send(Ok((md, confidence_header(&doc))));
+                }
+                Err(e) => {
+                    send(Err(api_error_message(e)));
                 }
             }
-            _ => {
-                let converter = match request_converter(&st, &options) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        send(Err(api_error_message(e)));
-                        return;
-                    }
-                };
-                // The streaming path bypasses `convert_document`, so the
-                // conversion metric (#297) is recorded here: success once the
-                // stream drains, failure on a conversion error (a client that
-                // disconnects mid-stream abandons the conversion and counts as
-                // neither).
-                match converter.convert_streaming_images(source, image_mode) {
-                    Ok(stream) => {
-                        for chunk in stream {
-                            match chunk {
-                                Ok(s) => {
-                                    if !send(Ok((s, None))) {
-                                        return;
-                                    }
-                                }
-                                Err(e) => {
-                                    o11y::record_conversion(false);
-                                    send(Err(e.to_string()));
+        } else {
+            let converter = match request_converter(&st, &options) {
+                Ok(c) => c,
+                Err(e) => {
+                    send(Err(api_error_message(e)));
+                    return;
+                }
+            };
+            // The streaming path bypasses `convert_document`, so the
+            // conversion metric (#297) is recorded here: success once the
+            // stream drains, failure on a conversion error (a client that
+            // disconnects mid-stream abandons the conversion and counts as
+            // neither).
+            match converter.convert_streaming_images(source, image_mode) {
+                Ok(stream) => {
+                    for chunk in stream {
+                        match chunk {
+                            Ok(s) => {
+                                if !send(Ok((s, None))) {
                                     return;
                                 }
                             }
+                            Err(e) => {
+                                o11y::record_conversion(false);
+                                send(Err(e.to_string()));
+                                return;
+                            }
                         }
-                        o11y::record_conversion(true);
                     }
-                    Err(e) => {
-                        o11y::record_conversion(false);
-                        send(Err(e.to_string()));
-                    }
+                    o11y::record_conversion(true);
+                }
+                Err(e) => {
+                    o11y::record_conversion(false);
+                    send(Err(e.to_string()));
                 }
             }
         }
@@ -2299,8 +2438,14 @@ mod ssrf_tests {
         ));
     }
 
+    /// Serializes the tests that touch process-global env vars — without it
+    /// the escape-hatch toggling below races the #304 VLM tests that depend
+    /// on those very vars being unset.
+    pub(super) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn private_ip_escape_hatch_defaults_off() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The env var gates only development use; unset it must read as false
         // so the block-list is enforced by default. (Set within this test only,
         // then cleared, to avoid leaking to sibling tests.)
@@ -2317,5 +2462,159 @@ mod ssrf_tests {
             assert_eq!(super::allow_private_ip_fetch(), want, "value {val:?}");
         }
         std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+    }
+}
+
+/// #304: the request-side VLM option resolution — the standard-pipeline
+/// ignore, the `--allow-url-fetch` gate on request-supplied endpoints, the
+/// SSRF resolution check, and the operator-pinned env fallback that skips it.
+#[cfg(test)]
+mod vlm_tests {
+    use super::{resolve_vlm_options, ApiError, AppState, ConvertOptions, ServeConfig};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::Semaphore;
+
+    fn state(allow_url_fetch: bool) -> AppState {
+        AppState {
+            pipeline: Mutex::new(None),
+            permits: Arc::new(Semaphore::new(1)),
+            jobs: Mutex::new(Default::default()),
+            ready: AtomicBool::new(true),
+            memory_ceiling_mb: None,
+            cfg: ServeConfig {
+                allow_url_fetch,
+                ..ServeConfig::default()
+            },
+        }
+    }
+
+    fn vlm_opts(endpoint: Option<&str>) -> ConvertOptions {
+        ConvertOptions {
+            pipeline: Some("vlm".into()),
+            vlm_endpoint: endpoint.map(str::to_string),
+            vlm_model: Some("m".into()),
+            ..ConvertOptions::default()
+        }
+    }
+
+    #[test]
+    fn standard_pipeline_ignores_stray_vlm_options() {
+        // Same contract as the Node bindings: no `pipeline=vlm`, no VLM — the
+        // stray options are ignored, not rejected, and nothing is resolved.
+        for pipeline in [None, Some("standard".to_string())] {
+            let options = ConvertOptions {
+                pipeline,
+                ..vlm_opts(Some("http://127.0.0.1:9/v1"))
+            };
+            let resolved = resolve_vlm_options(&state(false), &options, true);
+            assert!(matches!(resolved, Ok(None)));
+        }
+    }
+
+    #[test]
+    fn unknown_pipeline_is_rejected() {
+        let options = ConvertOptions {
+            pipeline: Some("magic".into()),
+            ..ConvertOptions::default()
+        };
+        match resolve_vlm_options(&state(true), &options, false) {
+            Err(ApiError::Bad(m)) => assert!(m.contains("unknown pipeline"), "{m}"),
+            _ => panic!("expected Bad"),
+        }
+    }
+
+    #[test]
+    fn request_endpoint_is_gated_behind_allow_url_fetch() {
+        // Without --allow-url-fetch a caller must not steer the server's
+        // outbound traffic; the operator-pinned env mode is the alternative.
+        match resolve_vlm_options(
+            &state(false),
+            &vlm_opts(Some("http://example.com/v1")),
+            false,
+        ) {
+            Err(ApiError::Unsupported(m)) => assert!(m.contains("--allow-url-fetch"), "{m}"),
+            _ => panic!("expected Unsupported"),
+        }
+    }
+
+    #[test]
+    fn request_endpoint_resolving_to_private_address_is_rejected() {
+        let _env = super::ssrf_tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+        match resolve_vlm_options(&state(true), &vlm_opts(Some("http://127.0.0.1:9/v1")), true) {
+            Err(ApiError::Bad(m)) => assert!(m.contains("private/loopback"), "{m}"),
+            _ => panic!("expected Bad"),
+        }
+        // The handler-side (no-DNS) pass lets the same request through — the
+        // check belongs to the blocking conversion path.
+        assert!(resolve_vlm_options(
+            &state(true),
+            &vlm_opts(Some("http://127.0.0.1:9/v1")),
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn operator_pinned_endpoint_skips_the_gate_and_the_ip_check() {
+        let _env = super::ssrf_tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Pinned mode: the operator configured the endpoint, so a local model
+        // server (the common deployment) is fine and no gate applies.
+        std::env::set_var("DOCLING_RS_VLM_ENDPOINT", "http://127.0.0.1:11434/v1");
+        std::env::set_var("DOCLING_RS_VLM_MODEL", "granite-docling");
+        let resolved = resolve_vlm_options(&state(false), &vlm_opts(None), true);
+        std::env::remove_var("DOCLING_RS_VLM_ENDPOINT");
+        std::env::remove_var("DOCLING_RS_VLM_MODEL");
+        let v = resolved.ok().flatten().expect("pinned endpoint resolves");
+        assert_eq!(v.endpoint, "http://127.0.0.1:11434/v1");
+        // The request still picks the model when it says so (env was the
+        // fallback for the endpoint only here).
+        assert_eq!(v.model, "m");
+    }
+
+    #[test]
+    fn vlm_max_tokens_zero_is_rejected_and_options_land() {
+        let _env = super::ssrf_tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("DOCLING_RS_VLM_ENDPOINT");
+        let mut options = vlm_opts(Some("http://example.com/v1"));
+        options.vlm_max_tokens = Some(0);
+        match resolve_vlm_options(&state(true), &options, false) {
+            Err(ApiError::Bad(m)) => assert!(m.contains("vlm_max_tokens"), "{m}"),
+            _ => panic!("expected Bad"),
+        }
+        // And without any endpoint at all, the error names this surface's
+        // option spelling, not the CLI flag.
+        let none = ConvertOptions {
+            pipeline: Some("vlm".into()),
+            ..ConvertOptions::default()
+        };
+        match resolve_vlm_options(&state(true), &none, false) {
+            Err(ApiError::Bad(m)) => {
+                assert!(m.contains("vlm_endpoint"), "{m}");
+                assert!(!m.contains("--vlm-endpoint"), "{m}");
+            }
+            _ => panic!("expected Bad"),
+        }
+        // The full option set reaches the resolved struct.
+        let mut options = vlm_opts(Some("http://example.com/v1"));
+        options.vlm_api_key = Some("sk-test".into());
+        options.vlm_prompt = Some("Read the page.".into());
+        options.vlm_max_tokens = Some(512);
+        options.pages = Some("2-5".into());
+        let v = resolve_vlm_options(&state(true), &options, false)
+            .ok()
+            .flatten()
+            .expect("resolves");
+        assert_eq!(v.api_key.as_deref(), Some("sk-test"));
+        assert_eq!(v.prompt.as_deref(), Some("Read the page."));
+        assert_eq!(v.max_tokens, 512);
+        assert_eq!(v.page_range, Some((2, 5)));
     }
 }

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -76,6 +76,12 @@ paths:
         - { $ref: "#/components/parameters/chunk_tokenizer" }
         - { $ref: "#/components/parameters/chunk_max_tokens" }
         - { $ref: "#/components/parameters/chunk_merge_peers" }
+        - { $ref: "#/components/parameters/pipeline" }
+        - { $ref: "#/components/parameters/vlm_endpoint" }
+        - { $ref: "#/components/parameters/vlm_model" }
+        - { $ref: "#/components/parameters/vlm_api_key" }
+        - { $ref: "#/components/parameters/vlm_prompt" }
+        - { $ref: "#/components/parameters/vlm_max_tokens" }
       requestBody:
         required: true
         content:
@@ -110,6 +116,12 @@ paths:
                 chunk_tokenizer: { type: string }
                 chunk_max_tokens: { type: integer, minimum: 1 }
                 chunk_merge_peers: { type: boolean }
+                pipeline: { $ref: "#/components/schemas/Pipeline" }
+                vlm_endpoint: { type: string, format: uri }
+                vlm_model: { type: string }
+                vlm_api_key: { type: string }
+                vlm_prompt: { type: string }
+                vlm_max_tokens: { type: integer, minimum: 1 }
           application/json:
             schema:
               allOf:
@@ -539,6 +551,35 @@ components:
           description: >
             `to=chunks` — merge undersized successive hybrid chunks with the
             same headings (docling's `merge_peers`).
+        pipeline: { $ref: "#/components/schemas/Pipeline" }
+        vlm_endpoint:
+          type: string
+          format: uri
+          description: >
+            `pipeline=vlm` — the OpenAI-compatible endpoint (base `/v1` URL or
+            full `…/chat/completions`). Request-supplied values need
+            `--allow-url-fetch`; unset falls back to the server's
+            `DOCLING_RS_VLM_ENDPOINT`.
+        vlm_model:
+          type: string
+          description: >-
+            `pipeline=vlm` — model name as the endpoint knows it; falls back
+            to `DOCLING_RS_VLM_MODEL`.
+        vlm_api_key:
+          type: string
+          description: >-
+            `pipeline=vlm` — Bearer token; falls back to
+            `DOCLING_RS_VLM_API_KEY`.
+        vlm_prompt:
+          type: string
+          description: >-
+            `pipeline=vlm` — per-page instruction; falls back to
+            `DOCLING_RS_VLM_PROMPT`, else docling's DocLang-eliciting prompt.
+        vlm_max_tokens:
+          type: integer
+          minimum: 1
+          default: 8192
+          description: "`pipeline=vlm` — max_tokens per completion."
     DoclingDocument:
       type: object
       description: >
@@ -585,6 +626,18 @@ components:
           type: string
           enum: [inbody, s3, azure_blob, google_cloud_storage]
       additionalProperties: true
+    Pipeline:
+      type: string
+      enum: [standard, vlm]
+      default: standard
+      description: >
+        Conversion pipeline (#304). `vlm` sends every PDF page / image to a
+        remote OpenAI-compatible vision model instead of the local ML stack;
+        the `vlm_*` options apply (and fall back to the server's
+        `DOCLING_RS_VLM_*` environment — the operator-pinned mode). A
+        request-supplied `vlm_endpoint` needs `--allow-url-fetch` (SSRF
+        surface) and must not resolve to a private address. With `standard`
+        the `vlm_*` options are ignored.
     Chunker:
       type: string
       enum: [hierarchical, hybrid]
@@ -693,3 +746,15 @@ components:
       { name: chunk_max_tokens, in: query, schema: { type: integer, minimum: 1 } }
     chunk_merge_peers:
       { name: chunk_merge_peers, in: query, schema: { type: boolean } }
+    pipeline:
+      { name: pipeline, in: query, schema: { $ref: "#/components/schemas/Pipeline" } }
+    vlm_endpoint:
+      { name: vlm_endpoint, in: query, schema: { type: string, format: uri } }
+    vlm_model:
+      { name: vlm_model, in: query, schema: { type: string } }
+    vlm_api_key:
+      { name: vlm_api_key, in: query, schema: { type: string } }
+    vlm_prompt:
+      { name: vlm_prompt, in: query, schema: { type: string } }
+    vlm_max_tokens:
+      { name: vlm_max_tokens, in: query, schema: { type: integer, minimum: 1 } }

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -1023,3 +1023,208 @@ async fn requests_and_conversions_are_counted() {
     assert!(ok_after >= ok_before + 1.0);
     assert!(failed_after >= failed_before + 1.0);
 }
+
+// --- #304: remote VLM pipeline ---------------------------------------------
+
+/// 1×1 red PNG (the same bytes as the fetch_images test) — the VLM image leg
+/// needs no pdfium and no models, so these tests run in plain CI.
+const VLM_PNG: &[u8] = &[
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+    0x00, 0x00, 0x03, 0x00, 0x01, 0x6e, 0x2c, 0xdc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+    0x44, 0xae, 0x42, 0x60, 0x82,
+];
+
+/// A one-shot OpenAI-compatible stub (the counterpart of
+/// `crates/docling/tests/vlm.rs::mock_openai`): serves `answer` as
+/// `choices[0].message.content` and records that it was hit.
+fn mock_vlm(
+    answer: &str,
+) -> (
+    String,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let served = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&served);
+    let answer = answer.to_string();
+    let handle = std::thread::spawn(move || {
+        let (mut conn, _) = listener.accept().expect("accept");
+        // Read until the full body arrived (Content-Length framing).
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 4096];
+        loop {
+            let n = conn.read(&mut tmp).expect("read request");
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(head_end) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                let head = String::from_utf8_lossy(&buf[..head_end]).to_ascii_lowercase();
+                let need: usize = head
+                    .lines()
+                    .find_map(|l| l.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse().ok())
+                    .expect("content-length");
+                if buf.len() >= head_end + 4 + need {
+                    break;
+                }
+            }
+        }
+        let body = String::from_utf8_lossy(&buf).into_owned();
+        assert!(body.contains("\"model\":\"mock-docling\""), "model missing");
+        let payload = serde_json::json!({
+            "choices": [{ "message": { "role": "assistant", "content": answer } }]
+        })
+        .to_string();
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{payload}",
+            payload.len()
+        );
+        conn.write_all(resp.as_bytes()).expect("write response");
+        count.fetch_add(1, Ordering::SeqCst);
+    });
+    (format!("http://{addr}/v1"), served, handle)
+}
+
+#[tokio::test]
+async fn vlm_pipeline_converts_via_the_operator_pinned_endpoint() {
+    // Pinned mode (#304's safer default): the endpoint comes from the
+    // server's DOCLING_RS_VLM_* environment, so the request needs neither a
+    // vlm_endpoint nor --allow-url-fetch — and a loopback model server (the
+    // common deployment) is the operator's own choice, exempt from the SSRF
+    // block-list. The other VLM tests below pass explicit endpoints, so these
+    // process-global vars can't steer them even while set.
+    let (endpoint, served, handle) = mock_vlm("Hello from the VLM");
+    std::env::set_var("DOCLING_RS_VLM_ENDPOINT", &endpoint);
+    let fields = [("pipeline", "vlm"), ("vlm_model", "mock-docling")];
+    let (ct, body) = multipart("page.png", VLM_PNG, &fields);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    let status = response.status();
+    let out = body_string(response).await;
+    std::env::remove_var("DOCLING_RS_VLM_ENDPOINT");
+    assert_eq!(status, StatusCode::OK, "{out}");
+    assert!(out.contains("Hello from the VLM"), "markdown: {out}");
+    assert_eq!(served.load(std::sync::atomic::Ordering::SeqCst), 1);
+    handle.join().unwrap();
+}
+
+#[tokio::test]
+async fn vlm_rejects_non_visual_formats_instead_of_converting_them() {
+    // pipeline=vlm on a Markdown upload must surface the VLM's format error,
+    // not silently run the standard conversion the caller didn't ask for —
+    // including on the to=md streaming path this request takes. The endpoint
+    // is never contacted (the format check precedes any HTTP), so a public
+    // literal that passes the SSRF block-list suffices — and keeps this test
+    // off the env vars the pinned test above toggles.
+    let fields = [
+        ("pipeline", "vlm"),
+        ("vlm_endpoint", "http://8.8.8.8:9/v1"),
+        ("vlm_model", "m"),
+    ];
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let (ct, body) = multipart("d.md", b"# hi", &fields);
+    let response = router(cfg)
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    let status = response.status();
+    let out = body_string(response).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{out}");
+    assert!(out.contains("vlm pipeline converts PDF and image"), "{out}");
+}
+
+#[tokio::test]
+async fn request_supplied_vlm_endpoint_needs_allow_url_fetch() {
+    // Secure default: without --allow-url-fetch a caller must not point the
+    // server's outbound traffic anywhere — 422 before anything is contacted.
+    let fields = [
+        ("pipeline", "vlm"),
+        ("vlm_endpoint", "http://127.0.0.1:9/v1"),
+        ("vlm_model", "m"),
+    ];
+    let (ct, body) = multipart("page.png", VLM_PNG, &fields);
+    let response = app().oneshot(convert_request(&ct, body, "")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let out = body_string(response).await;
+    assert!(out.contains("--allow-url-fetch"), "{out}");
+    assert!(out.contains("DOCLING_RS_VLM_ENDPOINT"), "{out}");
+}
+
+#[tokio::test]
+async fn vlm_endpoint_resolving_to_private_address_is_rejected() {
+    // Even with the gate open, a request endpoint may not reach back into the
+    // server's own network (same block-list as URL inputs).
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let fields = [
+        ("pipeline", "vlm"),
+        ("vlm_endpoint", "http://127.0.0.1:9/v1"),
+        ("vlm_model", "m"),
+    ];
+    let (ct, body) = multipart("page.png", VLM_PNG, &fields);
+    let response = router(cfg)
+        .oneshot(convert_request(&ct, body, ""))
+        .await
+        .unwrap();
+    let out = body_string(response).await;
+    assert!(out.contains("private/loopback"), "{out}");
+}
+
+#[tokio::test]
+async fn unknown_pipeline_is_a_400_and_fails_async_submissions_fast() {
+    // Query-param spelling on the sync endpoint…
+    let (ct, body) = multipart("d.md", b"# hi", &[]);
+    let response = app()
+        .oneshot(convert_request(&ct, body, "?pipeline=magic"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("unknown pipeline"));
+
+    // …and the async endpoint validates synchronously: nothing is queued.
+    let (ct, body) = multipart("d.md", b"# hi", &[("pipeline", "magic")]);
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/convert/async")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn vlm_options_ride_the_json_body_and_zero_max_tokens_is_a_400() {
+    // JSON-body spelling (the serde flatten path) — validated before any
+    // conversion or outbound traffic.
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "t.csv"}}],
+            "pipeline": "vlm", "vlm_endpoint": "http://example.com/v1",
+            "vlm_model": "m", "vlm_max_tokens": 0}}"#
+    );
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let response = router(cfg)
+        .oneshot(json_convert(&body, true))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("vlm_max_tokens"));
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -502,8 +502,11 @@ deliberate scope boundary or a cosmetic, single-fixture polish gap.
   OpenAI-compatible vision endpoint (LM Studio / Ollama / vLLM / hosted) and
   parses the returned DocLang with the existing reader — see the README's
   "VLM pipeline" section. Also on the Node bindings as `pipeline: 'vlm'`
-  (`vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` / `vlmMaxTokens`);
-  serve and the Python bindings don't carry it yet. (**Audio/ASR is now done** — see §2; Opus and AVI,
+  (`vlmEndpoint` / `vlmModel` / `vlmApiKey` / `vlmPrompt` / `vlmMaxTokens`),
+  on the Python bindings as the same-named constructor kwargs, and on serve
+  as `pipeline=vlm` + `vlm_*` request options (#304; a request-supplied
+  `vlm_endpoint` sits behind `--allow-url-fetch` + the SSRF check, or pin it
+  server-side via `DOCLING_RS_VLM_*`). (**Audio/ASR is now done** — see §2; Opus and AVI,
   which symphonia cannot decode, use the optional ffmpeg fallback. The **enrichment
   models are now done** too: DocumentFigureClassifier-v2.5 for
   `do_picture_classification` and CodeFormulaV2 — an Idefics3-class VLM,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -63,6 +63,14 @@ extracted to disk, so there is no zip-slip path.
   conversion (and thus the server). `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH=1` opts
   out of the IP block-list for local/intranet image servers, same as the URL
   fetch above.
+- **`pipeline=vlm` with a request-supplied `vlm_endpoint`** (#304) points
+  the server's outbound traffic (page images included) wherever the caller
+  says, so it sits behind the **same `--allow-url-fetch` gate** and the same
+  resolve-and-refuse private-address check as URL inputs. The safer
+  deployment is the operator-pinned mode: set `DOCLING_RS_VLM_ENDPOINT` /
+  `DOCLING_RS_VLM_MODEL` on the server and let requests send only
+  `pipeline=vlm` — the pinned endpoint is the operator's own choice, so it
+  may be local (e.g. an Ollama on loopback) and needs no gate.
 - **No authentication.** Bind to loopback (the default) or place an
   authenticating/policy proxy in front before exposing it.
 


### PR DESCRIPTION
…ython bindings

Close the #304 gap: the remote VLM pipeline (#77) — already on the library, CLI and Node bindings — now reaches the two remaining surfaces.

serve: per-request options pipeline=standard|vlm + vlm_endpoint / vlm_model / vlm_api_key / vlm_prompt / vlm_max_tokens (query, multipart and JSON-body spellings; OpenAPI updated). A request-supplied vlm_endpoint is caller-steered outbound traffic, so it sits behind --allow-url-fetch and the same resolve-and-refuse private-address SSRF check as URL inputs (now shared as check_outbound_url); the safer default is the operator-pinned mode — DOCLING_RS_VLM_* on the server, requests send just pipeline=vlm. Bad options fail fast on both the sync and async endpoints; a VLM failure fails that request, never the server; the to=md streaming path routes VLM requests through the buffered branch so its format rejection reaches the client.

python: constructor kwargs mirroring the Node option names — pipeline="vlm", vlm_endpoint, vlm_model, vlm_api_key, vlm_prompt, vlm_max_tokens — resolved eagerly (ValueError at construction, same contract as Node: standard ignores stray vlm_* kwargs, blank strings count as unset, env fallbacks apply); conversion failures raise the catchable ConversionError, and initialize_pipeline skips loading ML models a VLM converter never runs.

Tests: serve unit tests for the option resolution/gating (env-races serialized via a shared lock) plus router-level tests over a stub OpenAI endpoint (pinned-mode conversion, gate, SSRF refusal, JSON-body spelling, async fail-fast, non-visual rejection); Python config tests incl. an end-to-end http.server stub. Docs: README (serve options + VLM section), MIGRATION §5, SECURITY, docling-py README.

Refs #304