### PR TITLE
feat(serve): zip and put output targets — the remaining service-datam…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ validated for byte-for-byte conformance against upstream Python docling.
 - One feature = one branch off fresh `origin/master`. Don't stack unrelated
   work.
 - Issue numbers (`#80`, `#138`, …) refer to `docling-project/docling.rs`
-  issues; reference them in commit messages (`Refs #NN`).
+  issues; reference them in commit messages — `Closes #NN` when the
+  change fully resolves the ticket (GitHub then auto-closes it on merge),
+  `Refs #NN` for partial/related work.
 - **Slack notifications** (when the Slack MCP connector is available): post to
   **#claude-code** (channel ID `C0BKAHN0BSM`) when (a) a question blocks the
   work and needs the maintainer's answer, (b) a long task finishes — include

--- a/README.md
+++ b/README.md
@@ -229,7 +229,15 @@ with the opt-in `cloud` cargo feature (feature-gated `object_store`) — `s3`,
 fields mirroring upstream's models. A cloud target uploads each converted
 output as `<stem>.<ext>` under the prefix and answers with a
 `RemoteTargetResult` acknowledgment; everything outbound sits behind
-`--allow-url-fetch`. See the `s3_pipeline` example in `/openapi.yaml`.
+`--allow-url-fetch`. The jobkit targets `zip` and `put` work too (#303, no
+`cloud` feature needed): `{"kind": "zip"}` answers with one `application/zip`
+archive of the `<stem>.<ext>` rendered outputs (a batch download — nothing
+outbound, no gate; a failed batch item becomes a `<stem>.<ext>.error.txt`
+entry), and `{"kind": "put", "url": …}` HTTP-PUTs each rendered output to the
+given — typically pre-signed — URL, so upload credentials live in the URL the
+caller minted, never in the request (behind `--allow-url-fetch`, with the same
+SSRF resolution check as URL inputs and redirects disabled). See the
+`s3_pipeline` example in `/openapi.yaml`.
 
 Observability (#297, mirroring Python docling-serve's posture — metrics on by
 default, traces opt-in): every request logs through `tracing` (`RUST_LOG`

--- a/crates/docling-serve/src/lib.rs
+++ b/crates/docling-serve/src/lib.rs
@@ -595,19 +595,23 @@ type SourceItem = Result<SourceDocument, (String, ApiError)>;
 /// options and the optional cloud output target. Shared by the sync and
 /// async endpoints so both accept exactly the same requests (and reject bad
 /// ones synchronously).
+/// A parsed non-`inbody` output target: where rendered outputs go instead of
+/// (or, for `Zip`, packaged inside) the response body.
+enum ResolvedTarget {
+    /// Cloud object store (#139: `s3` / `azure_blob` / `google_cloud_storage`).
+    Cloud(passthrough::CloudCoords),
+    /// One zip archive of the rendered outputs in the response body (#303).
+    Zip,
+    /// HTTP PUT each rendered output to this URL (#303).
+    Put(String),
+}
+
 async fn parse_convert_request(
     state: &Arc<AppState>,
     query: ConvertOptions,
     headers: HeaderMap,
     body: axum::extract::Request,
-) -> Result<
-    (
-        Vec<SourceItem>,
-        ConvertOptions,
-        Option<passthrough::CloudCoords>,
-    ),
-    ApiError,
-> {
+) -> Result<(Vec<SourceItem>, ConvertOptions, Option<ResolvedTarget>), ApiError> {
     let content_type = headers
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
@@ -629,16 +633,28 @@ async fn parse_convert_request(
         let options = req.options.clone().merge_over(query);
         let target = match req.target {
             None | Some(passthrough::TargetSpec::Inbody) => None,
+            // #303: a zip archive answers in the response body — a download
+            // shape like to=dclx, nothing outbound, so no gate applies.
+            Some(passthrough::TargetSpec::Zip) => Some(ResolvedTarget::Zip),
+            // #303: PUT pushes outputs wherever the caller's URL says — the
+            // same outbound/SSRF surface as URL inputs, same gate (the URL's
+            // resolution check runs on the blocking pool, before any upload).
+            Some(passthrough::TargetSpec::Put(p)) => {
+                require_outbound(state, "put targets")?;
+                Some(ResolvedTarget::Put(p.url))
+            }
             Some(spec) => {
                 require_outbound(state, "cloud targets")?;
-                Some(match spec {
+                Some(ResolvedTarget::Cloud(match spec {
                     passthrough::TargetSpec::S3(c) => passthrough::CloudCoords::S3(c),
                     passthrough::TargetSpec::AzureBlob(c) => passthrough::CloudCoords::Azure(c),
                     passthrough::TargetSpec::GoogleCloudStorage(c) => {
                         passthrough::CloudCoords::Gcs(c)
                     }
-                    passthrough::TargetSpec::Inbody => unreachable!("matched above"),
-                })
+                    passthrough::TargetSpec::Inbody
+                    | passthrough::TargetSpec::Zip
+                    | passthrough::TargetSpec::Put(_) => unreachable!("matched above"),
+                }))
             }
         };
         let sources = match (req.url, req.sources) {
@@ -875,10 +891,10 @@ async fn convert(
 
 /// A cloud target combines with every buffered output format except
 /// `to=images` (page PNGs are a debugging aid, not a pipeline artifact).
-fn validate_target(to: &str, target: Option<&passthrough::CloudCoords>) -> Result<(), ApiError> {
+fn validate_target(to: &str, target: Option<&ResolvedTarget>) -> Result<(), ApiError> {
     if target.is_some() && to == "images" {
         return Err(ApiError::Bad(
-            "to=images does not combine with a cloud target".into(),
+            "to=images does not combine with an output target".into(),
         ));
     }
     Ok(())
@@ -1137,11 +1153,20 @@ fn run_conversion(
     options: &ConvertOptions,
     to: &str,
     image_mode: ImageMode,
-    target: Option<&passthrough::CloudCoords>,
+    target: Option<&ResolvedTarget>,
     rt: &tokio::runtime::Handle,
 ) -> Result<StoredResponse, ApiError> {
-    if let Some(coords) = target {
-        return run_conversion_to_target(state, sources, options, to, image_mode, coords, rt);
+    match target {
+        Some(ResolvedTarget::Cloud(coords)) => {
+            return run_conversion_to_target(state, sources, options, to, image_mode, coords, rt);
+        }
+        Some(ResolvedTarget::Zip) => {
+            return run_conversion_to_zip(state, sources, options, to, image_mode);
+        }
+        Some(ResolvedTarget::Put(url)) => {
+            return run_conversion_to_put(state, sources, options, to, image_mode, url);
+        }
+        None => {}
     }
     if sources.len() == 1 {
         let source = sources
@@ -1210,6 +1235,45 @@ fn run_conversion(
     })
 }
 
+/// The `<stem>.<ext>` output naming shared by the cloud, zip and put targets
+/// (#139/#303) — mirrors the CLI batch naming; a duplicate stem within one
+/// request gets `-2`, `-3`, … instead of overwriting/shadowing.
+struct OutputNames {
+    ext: &'static str,
+    used: std::collections::HashSet<String>,
+}
+
+impl OutputNames {
+    fn new(to: &str) -> Self {
+        let ext = match to {
+            "md" | "markdown" => "md",
+            "json" => "json",
+            "chunks" => "chunks.json",
+            "dclx" => "dclx",
+            _ => unreachable!("validated above"),
+        };
+        Self {
+            ext,
+            used: std::collections::HashSet::new(),
+        }
+    }
+
+    fn next(&mut self, source_name: &str) -> String {
+        let stem = std::path::Path::new(source_name)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "document".into());
+        let ext = self.ext;
+        let mut key = format!("{stem}.{ext}");
+        let mut n = 1;
+        while !self.used.insert(key.clone()) {
+            n += 1;
+            key = format!("{stem}-{n}.{ext}");
+        }
+        key
+    }
+}
+
 /// The #139 cloud-target path: convert each source, upload its rendered
 /// output as `<stem>.<ext>` under the target's prefix, answer with docling's
 /// `RemoteTargetResult` kind plus per-item detail. Batch semantics
@@ -1223,14 +1287,7 @@ fn run_conversion_to_target(
     coords: &passthrough::CloudCoords,
     rt: &tokio::runtime::Handle,
 ) -> Result<StoredResponse, ApiError> {
-    let ext = match to {
-        "md" | "markdown" => "md",
-        "json" => "json",
-        "chunks" => "chunks.json",
-        "dclx" => "dclx",
-        _ => unreachable!("validated above"),
-    };
-    let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut names = OutputNames::new(to);
     let items: Vec<serde_json::Value> = sources
         .into_iter()
         .map(|item| {
@@ -1257,18 +1314,7 @@ fn run_conversion_to_target(
                     })
                 }
             };
-            // `<stem>.<ext>` mirrors the CLI batch naming; a duplicate stem
-            // in one request gets `-2`, `-3`, … instead of overwriting.
-            let stem = std::path::Path::new(&name)
-                .file_stem()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "document".into());
-            let mut key = format!("{stem}.{ext}");
-            let mut n = 1;
-            while !used.insert(key.clone()) {
-                n += 1;
-                key = format!("{stem}-{n}.{ext}");
-            }
+            let key = names.next(&name);
             match rt.block_on(passthrough::put_object(coords, &key, stored.body)) {
                 Ok(()) => json!({ "name": name, "status": "success", "key": key }),
                 Err(e) => json!({ "name": name, "status": "failure", "error": e }),
@@ -1289,6 +1335,159 @@ fn run_conversion_to_target(
         }))
         .expect("target ack serializes"),
     })
+}
+
+/// The #303 `zip` target: convert every source, render as for `to`, answer
+/// with one deflated archive of `<stem>.<ext>` entries — jobkit's batch
+/// download, and the only target whose output stays in the response body.
+/// Batch semantics: a failing item becomes a `<stem>.<ext>.error.txt` entry
+/// carrying the message instead of sinking the whole archive; a single-source
+/// request propagates the error as its response, like the inbody path.
+fn run_conversion_to_zip(
+    state: &AppState,
+    sources: Vec<SourceItem>,
+    options: &ConvertOptions,
+    to: &str,
+    image_mode: ImageMode,
+) -> Result<StoredResponse, ApiError> {
+    let single = sources.len() == 1;
+    let mut names = OutputNames::new(to);
+    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut archive_stem: Option<String> = None;
+    for item in sources {
+        let (name, rendered) = match item {
+            Ok(source) => {
+                let name = source.name.clone();
+                let rendered = convert_document(state, source, options)
+                    .and_then(|doc| render_stored(state, to, image_mode, &name, &doc, options));
+                (name, rendered.map(|stored| stored.body))
+            }
+            Err((name, e)) => (name, Err(e)),
+        };
+        let entry = names.next(&name);
+        if single {
+            archive_stem = entry.split('.').next().map(str::to_string);
+        }
+        match rendered {
+            Ok(body) => entries.push((entry, body)),
+            Err(e) if single => return Err(e),
+            Err(e) => entries.push((
+                format!("{entry}.error.txt"),
+                api_error_message(e).into_bytes(),
+            )),
+        }
+    }
+    let entry_refs: Vec<(&str, &[u8])> = entries
+        .iter()
+        .map(|(n, b)| (n.as_str(), b.as_slice()))
+        .collect();
+    // A single input names its archive after itself; a batch gets a generic
+    // name (there is no one stem to speak for it).
+    let file_name = archive_stem.map_or_else(|| "converted.zip".into(), |s| format!("{s}.zip"));
+    Ok(StoredResponse {
+        content_type: "application/zip",
+        disposition: Some(format!("attachment; filename=\"{file_name}\"")),
+        confidence: None,
+        body: docling::dclx::zip_bytes(entry_refs),
+    })
+}
+
+/// The #303 `put` target: HTTP PUT each rendered output to the caller's URL —
+/// the pre-signed S3/GCS/Azure upload shape, so credentials live in the URL
+/// the caller minted, never in the request body. The URL is caller-steered
+/// outbound traffic: gated behind `--allow-url-fetch` at parse time, checked
+/// against the SSRF block-list here (on the blocking pool — DNS), uploaded
+/// with redirects disabled so a public URL can't bounce into an internal
+/// target. Answers with the same `RemoteTargetResult` acknowledgment as the
+/// cloud targets; a failing item (conversion or upload) fails only itself.
+fn run_conversion_to_put(
+    state: &AppState,
+    sources: Vec<SourceItem>,
+    options: &ConvertOptions,
+    to: &str,
+    image_mode: ImageMode,
+    url: &str,
+) -> Result<StoredResponse, ApiError> {
+    check_outbound_url(url)?;
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .max_redirects(0)
+        .timeout_connect(Some(std::time::Duration::from_secs(10)))
+        .timeout_global(Some(std::time::Duration::from_secs(300)))
+        .build()
+        .into();
+    let mut names = OutputNames::new(to);
+    let items: Vec<serde_json::Value> = sources
+        .into_iter()
+        .map(|item| {
+            let source = match item {
+                Ok(source) => source,
+                Err((name, e)) => {
+                    return json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    })
+                }
+            };
+            let name = source.name.clone();
+            let rendered = convert_document(state, source, options)
+                .and_then(|doc| render_stored(state, to, image_mode, &name, &doc, options));
+            let stored = match rendered {
+                Ok(stored) => stored,
+                Err(e) => {
+                    return json!({
+                        "name": name,
+                        "status": "failure",
+                        "error": api_error_message(e),
+                    })
+                }
+            };
+            // Every output goes to the one URL, as upstream's PutTarget says
+            // — a pre-signed URL addresses a single object, so a batch here
+            // last-writer-wins; the ack's `key` names what each PUT carried.
+            let key = names.next(&name);
+            match agent
+                .put(url)
+                .header("content-type", stored.content_type)
+                .send(&stored.body[..])
+            {
+                Ok(_) => json!({ "name": name, "status": "success", "key": key }),
+                // ureq treats a non-2xx status as an error, which is exactly
+                // the per-item failure we want recorded.
+                Err(e) => json!({
+                    "name": name,
+                    "status": "failure",
+                    "error": format!("PUT: {e}"),
+                }),
+            }
+        })
+        .collect();
+    Ok(StoredResponse {
+        content_type: "application/json",
+        disposition: None,
+        confidence: None,
+        // The echoed target drops the query string: pre-signed URLs carry
+        // their signature there, and the ack may transit logs and proxies.
+        body: serde_json::to_vec_pretty(&json!({
+            "kind": "RemoteTargetResult",
+            "target": redact_url(url),
+            "results": items,
+        }))
+        .expect("target ack serializes"),
+    })
+}
+
+/// A URL safe to echo back: scheme://host/path, with the query string (where
+/// pre-signed URLs carry their signatures) and fragment dropped.
+fn redact_url(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut u) => {
+            u.set_query(None);
+            u.set_fragment(None);
+            u.to_string()
+        }
+        Err(_) => url.to_string(),
+    }
 }
 
 /// Return freed heap to the OS after a conversion (#263). A PDF conversion

--- a/crates/docling-serve/src/openapi.yaml
+++ b/crates/docling-serve/src/openapi.yaml
@@ -178,9 +178,11 @@ paths:
                   - $ref: "#/components/schemas/Chunks"
             application/vnd.openxmlformats-officedocument.doclang:
               schema: { type: string, format: binary }
+            application/zip:
+              schema: { type: string, format: binary }
           headers:
             Content-Disposition:
-              description: Present for `to=dclx` (attachment filename).
+              description: Present for `to=dclx` and `target: {kind: zip}` (attachment filename).
               schema: { type: string }
             X-Docling-Confidence:
               description: >
@@ -616,15 +618,21 @@ components:
       type: object
       required: [kind]
       description: >
-        docling `kind`-tagged output target (#139): `inbody` (default — the
-        response body) or a cloud store with the same coordinate fields as the
-        matching source kind; each converted document uploads as
-        `<stem>.<ext>` under the prefix and the response is a
-        `RemoteTargetResult` acknowledgment with per-item outcomes.
+        docling `kind`-tagged output target (#139, #303): `inbody` (default —
+        the response body); a cloud store with the same coordinate fields as
+        the matching source kind (each converted document uploads as
+        `<stem>.<ext>` under the prefix, response is a `RemoteTargetResult`
+        acknowledgment with per-item outcomes); `zip` (one `application/zip`
+        archive of the `<stem>.<ext>` rendered outputs in the response body —
+        no gate, nothing outbound; a failed batch item becomes a
+        `<stem>.<ext>.error.txt` entry); or `put`: {url} (HTTP PUT each
+        rendered output to that — typically pre-signed — URL; needs
+        `--allow-url-fetch`, same SSRF check as URL inputs, answers with the
+        `RemoteTargetResult` acknowledgment, query string redacted).
       properties:
         kind:
           type: string
-          enum: [inbody, s3, azure_blob, google_cloud_storage]
+          enum: [inbody, s3, azure_blob, google_cloud_storage, zip, put]
       additionalProperties: true
     Pipeline:
       type: string

--- a/crates/docling-serve/src/passthrough.rs
+++ b/crates/docling-serve/src/passthrough.rs
@@ -9,9 +9,15 @@
 //! `cloud` cargo feature; without it the kinds still *parse* and answer a
 //! clear "rebuild with --features cloud" error instead of a serde puzzle.
 //!
+//! The jobkit targets `zip` (one archive of the rendered outputs, in the
+//! response body) and `put` (HTTP PUT each output to a caller-supplied —
+//! typically pre-signed — URL) are covered too (#303), and need neither
+//! `object_store` nor the `cloud` feature.
+//!
 //! Deliberately not covered (documented in MIGRATION.md): `google_drive`
-//! (OAuth flows, no object_store backend), and the jobkit-only targets
-//! (`zip`, `put`, `presigned_url`) — an unknown `kind` is a 400 listing
+//! (OAuth flows, no object_store backend) and `presigned_url` (jobkit's
+//! ask-the-server-for-upload-URLs flow — `put` with a URL the caller minted
+//! covers the use case) — an unknown `kind` is a 400 listing
 //! the supported ones. Credentials ride in the request exactly as they do
 //! upstream: passthrough assumes a trusted client and TLS, and the whole
 //! surface sits behind `--allow-url-fetch` like every other outbound
@@ -101,8 +107,9 @@ pub enum SourceSpec {
     GoogleCloudStorage(GcsCoordinates),
 }
 
-/// The `target` — docling's `kind`-discriminated target union (the subset
-/// with an object-store backend, plus the `inbody` default).
+/// The `target` — docling's `kind`-discriminated target union: the `inbody`
+/// default, the object-store subset, and the jobkit `zip` / `put` kinds
+/// (#303).
 #[derive(Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TargetSpec {
@@ -110,6 +117,20 @@ pub enum TargetSpec {
     S3(S3Coordinates),
     AzureBlob(AzureBlobCoordinates),
     GoogleCloudStorage(GcsCoordinates),
+    /// One zip archive of the rendered outputs, answered in the response
+    /// body (#303, jobkit's `ZipTarget`) — a batch download, not outbound.
+    Zip,
+    /// HTTP PUT each rendered output to `url` (#303, jobkit's `PutTarget`) —
+    /// the pre-signed S3/GCS/Azure upload shape: credentials live in the URL
+    /// the caller minted, never in the request body.
+    Put(PutTarget),
+}
+
+/// Upstream `PutTarget`: the one URL every rendered output is PUT to.
+#[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PutTarget {
+    pub url: String,
 }
 
 /// A cloud store reference: coordinates + the key prefix reads list under

--- a/crates/docling-serve/tests/api.rs
+++ b/crates/docling-serve/tests/api.rs
@@ -483,11 +483,19 @@ async fn strict_field_changes_markdown_dialect() {
 /// same `--allow-url-fetch` as URL inputs: honored only when the flag is on,
 /// silently ignored otherwise. Proven against a local image server that counts
 /// the requests it receives — the gate must let *zero* through when off.
+/// Serializes the tests that toggle `DOCLING_RS_ALLOW_PRIVATE_IP_FETCH`
+/// (process-global): without it, one test's `remove_var` can strip the escape
+/// hatch out from under another's in-flight loopback fetch/PUT. Tokio's mutex
+/// because the guard is held across the tests' awaits.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[tokio::test]
 async fn fetch_images_is_gated_behind_allow_url_fetch() {
     use std::io::{Read, Write};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+
+    let _env = ENV_LOCK.lock().await;
 
     // 1×1 red PNG — a real image so the resolved bytes decode and embed.
     const RED_PNG: &[u8] = &[
@@ -1227,4 +1235,207 @@ async fn vlm_options_ride_the_json_body_and_zero_max_tokens_is_a_400() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert!(body_string(response).await.contains("vlm_max_tokens"));
+}
+
+// --- #303: zip and put output targets --------------------------------------
+
+#[tokio::test]
+async fn zip_target_answers_with_an_archive_of_rendered_outputs() {
+    // No gate: the archive stays in the response body, nothing goes outbound.
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [
+            {{"kind": "file", "base64_string": "{b64}", "filename": "one.csv"}},
+            {{"kind": "file", "base64_string": "{b64}", "filename": "two.csv"}},
+            {{"kind": "file", "base64_string": "{b64}", "filename": "two.csv"}}
+        ], "target": {{"kind": "zip"}}, "to": "md"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(content_type, "application/zip");
+    let disposition = response
+        .headers()
+        .get(header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(disposition, "attachment; filename=\"converted.zip\"");
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&bytes[..2], b"PK", "zip magic");
+    // Entry names are stored verbatim in the local file headers; the
+    // duplicate stem gets the `-2` de-dup, same as the cloud targets.
+    let has = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
+    assert!(has(b"one.md"), "one.md entry missing");
+    assert!(has(b"two.md"), "two.md entry missing");
+    assert!(has(b"two-2.md"), "deduped two-2.md entry missing");
+}
+
+#[tokio::test]
+async fn zip_target_single_source_names_the_archive_and_propagates_errors() {
+    // A single input names its archive after itself…
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "sheet.csv"}}],
+            "target": {{"kind": "zip"}}, "to": "json"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let disposition = response
+        .headers()
+        .get(header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(disposition, "attachment; filename=\"sheet.zip\"");
+
+    // …and a single failing input propagates its error instead of answering
+    // with an archive of one error file (matching the inbody semantics).
+    let b64 = docling_b64("x");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "wat.unknown"}}],
+            "target": {{"kind": "zip"}}, "to": "md"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert!(response.status().is_client_error(), "{}", response.status());
+}
+
+#[tokio::test]
+async fn zip_target_batch_converts_around_a_bad_item() {
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [
+            {{"kind": "file", "base64_string": "{b64}", "filename": "good.csv"}},
+            {{"kind": "file", "base64_string": "{b64}", "filename": "bad.unknown"}}
+        ], "target": {{"kind": "zip"}}, "to": "md"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let has = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
+    assert!(has(b"good.md"), "good entry missing");
+    assert!(has(b"bad.md.error.txt"), "error entry missing");
+}
+
+#[tokio::test]
+async fn zip_target_does_not_combine_with_to_images() {
+    let b64 = docling_b64("a,b\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "s.csv"}}],
+            "target": {{"kind": "zip"}}, "to": "images"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("output target"));
+}
+
+#[tokio::test]
+async fn put_target_is_gated_behind_allow_url_fetch() {
+    let b64 = docling_b64("a,b\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "s.csv"}}],
+            "target": {{"kind": "put", "url": "http://127.0.0.1:9/up"}}, "to": "md"}}"#
+    );
+    let response = app().oneshot(json_convert(&body, false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(body_string(response).await.contains("--allow-url-fetch"));
+}
+
+#[tokio::test]
+async fn put_target_uploads_each_output_and_acknowledges() {
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let _env = ENV_LOCK.lock().await;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let server_hits = Arc::clone(&hits);
+    let handle = std::thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut conn, _) = listener.accept().expect("accept");
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            loop {
+                let n = conn.read(&mut tmp).expect("read request");
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(head_end) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let head = String::from_utf8_lossy(&buf[..head_end]).to_ascii_lowercase();
+                    let need: usize = head
+                        .lines()
+                        .find_map(|l| l.strip_prefix("content-length:"))
+                        .and_then(|v| v.trim().parse().ok())
+                        .expect("content-length");
+                    if buf.len() >= head_end + 4 + need {
+                        break;
+                    }
+                }
+            }
+            let head = String::from_utf8_lossy(&buf).into_owned();
+            assert!(head.starts_with("PUT /up?sig=abc "), "request line: {head}");
+            server_hits.fetch_add(1, Ordering::SeqCst);
+            let _ = conn
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n");
+        }
+    });
+
+    std::env::set_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH", "1");
+    let b64 = docling_b64("a,b\n1,2\n");
+    let body = format!(
+        r#"{{"sources": [
+            {{"kind": "file", "base64_string": "{b64}", "filename": "one.csv"}},
+            {{"kind": "file", "base64_string": "{b64}", "filename": "two.csv"}}
+        ], "target": {{"kind": "put", "url": "http://{addr}/up?sig=abc"}}, "to": "md"}}"#
+    );
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let response = router(cfg)
+        .oneshot(json_convert(&body, true))
+        .await
+        .unwrap();
+    let status = response.status();
+    let out = body_string(response).await;
+    std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+    assert_eq!(status, StatusCode::OK, "{out}");
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["kind"], "RemoteTargetResult");
+    // The signature-carrying query string must not be echoed back.
+    assert_eq!(v["target"], format!("http://{addr}/up"));
+    let results = v["results"].as_array().expect("results");
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|r| r["status"] == "success"), "{v}");
+    assert_eq!(results[0]["key"], "one.md");
+    assert_eq!(results[1]["key"], "two.md");
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    handle.join().unwrap();
+}
+
+#[tokio::test]
+async fn put_target_refuses_a_private_address_without_the_escape_hatch() {
+    let _env = ENV_LOCK.lock().await;
+    std::env::remove_var("DOCLING_RS_ALLOW_PRIVATE_IP_FETCH");
+    let b64 = docling_b64("a,b\n");
+    let body = format!(
+        r#"{{"sources": [{{"kind": "file", "base64_string": "{b64}", "filename": "s.csv"}}],
+            "target": {{"kind": "put", "url": "http://127.0.0.1:9/up"}}, "to": "md"}}"#
+    );
+    let cfg = ServeConfig {
+        allow_url_fetch: true,
+        ..ServeConfig::default()
+    };
+    let response = router(cfg)
+        .oneshot(json_convert(&body, true))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(body_string(response).await.contains("private/loopback"));
 }

--- a/crates/docling/src/dclx.rs
+++ b/crates/docling/src/dclx.rs
@@ -56,3 +56,21 @@ pub fn to_dclx_bytes(doc: &DoclingDocument) -> Vec<u8> {
 pub fn save_as_dclx(doc: &DoclingDocument, path: &std::path::Path) -> std::io::Result<()> {
     std::fs::write(path, to_dclx_bytes(doc))
 }
+
+/// Deflate arbitrary `(name, bytes)` entries into one zip archive — the
+/// generic sibling of [`to_dclx_bytes`], for callers that batch rendered
+/// outputs rather than OPC parts (docling-serve's `zip` output target, #303).
+pub fn zip_bytes<'a>(entries: impl IntoIterator<Item = (&'a str, &'a [u8])>) -> Vec<u8> {
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let opts =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for (name, bytes) in entries {
+            zip.start_file(name, opts).expect("zip start");
+            zip.write_all(bytes).expect("zip write");
+        }
+        zip.finish().expect("zip finish");
+    }
+    buf.into_inner()
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -448,11 +448,16 @@ These are deliberate or unavoidable divergences, not bugs.
     a cloud target uploads each converted output as `<stem>.<ext>` under
     the prefix and answers with upstream's `RemoteTargetResult` kind plus
     per-item outcomes. All outbound kinds sit behind `--allow-url-fetch`.
-    Not covered, as upstream-jobkit-specific or OAuth-bound:
-    `google_drive`, `zip`, `put`, `presigned_url` (and with the last of
-    those, the `ArtifactRef` union — still parked). Without the feature the
-    cloud kinds parse and answer a clear rebuild-with-`--features cloud`
-    error.
+    The jobkit `zip` (one archive of the rendered outputs in the response
+    body — a batch download) and `put` (HTTP PUT each output to a
+    caller-minted, typically pre-signed, URL — behind `--allow-url-fetch` +
+    the SSRF check) targets are covered too (#303), with no
+    `object_store`/`cloud`-feature involvement. Not covered, as
+    upstream-jobkit-specific or OAuth-bound: `google_drive` and
+    `presigned_url` (and with the latter, the `ArtifactRef` union — still
+    parked; `put` with a caller-minted URL covers the pre-signed use case).
+    Without the feature the cloud kinds parse and answer a clear
+    rebuild-with-`--features cloud` error.
 
 16. **Serve observability** (#297, Python docling-serve's OTel
     integration): the same *posture* — Prometheus-style metrics on by


### PR DESCRIPTION
…odel kinds

Close the #303 gap in the #139 sources/target passthrough. The target union gains jobkit's zip and put kinds, neither needing object_store nor the cloud feature:

- {"kind": "zip"}: convert every source, render as for `to`, answer with one deflated application/zip archive of <stem>.<ext> entries (a batch download; Content-Disposition names it after a single source's stem). Nothing goes outbound, so no gate applies. Batch semantics: a failing item becomes a <stem>.<ext>.error.txt entry; a single-source request propagates the error, matching the inbody path. The archive writer is a new generic docling::dclx::zip_bytes next to the OPC one.

- {"kind": "put", "url": ...}: HTTP PUT each rendered output to the caller's — typically pre-signed S3/GCS/Azure — URL, so upload credentials live in the URL the caller minted, never in the request. Behind --allow-url-fetch, through the same check_outbound_url SSRF resolution check as URL inputs, redirects disabled; answers with the same RemoteTargetResult acknowledgment as the cloud targets, with the signature-carrying query string redacted from the echoed target.

The internal target type widens from Option<CloudCoords> to a ResolvedTarget enum; the <stem>.<ext> naming (with -2/-3 stem de-dup) is factored into OutputNames shared by all three target paths. presigned_url stays out of scope (put covers the use case) and still answers the serde unknown-variant 400 listing the supported kinds.

Tests: zip roundtrip (entries, de-dup, archive naming, error entries, to=images rejection), put against a raw TcpListener stub (two uploads, ack shape, query redaction), gating and private-address refusal — with the DOCLING_RS_ALLOW_PRIVATE_IP_FETCH toggles serialized via a shared lock. Docs: README #139 paragraph, MIGRATION section 15, openapi.yaml.

Closes #303