### PR TITLE
fix(onnx,pdf): CoreML EP config with safe Apple-silicon defaults, opt-in XNNPACK, per-EP layout batching, static batch axis for NHWC convs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ validated for byte-for-byte conformance against upstream Python docling.
 | `crates/docling-core` | `DoclingDocument` model, Markdown/JSON/DCLX serializers, `MarkdownStreamer`, chunkers |
 | `crates/docling` | `DocumentConverter` (format routing), declarative backends (`src/backend/`), streaming (`src/stream.rs`), video (`src/video.rs`) |
 | `crates/docling-pdf` | ML pipeline: pdfium + RT-DETR layout + TableFormer + PP-OCRv3 + enrichment (`ml` feature); pure-Rust text-layer path compiles for wasm without it |
-| `crates/docling-onnx` | Shared ONNX Runtime execution-provider selection (`DOCLING_RS_EP`, `cuda`/`tensorrt`/`directml`/`coreml` features) for docling-pdf/docling-asr/docling-rag |
+| `crates/docling-onnx` | Shared ONNX Runtime execution-provider selection (`DOCLING_RS_EP`, `cuda`/`tensorrt`/`directml`/`coreml`/`xnnpack` features) for docling-pdf/docling-asr/docling-rag |
 | `crates/docling-asr` | Whisper ASR: symphonia decode (audio + video containers) → log-mel → ONNX encoder/decoder |
 | `crates/docling-cli` | `docling-rs` binary (also `serve` subcommand behind `--features serve`) |
 | `crates/docling-serve` | axum HTTP conversion API (+ Dockerfile with ffmpeg) |

--- a/README.md
+++ b/README.md
@@ -1084,7 +1084,8 @@ aborts inference on Apple silicon instead of falling back.
 `DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format on
 pre-macOS-12 systems, and `DOCLING_RS_COREML_UNITS`
 (`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`) narrows which compute units
-CoreML may use. The `xnnpack` feature adds the XNNPACK provider
+CoreML may use, and `DOCLING_RS_COREML_STATIC_SHAPES=1` limits CoreML to
+static-shaped partitions for models that still misbehave. The `xnnpack` feature adds the XNNPACK provider
 (`DOCLING_RS_EP=xnnpack`, thread pool sized by `DOCLING_RS_XNNPACK_THREADS`)
 — a CPU-class accelerator for machines without a usable GPU provider; note
 that pyke ships no prebuilt ONNX Runtime with the XNNPACK EP, so this

--- a/README.md
+++ b/README.md
@@ -1082,10 +1082,18 @@ ONNX Runtime's own default, `NeuralNetwork`, cannot place operators the
 layout model carries (`GridSample`, `ScatterND`, dynamic output shapes) and
 aborts inference on Apple silicon instead of falling back.
 `DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format on
-pre-macOS-12 systems, and `DOCLING_RS_COREML_UNITS`
-(`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`) narrows which compute units
-CoreML may use, and `DOCLING_RS_COREML_STATIC_SHAPES=1` limits CoreML to
-static-shaped partitions for models that still misbehave. The `xnnpack` feature adds the XNNPACK provider
+pre-macOS-12 systems. Two safety defaults come from the issue's follow-up
+testing on an M4 Max: CoreML takes only **static-shaped partitions** by
+default (`DOCLING_RS_COREML_STATIC_SHAPES=0` opts back into dynamic
+placement) — with the stock dynamic-batch layout model, dynamic partitions
+under MLProgram fail an MPSGraph assertion as an uncatchable SIGABRT — and
+compute units default to **`cpu_and_gpu`** (`DOCLING_RS_COREML_UNITS`:
+`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`): `all` may schedule the fp16
+Neural Engine, which silently corrupts this model's logits (measured
+max|Δlogits| = 6.5 with no error raised) and ran slower than the GPU path.
+Known residual: the deformable-attention `GridSample` can still return wrong
+boxes on CoreML even with static shapes — the durable fix is on the model
+export side (#339). The `xnnpack` feature adds the XNNPACK provider
 (`DOCLING_RS_EP=xnnpack`, thread pool sized by `DOCLING_RS_XNNPACK_THREADS`)
 — a CPU-class accelerator for machines without a usable GPU provider; note
 that pyke ships no prebuilt ONNX Runtime with the XNNPACK EP, so this

--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,8 @@ cargo build --release -p docling-cli --features cuda      # NVIDIA CUDA (Linux/W
 #                                     --features tensorrt # NVIDIA TensorRT (usually with cuda)
 #                                     --features directml # DirectML (Windows)
 #                                     --features coreml   # CoreML (macOS)
+#                                     --features xnnpack  # XNNPACK (CPU-class ARM NEON / x86 SIMD;
+#                                                         # needs a self-built ONNX Runtime, see below)
 ```
 
 Each provider only exists on its OS (ort ships no CoreML build for Linux, no
@@ -1073,7 +1075,21 @@ DOCLING_RS_EP=cpu  docling-rs input.pdf   # force CPU (the default-build behavio
 An explicitly named provider that can't initialize (no device, missing
 driver/toolkit libs) fails the conversion rather than silently running 10×
 slower on CPU; `auto` is the quiet-fallback mode for images deployed on mixed
-fleets. When a GPU provider is selected, the pipeline automatically prefers
+fleets.
+
+CoreML registers with the **`MLProgram`** model format by default (#324):
+ONNX Runtime's own default, `NeuralNetwork`, cannot place operators the
+layout model carries (`GridSample`, `ScatterND`, dynamic output shapes) and
+aborts inference on Apple silicon instead of falling back.
+`DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format on
+pre-macOS-12 systems, and `DOCLING_RS_COREML_UNITS`
+(`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`) narrows which compute units
+CoreML may use. The `xnnpack` feature adds the XNNPACK provider
+(`DOCLING_RS_EP=xnnpack`, thread pool sized by `DOCLING_RS_XNNPACK_THREADS`)
+— a CPU-class accelerator for machines without a usable GPU provider; note
+that pyke ships no prebuilt ONNX Runtime with the XNNPACK EP, so this
+feature requires linking a self-built ONNX Runtime (`ORT_LIB_LOCATION`,
+built with `--use_xnnpack`). When a GPU provider is selected, the pipeline automatically prefers
 the fp32 models over the int8 defaults — the int8 exports are calibrated for
 CPU kernels (an explicit `DOCLING_*_ONNX` path still wins). CUDA needs the
 CUDA 12 runtime + cuDNN 9 on the machine; the `ort` crate downloads the

--- a/crates/docling-onnx/Cargo.toml
+++ b/crates/docling-onnx/Cargo.toml
@@ -20,6 +20,13 @@ cuda = ["ort/cuda", "ort/copy-dylibs"]
 tensorrt = ["ort/tensorrt", "ort/copy-dylibs"]
 directml = ["ort/directml", "ort/copy-dylibs"]
 coreml = ["ort/coreml", "ort/copy-dylibs"]
+# XNNPACK is a CPU-class EP (ARM NEON / x86 SIMD kernels), statically linked —
+# no provider dylib to copy (#324). NOTE: pyke ships no prebuilt ONNX Runtime
+# with the XNNPACK EP (any target), so this feature links only against a
+# self-built ONNX Runtime (`ORT_LIB_LOCATION`, onnxruntime built with
+# `--use_xnnpack`) — with `download-binaries` the build fails at link time by
+# design. Keep it out of CI matrices that rely on downloaded binaries.
+xnnpack = ["ort/xnnpack"]
 
 [dependencies]
 docling-core = { path = "../docling-core", version = "1.25.1" }

--- a/crates/docling-onnx/src/lib.rs
+++ b/crates/docling-onnx/src/lib.rs
@@ -33,8 +33,13 @@
 //! layout model carries (`GridSample`, `ScatterND`, dynamic output shapes)
 //! and aborts inference on Apple silicon instead of falling back.
 //! `DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format for
-//! pre-macOS-12 systems, and `DOCLING_RS_COREML_UNITS`
-//! (`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`) narrows the compute units.
+//! pre-macOS-12 systems. Two safety defaults ride along (issue-#324
+//! testing, M4 Max): only *static-shaped* partitions are handed to CoreML
+//! (`DOCLING_RS_COREML_STATIC_SHAPES=0` opts out) — dynamic partitions under
+//! MLProgram fail an MPSGraph assertion as an uncatchable SIGABRT — and
+//! compute units default to `cpu_and_gpu` rather than `all`
+//! (`DOCLING_RS_COREML_UNITS`: `all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`),
+//! since the fp16 Neural Engine silently corrupts this model's logits.
 //! `DOCLING_RS_XNNPACK_THREADS` sizes XNNPACK's own thread pool.
 //!
 //! The int8 model defaults in docling-pdf are skipped whenever a GPU provider
@@ -195,34 +200,47 @@ fn coreml_ep() -> ort::ep::CoreML {
         }
     };
     let mut ep = ort::ep::CoreML::default().with_model_format(format);
-    // Only static-shaped partitions go to CoreML when set — the layout
-    // model's dynamic outputs are what trips the NeuralNetwork path, and
-    // this is the reporter-requested escape hatch for models that still
-    // misbehave under MLProgram.
-    if docling_core::env::flag("DOCLING_RS_COREML_STATIC_SHAPES") {
+    // Static-shaped partitions only, ON by default (#324 follow-up): with the
+    // stock dynamic-batch layout model, MLProgram otherwise fails an MPSGraph
+    // assertion *inside* CoreML — a SIGABRT the process cannot catch, worse
+    // than the NeuralNetwork error it replaced (M4 Max, macOS 26 report).
+    // Keeping dynamic partitions off CoreML avoids it at the root;
+    // `DOCLING_RS_COREML_STATIC_SHAPES=0` opts back into dynamic placement
+    // for models known to be safe under it.
+    let static_shapes =
+        docling_core::env::nonempty("DOCLING_RS_COREML_STATIC_SHAPES").is_none_or(|v| {
+            !matches!(
+                v.to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off"
+            )
+        });
+    if static_shapes {
         ep = ep.with_static_input_shapes(true);
     }
-    if let Some(raw) = docling_core::env::nonempty("DOCLING_RS_COREML_UNITS") {
-        match raw.to_ascii_lowercase().as_str() {
-            "all" => ep = ep.with_compute_units(ComputeUnits::All),
-            "cpu_and_gpu" | "cpu_gpu" | "gpu" => {
-                ep = ep.with_compute_units(ComputeUnits::CPUAndGPU)
-            }
-            "cpu_and_ne" | "cpu_ane" | "ane" => {
-                ep = ep.with_compute_units(ComputeUnits::CPUAndNeuralEngine)
-            }
-            "cpu_only" | "cpu" => ep = ep.with_compute_units(ComputeUnits::CPUOnly),
-            other => {
-                let other = other.to_string();
-                WARNED.get_or_init(|| {
-                    eprintln!(
-                        "docling-rs: DOCLING_RS_COREML_UNITS={other:?} is not                          all|cpu_and_gpu|cpu_and_ne|cpu_only; leaving the default"
-                    );
-                });
-            }
+    // Compute units default to CPU+GPU, not ONNX Runtime's `ALL` (#324
+    // follow-up): `ALL` may place partitions on the fp16 Neural Engine, which
+    // silently corrupts this model's output (max|Δlogits| = 6.5 vs CPU, no
+    // error raised) and measured slower than the GPU path. `all`/`cpu_and_ne`
+    // remain available for models validated on the ANE.
+    let units = match docling_core::env::nonempty("DOCLING_RS_COREML_UNITS")
+        .map(|v| v.to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("cpu_and_gpu" | "cpu_gpu" | "gpu") => ComputeUnits::CPUAndGPU,
+        Some("all") => ComputeUnits::All,
+        Some("cpu_and_ne" | "cpu_ane" | "ane") => ComputeUnits::CPUAndNeuralEngine,
+        Some("cpu_only" | "cpu") => ComputeUnits::CPUOnly,
+        Some(other) => {
+            let other = other.to_string();
+            WARNED.get_or_init(|| {
+                eprintln!(
+                    "docling-rs: DOCLING_RS_COREML_UNITS={other:?} is not                      all|cpu_and_gpu|cpu_and_ne|cpu_only; using cpu_and_gpu"
+                );
+            });
+            ComputeUnits::CPUAndGPU
         }
-    }
-    ep
+    };
+    ep.with_compute_units(units)
 }
 
 /// The XNNPACK provider (#324). It runs its own thread pool;

--- a/crates/docling-onnx/src/lib.rs
+++ b/crates/docling-onnx/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! CPU is the default and the only provider in a default build — the GPU
 //! providers exist behind cargo features (`cuda`, `tensorrt`, `directml`,
-//! `coreml`) so the standard build keeps zero GPU dependencies. A feature only
+//! `coreml`; plus the CPU-class `xnnpack`, #324) so the standard build keeps
+//! zero GPU dependencies. A feature only
 //! *compiles* a provider in (it makes `ort` link/download an ONNX Runtime
 //! binary that contains that EP); which provider actually runs is chosen at
 //! startup from `DOCLING_RS_EP`:
@@ -15,17 +16,26 @@
 //!   a GPU build or installed the GPU wheel: use the GPU when one is usable,
 //!   fall back to CPU when not); plain CPU in a default build
 //! * `cpu` — force CPU, exactly the pre-#74 behavior
-//! * `cuda` / `tensorrt` (`trt`) / `directml` (`dml`) / `coreml` — that
-//!   provider, registered with error-on-failure: an *explicitly requested*
+//! * `cuda` / `tensorrt` (`trt`) / `directml` (`dml`) / `coreml` /
+//!   `xnnpack` — that provider, registered with error-on-failure: an *explicitly requested*
 //!   accelerator that can't initialize (missing driver, no device) fails the
 //!   session load loudly instead of silently degrading to a CPU run that
 //!   looks fine but is 10× slower than expected. Requesting a provider the
 //!   binary wasn't compiled with warns once and stays on CPU (there is
 //!   nothing to register at all in that case).
 //! * `auto` — every compiled-in provider is registered in performance order
-//!   (TensorRT, CUDA, CoreML, DirectML) and ONNX Runtime falls back down the
-//!   list — ultimately to CPU — at session creation. The "try GPU if there is
+//!   (TensorRT, CUDA, CoreML, DirectML, then XNNPACK) and ONNX Runtime falls
+//!   back down the list — ultimately to CPU — at session creation. The "try GPU if there is
 //!   one" mode for images built once and deployed on mixed fleets.
+//!
+//! CoreML registers with the `MLProgram` model format by default (#324):
+//! the ONNX Runtime default, `NeuralNetwork`, cannot place operators the
+//! layout model carries (`GridSample`, `ScatterND`, dynamic output shapes)
+//! and aborts inference on Apple silicon instead of falling back.
+//! `DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format for
+//! pre-macOS-12 systems, and `DOCLING_RS_COREML_UNITS`
+//! (`all`|`cpu_and_gpu`|`cpu_and_ne`|`cpu_only`) narrows the compute units.
+//! `DOCLING_RS_XNNPACK_THREADS` sizes XNNPACK's own thread pool.
 //!
 //! The int8 model defaults in docling-pdf are skipped whenever a GPU provider
 //! is selected ([`prefers_fp32`]): the int8 exports are QDQ graphs calibrated
@@ -47,6 +57,9 @@ pub enum Ep {
     TensorRt,
     DirectMl,
     CoreMl,
+    /// CPU-class EP with ARM NEON / x86 SIMD kernels (#324) — an accelerator
+    /// for machines without a usable GPU provider, Apple silicon included.
+    Xnnpack,
     /// Register everything compiled in, let ONNX Runtime fall back.
     Auto,
 }
@@ -60,6 +73,7 @@ pub fn parse(v: &str) -> Option<Ep> {
         "tensorrt" | "trt" => Some(Ep::TensorRt),
         "directml" | "dml" => Some(Ep::DirectMl),
         "coreml" => Some(Ep::CoreMl),
+        "xnnpack" => Some(Ep::Xnnpack),
         "auto" => Some(Ep::Auto),
         _ => None,
     }
@@ -73,6 +87,7 @@ fn compiled(ep: Ep) -> bool {
         Ep::TensorRt => cfg!(feature = "tensorrt"),
         Ep::DirectMl => cfg!(feature = "directml"),
         Ep::CoreMl => cfg!(feature = "coreml"),
+        Ep::Xnnpack => cfg!(feature = "xnnpack"),
         Ep::Auto => true,
     }
 }
@@ -90,7 +105,9 @@ fn any_gpu_compiled() -> bool {
 /// falls back to CPU when not. A default build has nothing to register and
 /// stays on the exact pre-#74 CPU path.
 fn default_choice() -> Ep {
-    if any_gpu_compiled() {
+    // XNNPACK counts here (whoever built with it wants it used) but not in
+    // [`prefers_fp32`] — it runs the same CPU-calibrated graphs as the CPU EP.
+    if any_gpu_compiled() || cfg!(feature = "xnnpack") {
         Ep::Auto
     } else {
         Ep::Cpu
@@ -109,7 +126,7 @@ pub fn choice() -> Ep {
         let Some(ep) = parse(&raw) else {
             eprintln!(
                 "docling-rs: DOCLING_RS_EP={raw:?} names no known execution provider \
-                 (cpu|cuda|tensorrt|directml|coreml|auto); using CPU"
+                 (cpu|cuda|tensorrt|directml|coreml|xnnpack|auto); using CPU"
             );
             return Ep::Cpu;
         };
@@ -122,6 +139,7 @@ pub fn choice() -> Ep {
                     Ep::TensorRt => "tensorrt",
                     Ep::DirectMl => "directml",
                     Ep::CoreMl => "coreml",
+                    Ep::Xnnpack => "xnnpack",
                     Ep::Cpu | Ep::Auto => unreachable!("always compiled"),
                 }
             );
@@ -142,14 +160,81 @@ pub fn choice() -> Ep {
 /// is no model selection for this to influence on that path.
 pub fn prefers_fp32() -> bool {
     match choice() {
-        Ep::Cpu => false,
+        // XNNPACK is CPU-class: the int8 QDQ graphs were calibrated for CPU
+        // kernels and stay valid on it.
+        Ep::Cpu | Ep::Xnnpack => false,
         Ep::Cuda | Ep::TensorRt | Ep::DirectMl | Ep::CoreMl => true,
         Ep::Auto => any_gpu_compiled(),
     }
 }
 
+/// The CoreML provider, configured from the environment (#324). `MLProgram`
+/// is the default model format: ONNX Runtime's own default, `NeuralNetwork`,
+/// cannot place operators the layout model carries (`GridSample`,
+/// `ScatterND`, dynamic output shapes) and aborts inference with error -1 on
+/// Apple silicon instead of falling back. `MLProgram` needs macOS 12+ —
+/// older systems can restore the old format explicitly.
+#[cfg(feature = "coreml")]
+fn coreml_ep() -> ort::ep::CoreML {
+    use ort::ep::coreml::{ComputeUnits, ModelFormat};
+    static WARNED: OnceLock<()> = OnceLock::new();
+    let format = match docling_core::env::nonempty("DOCLING_RS_COREML_FORMAT")
+        .map(|v| v.to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("mlprogram") => ModelFormat::MLProgram,
+        Some("neuralnetwork") => ModelFormat::NeuralNetwork,
+        Some(other) => {
+            let other = other.to_string();
+            WARNED.get_or_init(|| {
+                eprintln!(
+                    "docling-rs: DOCLING_RS_COREML_FORMAT={other:?} is not                      mlprogram|neuralnetwork; using mlprogram"
+                );
+            });
+            ModelFormat::MLProgram
+        }
+    };
+    let mut ep = ort::ep::CoreML::default().with_model_format(format);
+    if let Some(raw) = docling_core::env::nonempty("DOCLING_RS_COREML_UNITS") {
+        match raw.to_ascii_lowercase().as_str() {
+            "all" => ep = ep.with_compute_units(ComputeUnits::All),
+            "cpu_and_gpu" | "cpu_gpu" | "gpu" => {
+                ep = ep.with_compute_units(ComputeUnits::CPUAndGPU)
+            }
+            "cpu_and_ne" | "cpu_ane" | "ane" => {
+                ep = ep.with_compute_units(ComputeUnits::CPUAndNeuralEngine)
+            }
+            "cpu_only" | "cpu" => ep = ep.with_compute_units(ComputeUnits::CPUOnly),
+            other => {
+                let other = other.to_string();
+                WARNED.get_or_init(|| {
+                    eprintln!(
+                        "docling-rs: DOCLING_RS_COREML_UNITS={other:?} is not                          all|cpu_and_gpu|cpu_and_ne|cpu_only; leaving the default"
+                    );
+                });
+            }
+        }
+    }
+    ep
+}
+
+/// The XNNPACK provider (#324). It runs its own thread pool;
+/// `DOCLING_RS_XNNPACK_THREADS` sizes it, unset keeps ONNX Runtime's default.
+#[cfg(feature = "xnnpack")]
+fn xnnpack_ep() -> ort::ep::XNNPACK {
+    let mut ep = ort::ep::XNNPACK::default();
+    if let Some(n) = docling_core::env::parse::<usize>("DOCLING_RS_XNNPACK_THREADS")
+        .and_then(core::num::NonZeroUsize::new)
+    {
+        ep = ep.with_intra_op_num_threads(n);
+    }
+    ep
+}
+
 /// The dispatch list for the current choice. `None` means "register nothing"
 /// (CPU — leave the builder untouched, the pre-#74 code path).
+// The cfg-gated pushes read as sequential to clippy in single-feature builds.
+#[allow(clippy::vec_init_then_push)]
 fn dispatches() -> Option<Vec<ExecutionProviderDispatch>> {
     // Since ort 2.0.0-rc.13 the `ort::ep::*` structs are themselves gated
     // behind their cargo features (rc.12 exposed them unconditionally), so
@@ -166,7 +251,9 @@ fn dispatches() -> Option<Vec<ExecutionProviderDispatch>> {
         #[cfg(feature = "directml")]
         Ep::DirectMl => vec![ort::ep::DirectML::default().build().error_on_failure()],
         #[cfg(feature = "coreml")]
-        Ep::CoreMl => vec![ort::ep::CoreML::default().build().error_on_failure()],
+        Ep::CoreMl => vec![coreml_ep().build().error_on_failure()],
+        #[cfg(feature = "xnnpack")]
+        Ep::Xnnpack => vec![xnnpack_ep().build().error_on_failure()],
         Ep::Auto => {
             #[allow(unused_mut)]
             let mut v: Vec<ExecutionProviderDispatch> = Vec::new();
@@ -175,9 +262,13 @@ fn dispatches() -> Option<Vec<ExecutionProviderDispatch>> {
             #[cfg(feature = "cuda")]
             v.push(ort::ep::CUDA::default().build());
             #[cfg(feature = "coreml")]
-            v.push(ort::ep::CoreML::default().build());
+            v.push(coreml_ep().build());
             #[cfg(feature = "directml")]
             v.push(ort::ep::DirectML::default().build());
+            // Last, above only the implicit CPU fallback: a CPU-class
+            // accelerator must not shadow a usable GPU.
+            #[cfg(feature = "xnnpack")]
+            v.push(xnnpack_ep().build());
             if v.is_empty() {
                 return None; // CPU-only build: auto ≡ cpu
             }
@@ -249,6 +340,7 @@ mod tests {
         assert_eq!(parse("directml"), Some(Ep::DirectMl));
         assert_eq!(parse("dml"), Some(Ep::DirectMl));
         assert_eq!(parse("CoreML"), Some(Ep::CoreMl));
+        assert_eq!(parse("xnnpack"), Some(Ep::Xnnpack));
         assert_eq!(parse("auto"), Some(Ep::Auto));
     }
 
@@ -274,14 +366,16 @@ mod tests {
             feature = "cuda",
             feature = "tensorrt",
             feature = "directml",
-            feature = "coreml"
+            feature = "coreml",
+            feature = "xnnpack"
         ))]
         assert_eq!(default_choice(), Ep::Auto);
         #[cfg(not(any(
             feature = "cuda",
             feature = "tensorrt",
             feature = "directml",
-            feature = "coreml"
+            feature = "coreml",
+            feature = "xnnpack"
         )))]
         assert_eq!(default_choice(), Ep::Cpu);
     }

--- a/crates/docling-onnx/src/lib.rs
+++ b/crates/docling-onnx/src/lib.rs
@@ -195,6 +195,13 @@ fn coreml_ep() -> ort::ep::CoreML {
         }
     };
     let mut ep = ort::ep::CoreML::default().with_model_format(format);
+    // Only static-shaped partitions go to CoreML when set — the layout
+    // model's dynamic outputs are what trips the NeuralNetwork path, and
+    // this is the reporter-requested escape hatch for models that still
+    // misbehave under MLProgram.
+    if docling_core::env::flag("DOCLING_RS_COREML_STATIC_SHAPES") {
+        ep = ep.with_static_input_shapes(true);
+    }
     if let Some(raw) = docling_core::env::nonempty("DOCLING_RS_COREML_UNITS") {
         match raw.to_ascii_lowercase().as_str() {
             "all" => ep = ep.with_compute_units(ComputeUnits::All),

--- a/crates/docling-pdf/src/layout.rs
+++ b/crates/docling-pdf/src/layout.rs
@@ -169,12 +169,26 @@ impl LayoutModel {
                  converts without models in no-OCR mode (CLI: --no-ocr)"
             ));
         }
-        let builder = Session::builder()
+        let mut builder = Session::builder()
             .map_err(|e| format!("layout: builder: {e}"))?
             // Let inference use the available cores (ort otherwise defaults low);
             // a large PDF runs this model once per page.
             .with_intra_threads(intra)
             .map_err(|e| format!("layout: intra_threads: {e}"))?;
+        // Per-page mode pins the model's dynamic `batch` axis to 1 (#339):
+        // the free dimension blocks ONNX Runtime's channels-last conv
+        // transform, so the graph runs NCHW `FusedConv` instead of
+        // `NhwcFusedConv` — the issue measured ~1.4× on Apple-silicon CPU
+        // for the same weights re-exported static. Overriding the dimension
+        // at session creation gets the static graph without a re-export; it
+        // also leaves the whole graph static-shaped, which is what the
+        // CoreML provider's static-partitions default (#324) wants. Batched
+        // mode keeps the axis free — those sessions must accept N pages.
+        if crate::pdf_layout_batch() == 1 {
+            builder = builder
+                .with_dimension_override("batch", 1)
+                .map_err(|e| format!("layout: dimension override: {e}"))?;
+        }
         docling_onnx::apply(builder)
             .map_err(|e| format!("layout: {e}"))?
             .commit_from_file(path)

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -1286,17 +1286,22 @@ fn pdf_worker_count() -> usize {
 /// whatever is already rendered gets batched, so batching never *waits* for
 /// pages and adds no latency when rendering is the bottleneck.
 ///
-/// Default: 4 on 8+ cores, 1 (per-page) below. Measured on a 4-core box the
-/// batch only adds cache pressure and costs pipeline overlap (2 workers × 2
-/// threads: 8.1 s/conv at batch=1 vs 9.3 s at batch=4 on the 9-page
-/// 2206.01062 fixture); the single-session amortization it buys needs the
-/// wider thread budget of a many-core machine. Output is bit-identical at
-/// every batch size, so this is purely a throughput knob.
-/// `DOCLING_RS_PDF_LAYOUT_BATCH` overrides; `1` restores per-page inference.
-fn pdf_layout_batch() -> usize {
+/// Default: per-page (1) on the CPU provider, 4 when a GPU provider is
+/// selected (#338). The old "4 on 8+ cores" CPU default was a hypothesis —
+/// that single-session amortization pays off with a wider thread budget —
+/// and every actual CPU measurement lands the other way: a 4-core x86 box
+/// runs the 9-page 2206.01062 fixture in 8.5 s/conv at batch=1 vs 9.3 s at
+/// batch=4 (re-measured for #338; the original 8.1 vs 9.3 agrees), and the
+/// issue-#338 report measured batch=1 ~2× faster on a 16-core M4 Max at
+/// every worker count — batching only adds cache pressure once workers
+/// saturate the cores. On a GPU the per-call dispatch overhead is real and
+/// batching amortizes it, so the GPU default stays. Output is bit-identical
+/// at every batch size, so this is purely a throughput knob.
+/// `DOCLING_RS_PDF_LAYOUT_BATCH` overrides either way; `1` = per-page.
+pub(crate) fn pdf_layout_batch() -> usize {
     env::parse::<usize>("DOCLING_RS_PDF_LAYOUT_BATCH")
         .filter(|&n| n > 0)
-        .unwrap_or_else(|| if intra_threads() >= 8 { 4 } else { 1 })
+        .unwrap_or_else(|| if docling_onnx::prefers_fp32() { 4 } else { 1 })
 }
 
 #[cfg(feature = "ml")]

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -512,10 +512,14 @@ in-cache copy of the weights beats both one fat model and many single-thread wor
 The speed-up scales with cores and memory bandwidth. Tune per machine with
 `DOCLING_RS_PDF_WORKERS` (pool size) and `DOCLING_RS_PDF_INTRA` (intra-op threads
 per worker). Each worker layout-detects up to `DOCLING_RS_PDF_LAYOUT_BATCH`
-already-rendered pages per inference call (issue #73; default 4 on 8+ cores,
-1 below — measured on a 4-core box the batch costs pipeline overlap: 8.1 →
-9.3 s/conv on 2206.01062). Output is bit-identical at every batch size, so
-the knob is purely about throughput.
+already-rendered pages per inference call (issue #73; default: per-page on
+the CPU provider, 4 when a GPU provider is selected — #338: every CPU
+measurement favors per-page, 8.5 vs 9.3 s/conv on a 4-core x86 box and ~2×
+on a 16-core M4 Max, while GPU dispatch overhead still amortizes). In
+per-page mode the model's dynamic `batch` axis is pinned to 1 at session
+creation (#339): the free dimension blocks ONNX Runtime's channels-last conv
+transform (~1.4× on Apple-silicon CPU); x86 measured neutral. Output is
+bit-identical at every batch size, so the knob is purely about throughput.
 
 ### Text reconstruction: a pure-Rust PDF text parser (default)
 
@@ -946,7 +950,7 @@ Ordered by expected impact ÷ risk. Items 1–3 attack the 85–95%.
 3. ~~**Layout batching for the parallel path**: the pool currently runs batch-1
    inference per page.~~ **Done (issue #73)**: each pool worker drains the work
    channel opportunistically (whatever is already rendered, up to
-   `DOCLING_RS_PDF_LAYOUT_BATCH` — default 4 on 8+ cores, 1 below) and
+   `DOCLING_RS_PDF_LAYOUT_BATCH` — default per-page on CPU, 4 on GPU, #338) and
    layout-detects the batch with one inference call — batching never *waits* for pages, so it adds no
    latency when rendering is the bottleneck. Needs the dynamic-batch ONNX
    export (`scripts/install/export_layout.py`); an old fixed-batch graph

--- a/scripts/install/export_layout.py
+++ b/scripts/install/export_layout.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# NOTE (#339): the dynamic `batch` axis this script exports blocks ONNX
+# Runtime's channels-last conv transform on CPU (~1.4x on Apple silicon).
+# The runtime now pins the axis to 1 via a free-dimension override whenever
+# per-page layout inference is in effect (the CPU default, #338), which gets
+# the static graph without a re-export — so the dynamic export remains the
+# right artifact to ship (GPU batching still needs the free axis).
+
 """Export docling's RT-DETR layout model (heron) to ONNX for the Rust pipeline.
 
 The graph gets a **dynamic batch dimension** so the Rust worker can layout-detect


### PR DESCRIPTION
## Problem

The CoreML execution provider registered as `CoreML::default()`, so ONNX Runtime's C-API defaults applied: `ModelFormat=NeuralNetwork`, `MLComputeUnits=ALL`, dynamic shapes allowed. With the bundled `layout_heron.onnx` (GridSample, ScatterND, dynamic output shapes) the NeuralNetwork backend takes partitions it cannot execute and aborts inference with `error code: -1` — no per-node CPU fallback — so every PDF conversion fails on Apple silicon, and `DOCLING_RS_EP=auto` goes down with it (#324).

## Changes

**CoreML is now configured, with defaults validated by the reporter's follow-up testing on an M4 Max (macOS 26):**

- **`MLProgram` model format by default** — the NeuralNetwork format cannot place this model's operators; MLProgram needs macOS 12+, which every ort-supported system already meets. `DOCLING_RS_COREML_FORMAT=neuralnetwork` restores the old format.
- **Static-shaped partitions only, ON by default** (`DOCLING_RS_COREML_STATIC_SHAPES=0` opts out): with the stock dynamic-batch layout model, dynamic partitions under MLProgram fail an MPSGraph assertion as an *uncatchable SIGABRT* — worse than the error it replaced. Keeping dynamic partitions off CoreML avoids it at the root.
- **Compute units default to `cpu_and_gpu`**, not ORT's `ALL` (`DOCLING_RS_COREML_UNITS`: `all|cpu_and_gpu|cpu_and_ne|cpu_only`): `ALL` may schedule the fp16 Neural Engine, which silently corrupts this model's output (measured max|Δlogits| = 6.5 vs CPU, no error raised) and ran slower than the GPU path.
- **New opt-in `xnnpack` cargo feature** + `DOCLING_RS_EP=xnnpack` (`DOCLING_RS_XNNPACK_THREADS` sizes its pool): a CPU-class ARM-NEON/x86-SIMD accelerator for machines without a usable GPU provider. Deliberately opt-in and outside the CI download-binaries matrix: pyke ships no prebuilt ONNX Runtime with the XNNPACK EP, so the feature requires a self-built runtime (`ORT_LIB_LOCATION`, `--use_xnnpack`).
- Unknown env values warn once and keep the safe default, per the existing `ep.rs` convention.

The issue's optional per-inference CPU retry is deliberately not implemented: the defaults above remove the reported failure at its root, `auto` already falls back at session creation, and rebuilding sessions mid-run would mask real errors behind silent slowdowns.

## Follow-ups from the reporter's profiling, included here (#338, #339)

- **Layout batch default is now per-EP** (#338): per-page on the CPU provider, 4 when a GPU provider is selected. The old "4 on 8+ cores" was an unmeasured hypothesis; every actual CPU measurement favors per-page — 8.5 vs 9.3 s/conv re-measured on a 4-core x86 box, ~2× on the reporter's 16-core M4 Max at every worker count. `DOCLING_RS_PDF_LAYOUT_BATCH` still overrides; output is bit-identical at any batch size.
- **Per-page mode pins the model's free `batch` axis to 1** via ORT's free-dimension override at session creation (#339): the free dimension blocks the channels-last conv transform (NCHW `FusedConv` instead of `NhwcFusedConv`, ~1.4× on Apple-silicon CPU per the issue). This yields the static graph from the shipped dynamic artifact — no re-export, and `export_layout.py`'s dynamic export stays correct for GPU batching. It also leaves the whole graph static-shaped, which is exactly what the CoreML static-partitions default above wants. x86 measured neutral (output byte-identical); asking the reporter to confirm the ARM number on the stock model.

## Known residual (documented in README, out of scope)

CoreML `GridSample` can return wrong boxes even with static shapes — an export-side substitution (gather+lerp) is the durable fix if CoreML usage materializes. CoreML session creation (~2 s/process, non-parallelizing) still means long-lived `docling-serve` profits while one-shot CLI runs may not (reporter's crossover ≈480 pages/process).

Refs #324
Closes #338
Closes #339

## Testing

- Reporter-verified on M4 Max: the knobs work; `STATIC_SHAPES` is what makes the stock model survive; defaults updated to match his suggested resolution.
- `cargo test`/`clippy` clean, including `--features coreml`; the `check (coreml, macos-latest)` CI arm compile-checks the CoreML path.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT