### PR TITLE
fix(ci): actually publish docker images on push and release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,8 +104,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        # Only log in when pushing digests (push/release/dispatch)
-        if: github.event_name != 'pull_request' && (inputs.publish != false)
+        # Only log in when pushing digests (push/release/dispatch). The
+        # dispatch guard matters: outside `workflow_dispatch` the `inputs`
+        # context is empty and `inputs.publish` is null, which GitHub's loose
+        # comparison coerces to 0 — so `inputs.publish != false` evaluated to
+        # *false* on push and release, silently skipping every publish step
+        # and the merge job (run #9 on master built both arches, pushed nothing).
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -172,7 +177,7 @@ jobs:
       # Push single-arch image by digest to GHCR (skipped on PRs)
       - name: Build and push by digest
         id: build
-        if: github.event_name != 'pull_request' && (inputs.publish != false)
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -184,14 +189,14 @@ jobs:
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
       - name: Export digest
-        if: github.event_name != 'pull_request' && (inputs.publish != false)
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request' && (inputs.publish != false)
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.platform_slug }}
@@ -204,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build
-    if: github.event_name != 'pull_request' && (inputs.publish != false)
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
     permissions:
       contents: read
       packages: write

--- a/crates/docling-serve/Dockerfile
+++ b/crates/docling-serve/Dockerfile
@@ -18,11 +18,38 @@
 # tops out at 3.4.30, so the release link fails with undefined references.
 # The runtime stage below must stay on the same Debian release: the binary
 # links that libstdc++ (and trixie's glibc) dynamically.
-FROM rust:1.96-trixie AS build
+#
+# Layering for CI cache hits (docker-publish.yml exports every stage to the
+# GitHub Actions cache): a plain `COPY . . && cargo build` invalidates the
+# whole dependency compile on any commit, so the ~10 min build ran from
+# scratch on every PR and push (`Cached 0%`). cargo-chef splits it — the
+# `planner` stage reduces the workspace to its manifests (recipe.json), and
+# `cook` compiles only the dependency graph from that recipe, so that layer
+# is reused until Cargo.toml/Cargo.lock change. A source change then rebuilds
+# just the workspace crates. The ML assets are fetched in their own stage
+# that depends on nothing but the download script, so ~900 MB of models are
+# not re-downloaded per build either.
+FROM rust:1.96-trixie AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /src
+
+FROM chef AS planner
 COPY . .
-ARG FETCH_ASSETS=1
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS build
+COPY --from=planner /src/recipe.json recipe.json
+# Same profile/package/flags as the real build below, or cargo recompiles.
+RUN cargo chef cook --release -p docling-serve --locked --recipe-path recipe.json
+COPY . .
 RUN cargo build --release -p docling-serve --locked
+
+FROM debian:trixie-slim AS assets
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY scripts/install/download_dependencies.sh scripts/install/download_dependencies.sh
+ARG FETCH_ASSETS=1
 RUN if [ "$FETCH_ASSETS" = "1" ]; then sh scripts/install/download_dependencies.sh; \
     else mkdir -p .models .pdfium; fi
 
@@ -34,8 +61,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /app
 COPY --from=build /src/target/release/docling-serve /usr/local/bin/docling-serve
 # Assets resolve relative to the working directory (`.models/`, `.pdfium/lib`).
-COPY --from=build /src/.models ./.models
-COPY --from=build /src/.pdfium ./.pdfium
+COPY --from=assets /src/.models ./.models
+COPY --from=assets /src/.pdfium ./.pdfium
 ENV PDFIUM_DYNAMIC_LIB_PATH=/app/.pdfium/lib
 EXPOSE 5001
 HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=3 \


### PR DESCRIPTION
The publish guard `inputs.publish != false` is only meaningful under `workflow_dispatch`. On `push` and `release` the `inputs` context is empty, `inputs.publish` is null, and GitHub's loose comparison coerces both null and false to 0 — so the guard evaluated to false, the push-by-digest / export / upload steps were skipped in both build jobs and the merge job was skipped outright. Run #9 on master after #315 merged built linux/amd64 and linux/arm64 successfully and published nothing.

Guard on the event instead: publish unless it is a pull request, or a
manual dispatch with `publish: false`.

Refs #315



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT