### PR TITLE
fix: input-robustness parity with docling 2.120.2-2.124

### DIFF
--- a/crates/docling/src/backend/csv.rs
+++ b/crates/docling/src/backend/csv.rs
@@ -52,20 +52,34 @@ impl DeclarativeBackend for CsvBackend {
 }
 
 /// Sniff the delimiter from the first line: the candidate (`, ; \t | :`) that
-/// occurs most often wins; comma is the default when none appear.
+/// occurs most often wins. When the first line carries none — a quoted field
+/// spanning several lines cuts it mid-quote (docling#3985, 2.123) — retry
+/// over the first 4 KiB, which closes the quote; comma remains the default
+/// when nothing matches at all. The first line stays authoritative otherwise:
+/// widening the sample unconditionally would change the delimiter picked for
+/// ragged files.
 fn detect_delimiter(text: &str) -> u8 {
     const CANDIDATES: [u8; 5] = [b',', b';', b'\t', b'|', b':'];
+    let count_best = |sample: &[u8]| {
+        let mut best = b',';
+        let mut best_count = 0usize;
+        for &c in &CANDIDATES {
+            let n = sample.iter().filter(|&&b| b == c).count();
+            if n > best_count {
+                best_count = n;
+                best = c;
+            }
+        }
+        (best, best_count)
+    };
     let first = text.lines().next().unwrap_or("");
-    let mut best = b',';
-    let mut best_count = 0usize;
-    for &c in &CANDIDATES {
-        let n = first.bytes().filter(|&b| b == c).count();
-        if n > best_count {
-            best_count = n;
-            best = c;
+    match count_best(first.as_bytes()) {
+        (best, n) if n > 0 => best,
+        _ => {
+            let bytes = text.as_bytes();
+            count_best(&bytes[..bytes.len().min(4096)]).0
         }
     }
-    best
 }
 
 #[cfg(test)]

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -1348,6 +1348,14 @@ fn parse_table_cells(
             num_rows += 1;
         }
     }
+    // A table whose every row is a "row header" (e.g. one `<th rowspan>` and
+    // no body rows to span into) would count zero rows and vanish — upstream's
+    // out-of-bounds crash in the same shape (docling#3827, 2.122); it keeps
+    // the cells, so treat the rows as ordinary ones instead.
+    let all_row_headers = num_rows == 0 && !trs.is_empty();
+    if all_row_headers {
+        num_rows = trs.len();
+    }
     if num_rows == 0 || num_cols == 0 {
         return None;
     }
@@ -1366,7 +1374,7 @@ fn parse_table_cells(
     let mut start_row_span: usize = 0;
     for tr in &trs {
         let cells = row_cells(*tr);
-        let row_header = is_row_header(&cells);
+        let row_header = !all_row_headers && is_row_header(&cells);
         if row_header {
             start_row_span += 1;
         } else {

--- a/crates/docling/src/backend/markdown.rs
+++ b/crates/docling/src/backend/markdown.rs
@@ -28,9 +28,128 @@ pub struct MarkdownBackend {
     pub strict: bool,
 }
 
+/// Is this trimmed line a GFM table delimiter row (`--- | :---:` …)? Every
+/// `|`-separated cell must be `-`s with optional edge colons, and at least one
+/// pipe must be present (a bare `---` is a thematic break / setext underline).
+fn is_delimiter_row(line: &str) -> bool {
+    let line = line.trim();
+    if !line.contains('|') {
+        return false;
+    }
+    line.trim_start_matches('|')
+        .trim_end_matches('|')
+        .split('|')
+        .all(|cell| {
+            let dashes = cell.trim().trim_start_matches(':').trim_end_matches(':');
+            !dashes.is_empty() && dashes.bytes().all(|b| b == b'-')
+        })
+}
+
+/// GFM leaves a table row's edge pipes optional, but pulldown-cmark only
+/// enters table mode on a leading one — a table written `Region | Q1` over a
+/// `--- | ---` delimiter row came out as plain text (docling 2.122 reads it,
+/// docling#3817). Detect that shape — a pipe-carrying line whose next line is
+/// a delimiter row with the same cell count — and normalize the whole block's
+/// edge pipes so pulldown parses it like the canonical spelling. Fenced code
+/// is left untouched, and input with no such table borrows unchanged.
+fn normalize_table_edge_pipes(text: &str) -> std::borrow::Cow<'_, str> {
+    let cell_count = |line: &str| {
+        line.trim()
+            .trim_start_matches('|')
+            .trim_end_matches('|')
+            .split('|')
+            .count()
+    };
+    let is_fence = |line: &str| {
+        let t = line.trim_start();
+        t.starts_with("```") || t.starts_with("~~~")
+    };
+
+    let lines: Vec<&str> = text.split('\n').collect();
+    let mut needs_fix = false;
+    {
+        let mut in_fence = false;
+        for w in lines.windows(2) {
+            let head = w[0].trim_end_matches('\r');
+            if is_fence(head) {
+                in_fence = !in_fence;
+                continue;
+            }
+            let delim = w[1].trim_end_matches('\r');
+            if !in_fence
+                && head.contains('|')
+                && !head.trim_start().starts_with('|')
+                && is_delimiter_row(delim)
+                && cell_count(head) == cell_count(delim)
+            {
+                needs_fix = true;
+                break;
+            }
+        }
+    }
+    if !needs_fix {
+        return std::borrow::Cow::Borrowed(text);
+    }
+
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut in_fence = false;
+    let mut i = 0;
+    while i < lines.len() {
+        let head = lines[i].trim_end_matches('\r');
+        if is_fence(head) {
+            in_fence = !in_fence;
+            out.push(lines[i].to_string());
+            i += 1;
+            continue;
+        }
+        let is_table_start = !in_fence
+            && head.contains('|')
+            && !head.trim_start().starts_with('|')
+            && lines
+                .get(i + 1)
+                .is_some_and(|d| is_delimiter_row(d.trim_end_matches('\r')))
+            && cell_count(head) == cell_count(lines[i + 1].trim_end_matches('\r'));
+        if !is_table_start {
+            out.push(lines[i].to_string());
+            i += 1;
+            continue;
+        }
+        // The block runs while lines keep carrying pipes; each gets both edge
+        // pipes (rows already carrying one keep it).
+        while i < lines.len() {
+            let (body, cr) = match lines[i].strip_suffix('\r') {
+                Some(b) => (b, "\r"),
+                None => (lines[i], ""),
+            };
+            if !body.contains('|') || body.trim().is_empty() {
+                break;
+            }
+            let t = body.trim();
+            let mut fixed = String::with_capacity(t.len() + 4);
+            if !t.starts_with('|') {
+                fixed.push_str("| ");
+            }
+            fixed.push_str(t);
+            if !t.ends_with('|') {
+                fixed.push_str(" |");
+            }
+            fixed.push_str(cr);
+            out.push(fixed);
+            i += 1;
+        }
+    }
+    std::borrow::Cow::Owned(out.join("\n"))
+}
+
 impl DeclarativeBackend for MarkdownBackend {
     fn convert(&self, source: &SourceDocument) -> Result<DoclingDocument, ConversionError> {
-        let text = source.text()?;
+        // GFM makes a table row's edge pipes optional, but pulldown-cmark only
+        // recognizes a table whose header starts with one. docling 2.122
+        // (docling#3817) reads the pipe-less spelling; normalizing the edges
+        // up front lets pulldown parse the same tables. `text` stays borrowed
+        // (no allocation) when nothing needs normalizing — the common case.
+        let normalized = normalize_table_edge_pipes(source.text()?);
+        let text = normalized.as_ref();
         let mut opts = Options::empty();
         opts.insert(Options::ENABLE_TABLES);
         opts.insert(Options::ENABLE_STRIKETHROUGH);

--- a/crates/docling/src/converter.rs
+++ b/crates/docling/src/converter.rs
@@ -32,8 +32,14 @@ fn looks_like_xml(text: &str) -> bool {
 
 /// Pick the concrete XML backend for a generic `.xml` source by sniffing its
 /// DOCTYPE / root element (the first part of the file).
-fn sniff_xml(text: &str) -> InputFormat {
-    let head = &text[..text.len().min(4000)];
+fn sniff_xml(bytes: &[u8]) -> InputFormat {
+    // Lossy over the raw head (docling#4038, 2.122): the window can cut a
+    // well-formed file mid-codepoint — a fixed-offset `&str` slice would
+    // panic on that char boundary — and an XML document may legitimately
+    // declare a non-UTF-8 encoding. Every marker matched below is ASCII, so
+    // replacement characters cannot change the outcome.
+    let head = String::from_utf8_lossy(&bytes[..bytes.len().min(4000)]);
+    let head = head.as_ref();
     // Case-insensitive: USPTO DOCTYPE/root casing varies in the wild (docling
     // PR #3801 — Grant Full Text v2.5 files were missed on casing).
     let lower = head.to_ascii_lowercase();
@@ -658,7 +664,7 @@ impl DocumentConverter {
             // A text/Markdown-typed file that is actually an XML document (e.g. a
             // JATS article saved with a `.txt` extension) routes to the XML
             // backends by content, mirroring docling's content-based detection.
-            InputFormat::Md if looks_like_xml(source.text()?) => match sniff_xml(source.text()?) {
+            InputFormat::Md if looks_like_xml(source.text()?) => match sniff_xml(&source.bytes) {
                 InputFormat::XmlUspto => UsptoBackend.convert(&source)?,
                 InputFormat::XmlXbrl => XbrlBackend.convert(&source)?,
                 // A JATS/other XML document saved as `.txt` is reconstructed
@@ -746,7 +752,7 @@ impl DocumentConverter {
             // A bare `.xml` defaults to XmlJats; sniff the content to route to the
             // right XML backend (docling distinguishes by DOCTYPE / root element).
             InputFormat::XmlJats | InputFormat::XmlUspto | InputFormat::XmlXbrl => {
-                match sniff_xml(source.text()?) {
+                match sniff_xml(&source.bytes) {
                     InputFormat::XmlUspto => UsptoBackend.convert(&source)?,
                     InputFormat::XmlXbrl => XbrlBackend.convert(&source)?,
                     _ => JatsBackend.convert(&source)?,
@@ -958,7 +964,7 @@ mod tests {
             "<?xml version=\"1.0\"?><US-PATENT-GRANT-V4/>",
         ] {
             assert_eq!(
-                super::sniff_xml(head),
+                super::sniff_xml(head.as_bytes()),
                 InputFormat::XmlUspto,
                 "head: {head}"
             );

--- a/crates/docling/src/source.rs
+++ b/crates/docling/src/source.rs
@@ -79,9 +79,15 @@ impl SourceDocument {
         self.path.as_deref().and_then(Path::parent)
     }
 
-    /// View the bytes as UTF-8 text, for text-based backends.
+    /// View the bytes as UTF-8 text, for text-based backends. A leading UTF-8
+    /// BOM is dropped (docling#4098/#4109, 2.123.1–2.124): Excel and Google
+    /// Sheets write one when exporting "CSV UTF-8", and kept it prefixes the
+    /// first cell/line — `# Title`/`= Title` stops being a heading, WebVTT's
+    /// signature check misses `WEBVTT`, JSON parsing rejects the document
+    /// outright. One strip here covers every text backend.
     pub fn text(&self) -> Result<&str, ConversionError> {
-        std::str::from_utf8(&self.bytes)
-            .map_err(|e| ConversionError::with_source("input is not valid UTF-8", e))
+        let text = std::str::from_utf8(&self.bytes)
+            .map_err(|e| ConversionError::with_source("input is not valid UTF-8", e))?;
+        Ok(text.strip_prefix('\u{feff}').unwrap_or(text))
     }
 }

--- a/crates/docling/tests/input_robustness.rs
+++ b/crates/docling/tests/input_robustness.rs
@@ -1,0 +1,170 @@
+//! Input-robustness parity with docling 2.120.2–2.124 (#319): UTF-8 BOM
+//! handling, CSV dialect detection, table-edge cases, crash-proofing.
+//! Each test mirrors the upstream regression test of the fix it ports.
+
+use docling::{DocumentConverter, InputFormat, SourceDocument};
+
+fn convert(name: &str, format: InputFormat, bytes: &[u8]) -> docling_core::DoclingDocument {
+    DocumentConverter::new()
+        .convert(SourceDocument::from_bytes(name, format, bytes.to_vec()))
+        .expect("conversion succeeds")
+        .document
+}
+
+// --- UTF-8 BOM (docling#4098 CSV, docling#4109 md/asciidoc/webvtt/json) ----
+
+#[test]
+fn csv_bom_is_not_part_of_the_first_cell() {
+    let doc = convert(
+        "bom.csv",
+        InputFormat::Csv,
+        "\u{feff}Name,Age\nAlice,30\n".as_bytes(),
+    );
+    let md = doc.export_to_markdown().replace(' ', "");
+    assert!(md.contains("|Name|Age|"), "BOM reached the header: {md}");
+}
+
+#[test]
+fn markdown_bom_does_not_hide_the_first_heading() {
+    let doc = convert(
+        "bom.md",
+        InputFormat::Md,
+        "\u{feff}# Title\n\nBody.\n".as_bytes(),
+    );
+    let md = doc.export_to_markdown();
+    assert!(md.starts_with("# Title"), "BOM hid the heading: {md:?}");
+}
+
+#[test]
+fn asciidoc_bom_does_not_hide_the_document_title() {
+    let doc = convert(
+        "bom.adoc",
+        InputFormat::Asciidoc,
+        "\u{feff}= Document Title\n\nBody.\n".as_bytes(),
+    );
+    let md = doc.export_to_markdown();
+    assert!(md.contains("Document Title"), "{md:?}");
+    assert!(!md.contains('\u{feff}'), "BOM reached the output: {md:?}");
+}
+
+#[test]
+fn webvtt_bom_does_not_invalidate_the_signature() {
+    let doc = convert(
+        "bom.vtt",
+        InputFormat::Vtt,
+        "\u{feff}WEBVTT\n\n00:00:01.000 --> 00:00:05.000\nHello there\n".as_bytes(),
+    );
+    assert!(doc.export_to_markdown().contains("Hello there"));
+}
+
+#[test]
+fn docling_json_bom_does_not_fail_the_load() {
+    let json = convert("x.md", InputFormat::Md, b"# Hi\n").export_to_json();
+    let bytes = [b"\xef\xbb\xbf".to_vec(), json.into_bytes()].concat();
+    let doc = convert("bom.json", InputFormat::JsonDocling, &bytes);
+    assert!(doc.export_to_markdown().contains("# Hi"));
+}
+
+// --- CSV dialect: quoted field spanning lines (docling#3985) ---------------
+
+#[test]
+fn csv_quoted_newline_in_first_field_still_sniffs_the_delimiter() {
+    let doc = convert(
+        "quoted.csv",
+        InputFormat::Csv,
+        b"\"line one\nstill line one\";b;c\n1;2;3\n",
+    );
+    let md = doc.export_to_markdown().replace(' ', "");
+    // Three columns, and the multi-line cell survives as one cell.
+    assert!(md.contains("|1|2|3|"), "wrong delimiter: {md}");
+}
+
+// --- Markdown table edge pipes (docling#3817) ------------------------------
+
+#[test]
+fn markdown_table_row_without_trailing_pipe_keeps_the_last_cell() {
+    let doc = convert(
+        "t.md",
+        InputFormat::Md,
+        b"| Character | Name in German\n|---|---\n| Scrooge McDuck | Dagobert Duck\n",
+    );
+    let md = doc.export_to_markdown();
+    assert!(
+        md.contains("Name in German"),
+        "last header cell dropped: {md}"
+    );
+    assert!(md.contains("Dagobert Duck"), "last data cell dropped: {md}");
+}
+
+#[test]
+fn markdown_table_without_leading_pipes_is_a_table() {
+    let doc = convert(
+        "t.md",
+        InputFormat::Md,
+        b"Region | Q1\n--- | ---\nNorth | 10\n",
+    );
+    let md = doc.export_to_markdown().replace(' ', "");
+    assert!(md.contains("|Region|Q1|"), "not parsed as a table: {md}");
+    assert!(md.contains("|North|10|"), "{md}");
+}
+
+#[test]
+fn markdown_table_without_leading_pipes_keeps_formatted_header_cells() {
+    let doc = convert(
+        "t.md",
+        InputFormat::Md,
+        b"**Region** | Q1\n--- | ---\nNorth | 10\n",
+    );
+    let md = doc.export_to_markdown().replace(' ', "");
+    assert!(md.contains("Region"), "{md}");
+    assert!(md.contains("|North|10|"), "{md}");
+}
+
+// --- AsciiDoc dedent to base level (docling#3826) --------------------------
+
+#[test]
+fn asciidoc_list_dedent_to_base_keeps_both_items() {
+    let doc = convert("dedent.adoc", InputFormat::Asciidoc, b"  * a\n* b\n");
+    let md = doc.export_to_markdown();
+    assert!(md.contains("- a"), "{md}");
+    assert!(md.contains("- b"), "{md}");
+}
+
+// --- HTML header-only rowspan table (docling#3827) -------------------------
+
+#[test]
+fn html_header_only_rowspan_table_keeps_the_cell() {
+    let doc = convert(
+        "t.html",
+        InputFormat::Html,
+        b"<table><tr><th rowspan='2'>h</th></tr></table>",
+    );
+    let md = doc.export_to_markdown();
+    assert!(md.contains('h'), "cell lost: {md}");
+}
+
+// --- XML sniffing with an undecodable / cut head (docling#4038) ------------
+
+#[test]
+fn xml_sniff_survives_a_multibyte_char_straddling_the_window() {
+    // Well-formed UTF-8 whose 4000-byte sniff window ends mid-codepoint —
+    // slicing the head at a fixed byte offset must not panic.
+    let head = "<?xml version=\"1.0\"?>\n<article><body><sec><p>";
+    let padding = "a".repeat(4000 - head.len() - 1);
+    let xml = format!("{head}{padding}é</p></sec></body></article>\n");
+    assert!(!xml.is_char_boundary(4000), "fixture must straddle the cut");
+    let doc = convert("split.xml", InputFormat::XmlJats, xml.as_bytes());
+    assert!(doc.export_to_markdown().contains("aaa"), "content lost");
+}
+
+#[test]
+fn xml_sniff_tolerates_a_non_utf8_document() {
+    // A JATS article declared in ISO-8859-1 (0xF8 = ø). Format sniffing must
+    // not abort; the strict backend may then fail cleanly, but never panic.
+    let latin1: Vec<u8> = b"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE article PUBLIC \"-//NLM//DTD JATS-journalpublishing1.dtd\" \"x.dtd\">\n<article><front><article-meta><contrib><name><surname>Bj\xf8rnstad</surname></name></contrib></article-meta></front></article>\n".to_vec();
+    let _ = DocumentConverter::new().convert(SourceDocument::from_bytes(
+        "latin1.xml",
+        InputFormat::XmlJats,
+        latin1,
+    ));
+}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -112,8 +112,8 @@ PyPI; run via `scripts/conformance/conformance.sh <fmt>`), not the committed gro
 
 | Format | Backend | Status |
 |---|---|---|
-| Markdown | `markdown.rs` (pulldown-cmark) | **10/10 exact** |
-| CSV | `csv.rs` (`csv` crate) | **9/9 exact**; `.tsv` routes here too (#208 — the delimiter sniffing already covers tabs; a docling.rs extension, upstream accepts only `.csv`) |
+| Markdown | `markdown.rs` (pulldown-cmark) | **10/10 exact**; #319 (docling 2.122's docling#3817): tables written without edge pipes (`Region \| Q1` over `--- \| ---`) are normalized up front so pulldown parses them like the canonical spelling; a leading UTF-8 BOM no longer hides the first heading (docling#4109) |
+| CSV | `csv.rs` (`csv` crate) | **9/9 exact**; `.tsv` routes here too (#208 — the delimiter sniffing already covers tabs; a docling.rs extension, upstream accepts only `.csv`); #319: a quoted field spanning lines no longer defeats delimiter sniffing (4 KiB fallback sample, docling#3985) and an Excel-style leading BOM stays out of the first header cell (docling#4098) |
 | HTML | `html.rs` (scraper/html5ever) | **32/32 exact** (`wiki_duck` included — rich table cells, caption run spacing, indicator images, `<footer>` furniture all match docling 2.112); #284: an *unclosed* inline tag (`<a name=…>`, `<b>`, `<font>` — endemic in legacy authoring-tool HTML) legally swallows subsequent blocks under html5ever's spec parsing, where Python's parser recovers by reparenting — inline wrappers hiding structured blocks (tables, lists, headings, code, figures) are now block-walked so the structure surfaces; pure text containers under a well-formed `<a href>` keep rendering as links |
 | AsciiDoc | `asciidoc.rs` (regex) | **4/4 exact** |
 | DeepSeek-OCR Markdown | `deepseek.rs` | **3/3 exact** (auto-detected VLM-token variant) |


### PR DESCRIPTION
Port the upstream input-handling batch, each item mirroring the corresponding upstream regression test (crates/docling/tests/ input_robustness.rs):

- UTF-8 BOM (docling#4098/#4109): one strip in SourceDocument::text() covers every text backend - the BOM no longer lands in the first CSV header cell, hides a leading Markdown/AsciiDoc title, breaks WebVTT's signature check, or fails a docling-JSON load.
- XML sniffing (docling#4038): sniff_xml now reads a lossy head of the raw bytes instead of slicing strict UTF-8 at a fixed offset - the old slice PANICKED when byte 4000 fell mid-codepoint in a well-formed file, and a document legitimately declared in a non-UTF-8 encoding aborted format detection outright. Every marker matched is ASCII, so replacement characters cannot change the routing.
- CSV dialect (docling#3985): a quoted first field spanning several lines cut the sniff line mid-quote and left zero delimiter hits; a 4 KiB fallback sample now closes the quote. The first line stays authoritative otherwise, matching upstream's reasoning about ragged files.
- Markdown tables (docling#3817): GFM leaves a row's edge pipes optional, but pulldown-cmark only enters table mode on a leading one; a conservative pre-pass (fence-aware, cell-count-checked against the delimiter row, borrow-only when nothing matches) normalizes the edge pipes so the pipe-less spelling parses like the canonical one - formatted header cells included.
- HTML tables (docling#3827): a table whose only rows are spanning <th>s counted zero data rows and vanished (upstream crashed in the same shape); its rows are now kept as ordinary ones.

Already-correct behaviors pinned by the same test file: the trailing- pipe-less last cell (pulldown), the AsciiDoc dedent-past-base guard (docling#3826), WebVTT BOM tolerance, and METS-GBS's skip of a page missing its image pair (docling#3930) stays as-is in mets.rs. The conformance corpus is untouched and stays byte-for-byte green.

Closes #319



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT