### PR TITLE
feat(docker): publish the CLI as ghcr.io/docling-project/docling-rs instead of an alias

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,9 +11,10 @@
 # single-arch images are pushed by digest and assembled into multi-arch manifest
 # lists by the `merge` job.
 #
-# Published image names:
-#   - Primary: ghcr.io/docling-project/docling-rs-serve
-#   - Alias:   ghcr.io/docling-project/docling-rs
+# Published images (two targets of crates/docling-serve/Dockerfile, sharing the
+# dependency, runtime and asset layers):
+#   - ghcr.io/docling-project/docling-rs-serve — the HTTP conversion API
+#   - ghcr.io/docling-project/docling-rs       — the `docling-rs` CLI
 #
 # Triggers:
 #   - Release published: tags with semantic versions (vX.Y.Z, X.Y, X, latest)
@@ -75,8 +76,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  PRIMARY_IMAGE: ${{ github.repository_owner }}/docling-rs-serve
-  ALIAS_IMAGE: ${{ github.repository_owner }}/docling-rs
+  SERVE_IMAGE: ${{ github.repository_owner }}/docling-rs-serve
+  CLI_IMAGE: ${{ github.repository_owner }}/docling-rs
 
 jobs:
   build:
@@ -121,27 +122,60 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.PRIMARY_IMAGE }}
-            ${{ env.REGISTRY }}/${{ env.ALIAS_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }}
           labels: |
             org.opencontainers.image.title=docling-rs-serve
             org.opencontainers.image.description=High-performance document conversion API in Rust (PDF, DOCX, PPTX, XLSX, HTML, Audio)
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.vendor=docling-project
 
-      # Build single-arch image locally and verify container readiness
-      - name: Build local image for smoke test
+      - name: Extract metadata labels for the CLI image
+        id: meta_cli
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.CLI_IMAGE }}
+          labels: |
+            org.opencontainers.image.title=docling-rs
+            org.opencontainers.image.description=docling-rs CLI — document conversion (PDF, DOCX, PPTX, XLSX, HTML, Audio) to Markdown / JSON / DCLX / LaTeX
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.vendor=docling-project
+
+      # Build both single-arch images locally and verify them. The two targets
+      # share every layer up to the final stage, so the second build is cheap.
+      - name: Build local serve image for smoke test
         uses: docker/build-push-action@v6
         with:
           context: .
           file: crates/docling-serve/Dockerfile
+          target: serve
           load: true
           tags: docling-rs-serve:test
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
+
+      - name: Build local CLI image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: cli
+          load: true
+          tags: docling-rs:test
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta_cli.outputs.labels }}
+          cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
+
+      - name: Run CLI smoke test
+        run: |
+          echo "Converting a Markdown fixture (no models involved)..."
+          docker run --rm -v "$PWD/tests/data/md/sources:/data:ro" docling-rs:test wiki.md --to md | head -n 3
+          echo "Converting a small PDF (models must resolve via DOCLING_RS_MODELS_DIR)..."
+          out=$(docker run --rm -v "$PWD/tests/data/pdf/sources:/data:ro" docling-rs:test base14_fonts.pdf --to latex)
+          echo "$out" | head -n 20
+          echo "$out" | grep -q '\\begin{document}' || { echo "CLI smoke test failed: no LaTeX document produced"; exit 1; }
 
       - name: Run container smoke test
         run: |
@@ -174,33 +208,60 @@ jobs:
           echo "Cleaning up smoke test container..."
           docker rm -f docling-rs-serve-test
 
-      # Push single-arch image by digest to GHCR (skipped on PRs)
-      - name: Build and push by digest
+      # Push the single-arch images by digest to GHCR (skipped on PRs); the
+      # merge job assembles the multi-arch manifest lists per image.
+      - name: Build and push serve image by digest
         id: build
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: crates/docling-serve/Dockerfile
+          target: serve
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.PRIMARY_IMAGE }},${{ env.REGISTRY }}/${{ env.ALIAS_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
-      - name: Export digest
+      - name: Build and push CLI image by digest
+        id: build_cli
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: cli
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta_cli.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.CLI_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
+
+      - name: Export digests
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         run: |
-          mkdir -p /tmp/digests
+          mkdir -p /tmp/digests/serve /tmp/digests/cli
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/serve/${digest#sha256:}"
+          digest="${{ steps.build_cli.outputs.digest }}"
+          touch "/tmp/digests/cli/${digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload serve digest
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/upload-artifact@v7
         with:
-          name: digests-${{ matrix.platform_slug }}
-          path: /tmp/digests/*
+          name: digests-serve-${{ matrix.platform_slug }}
+          path: /tmp/digests/serve/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload CLI digest
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-cli-${{ matrix.platform_slug }}
+          path: /tmp/digests/cli/*
           if-no-files-found: error
           retention-days: 1
 
@@ -216,11 +277,18 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Download digests
+      - name: Download serve digests
         uses: actions/download-artifact@v8
         with:
-          pattern: digests-*
-          path: /tmp/digests
+          pattern: digests-serve-*
+          path: /tmp/digests/serve
+          merge-multiple: true
+
+      - name: Download CLI digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: digests-cli-*
+          path: /tmp/digests/cli
           merge-multiple: true
 
       - name: Log in to GitHub Container Registry
@@ -238,8 +306,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.PRIMARY_IMAGE }}
-            ${{ env.REGISTRY }}/${{ env.ALIAS_IMAGE }}
+            ${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }}
+            ${{ env.REGISTRY }}/${{ env.CLI_IMAGE }}
           flavor: |
             latest=auto
           tags: |
@@ -255,8 +323,8 @@ jobs:
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.vendor=docling-project
 
-      - name: Create manifest list and push for primary image
-        id: merge-primary
+      - name: Create manifest list and push for the serve image
+        id: merge-serve
         env:
           ALL_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -264,7 +332,7 @@ jobs:
           tags=()
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if [[ "$tag" == "${REGISTRY}/${PRIMARY_IMAGE}:"* ]]; then
+            if [[ "$tag" == "${REGISTRY}/${SERVE_IMAGE}:"* ]]; then
               tags+=("-t" "$tag")
               if [ -z "$first_tag" ]; then
                 first_tag="$tag"
@@ -273,17 +341,17 @@ jobs:
           done <<< "$ALL_TAGS"
 
           sources=()
-          for digest in /tmp/digests/*; do
+          for digest in /tmp/digests/serve/*; do
             [ -f "$digest" ] || continue
-            sources+=("${REGISTRY}/${PRIMARY_IMAGE}@sha256:$(basename "$digest")")
+            sources+=("${REGISTRY}/${SERVE_IMAGE}@sha256:$(basename "$digest")")
           done
 
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
           digest=$(docker buildx imagetools inspect "$first_tag" --raw | sha256sum | awk '{print $1}')
           echo "digest=sha256:$digest" >> "$GITHUB_OUTPUT"
 
-      - name: Create manifest list and push for alias image
-        id: merge-alias
+      - name: Create manifest list and push for the CLI image
+        id: merge-cli
         env:
           ALL_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -291,7 +359,7 @@ jobs:
           tags=()
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if [[ "$tag" == "${REGISTRY}/${ALIAS_IMAGE}:"* ]]; then
+            if [[ "$tag" == "${REGISTRY}/${CLI_IMAGE}:"* ]]; then
               tags+=("-t" "$tag")
               if [ -z "$first_tag" ]; then
                 first_tag="$tag"
@@ -300,9 +368,9 @@ jobs:
           done <<< "$ALL_TAGS"
 
           sources=()
-          for digest in /tmp/digests/*; do
+          for digest in /tmp/digests/cli/*; do
             [ -f "$digest" ] || continue
-            sources+=("${REGISTRY}/${ALIAS_IMAGE}@sha256:$(basename "$digest")")
+            sources+=("${REGISTRY}/${CLI_IMAGE}@sha256:$(basename "$digest")")
           done
 
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
@@ -311,13 +379,13 @@ jobs:
       - name: Generate artifact attestation for docling-rs-serve
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.PRIMARY_IMAGE }}
-          subject-digest: ${{ steps.merge-primary.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }}
+          subject-digest: ${{ steps.merge-serve.outputs.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation for docling-rs
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.ALIAS_IMAGE }}
-          subject-digest: ${{ steps.merge-alias.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.CLI_IMAGE }}
+          subject-digest: ${{ steps.merge-cli.outputs.digest }}
           push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -215,9 +215,12 @@ the server defaults `DOCLING_RS_NO_ARENA=1`: with the ONNX CPU arena off plus
 heap trimming, warm retained RSS measured ~3× lower (2.0 GB → 0.7 GB) at no
 latency cost — set `DOCLING_RS_NO_ARENA=0` to restore the arena. Prebuilt
 multi-arch images (`linux/amd64`, `linux/arm64`) publish to GHCR:
-`ghcr.io/docling-project/docling-rs-serve:latest` (built from
-[`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfile) with models
-and pdfium baked in, or mountable with `--build-arg FETCH_ASSETS=0`). Docker
+`ghcr.io/docling-project/docling-rs-serve:latest` (the server) and
+`ghcr.io/docling-project/docling-rs:latest` (the CLI, `docker run --rm -v
+"$PWD:/data" ghcr.io/docling-project/docling-rs report.pdf --to md`), both
+built from [`crates/docling-serve/Dockerfile`](./crates/docling-serve/Dockerfile)
+with models and pdfium baked in (or mountable with `--build-arg
+FETCH_ASSETS=0`). Docker
 Compose setups are in [`examples/docker-compose/`](./examples/docker-compose/) and
 the full guide is in [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md).
 URL inputs are **off by default** (SSRF surface): pass `--allow-url-fetch` to
@@ -1378,14 +1381,14 @@ fetches missing model files. Uninstall:
 
 ### Container Images
 
-The following container images are available on **GitHub Container Registry (GHCR)** for running **`docling-rs-serve`** with all native dependencies, pdfium, ffmpeg, and ONNX models baked in (zero Python runtime dependencies):
+The following container images are available on **GitHub Container Registry (GHCR)**, with all native dependencies, pdfium, ffmpeg, and ONNX models baked in (zero Python runtime dependencies). Both are targets of the same Dockerfile and share their layers:
 
 #### 📦 Distributed Images
 
 | Image | Description | Architectures |
 |---|---|---|
 | [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed. | `linux/amd64`, `linux/arm64` |
-| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | Repository-name alias pointing to the same multi-arch container image. | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in — batch conversion without installing Rust. Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
 
 ```bash
 # Run docling-rs-serve HTTP API (models baked in, zero Python runtime dependencies):
@@ -1393,6 +1396,10 @@ docker run -p 127.0.0.1:5001:5001 ghcr.io/docling-project/docling-rs-serve:lates
 
 # Convert a document:
 curl -F file=@paper.pdf localhost:5001/v1/convert
+
+# Or use the CLI image on local files (mounted at /data):
+docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest paper.pdf --to md
+docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest --input docs --output converted --to latex
 ```
 
 ### Docker Compose

--- a/crates/docling-serve/Dockerfile
+++ b/crates/docling-serve/Dockerfile
@@ -1,7 +1,16 @@
-# docling-serve — container image for the HTTP conversion API.
+# docling.rs container images: the `docling-serve` HTTP conversion API and the
+# `docling-rs` CLI, built from one Dockerfile as two targets over shared
+# layers (same dependency compile, same runtime base, same ML assets).
 #
 # Build (from the repository root):
-#   docker build -f crates/docling-serve/Dockerfile -t docling-serve .
+#   docker build -f crates/docling-serve/Dockerfile --target serve -t docling-rs-serve .
+#   docker build -f crates/docling-serve/Dockerfile --target cli   -t docling-rs .
+# (`serve` is the last stage, so a build without --target yields the server.)
+#
+# CLI image: the entrypoint is `docling-rs`, the working directory /data — mount
+# the documents there and pass the usual flags:
+#   docker run --rm -v "$PWD:/data" docling-rs report.pdf --to md
+#   docker run --rm -v "$PWD:/data" docling-rs --input in --output out --to latex
 #
 # Run. The ML assets (ONNX models + pdfium) are fetched into the image by
 # `download_dependencies.sh` at build time; to keep the image slim instead,
@@ -39,10 +48,10 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS build
 COPY --from=planner /src/recipe.json recipe.json
-# Same profile/package/flags as the real build below, or cargo recompiles.
-RUN cargo chef cook --release -p docling-serve --locked --recipe-path recipe.json
+# Same profile/packages/flags as the real build below, or cargo recompiles.
+RUN cargo chef cook --release -p docling-serve -p docling-cli --locked --recipe-path recipe.json
 COPY . .
-RUN cargo build --release -p docling-serve --locked
+RUN cargo build --release -p docling-serve -p docling-cli --locked
 
 FROM debian:trixie-slim AS assets
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -53,17 +62,30 @@ ARG FETCH_ASSETS=1
 RUN if [ "$FETCH_ASSETS" = "1" ]; then sh scripts/install/download_dependencies.sh; \
     else mkdir -p .models .pdfium; fi
 
-FROM debian:trixie-slim
-# ffmpeg powers video frame sampling (#138 Phase 2); without it a video input
-# still converts, transcript-only.
+# Shared runtime base for both images: ffmpeg powers video frame sampling
+# (#138 Phase 2; without it a video input still converts, transcript-only),
+# curl serves the health check, and the ML assets live under /app.
+FROM debian:trixie-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=build /src/target/release/docling-serve /usr/local/bin/docling-serve
-# Assets resolve relative to the working directory (`.models/`, `.pdfium/lib`).
 COPY --from=assets /src/.models ./.models
 COPY --from=assets /src/.pdfium ./.pdfium
 ENV PDFIUM_DYNAMIC_LIB_PATH=/app/.pdfium/lib
+
+# --- ghcr.io/docling-project/docling-rs: the CLI -----------------------------
+FROM runtime AS cli
+COPY --from=build /src/target/release/docling-rs /usr/local/bin/docling-rs
+# The CLI runs from /data (the user's mount), so `.models/…` cannot resolve
+# CWD-relative; point the whole-directory override (#285) at the baked assets.
+ENV DOCLING_RS_MODELS_DIR=/app/.models
+WORKDIR /data
+ENTRYPOINT ["docling-rs"]
+
+# --- ghcr.io/docling-project/docling-rs-serve: the HTTP API ------------------
+FROM runtime AS serve
+COPY --from=build /src/target/release/docling-serve /usr/local/bin/docling-serve
+# Assets resolve relative to the working directory (`.models/`, `.pdfium/lib`).
 EXPOSE 5001
 HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=3 \
     CMD curl -f http://localhost:5001/ready || exit 1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,18 +12,20 @@ The following container images are published on **GitHub Container Registry (GHC
 
 | Image | Description | Architectures |
 |---|---|---|
-| [`ghcr.io/docling-project/docling-serve-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-serve-rs) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed (zero Python runtime dependencies). | `linux/amd64`, `linux/arm64` |
-| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | Repository-name alias pointing to the same multi-arch container image. | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed (zero Python runtime dependencies). | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in: batch conversion of local files without installing Rust. Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
 
 > [!NOTE]
-> **Image Naming**: The `-rs` suffix (`docling-serve-rs` / `docling-rs`) differentiates this high-performance native Rust implementation from the Python `docling-project/docling-serve` image repository on GHCR.
+> **Image Naming**: The `-rs` in `docling-rs-serve` / `docling-rs` differentiates this native Rust implementation from the Python `docling-project/docling-serve` image repository on GHCR. Both images are targets of the same [`Dockerfile`](../crates/docling-serve/Dockerfile) and share every layer but the final binary.
 
 ```bash
 # Pull the docling-serve HTTP API image (Rust engine):
-docker pull ghcr.io/docling-project/docling-serve-rs:latest
+docker pull ghcr.io/docling-project/docling-rs-serve:latest
 
-# The image is also available under the alias:
+# Pull the CLI image and convert files from the current directory:
 docker pull ghcr.io/docling-project/docling-rs:latest
+docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest report.pdf --to md
+docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest --input docs --output converted --to json
 ```
 
 ### Supported Architectures & Tags
@@ -53,7 +55,7 @@ docker run -d \
   --name docling-serve \
   -p 5001:5001 \
   --restart unless-stopped \
-  ghcr.io/docling-project/docling-serve-rs:latest
+  ghcr.io/docling-project/docling-rs-serve:latest
 ```
 
 Check health:
@@ -80,7 +82,7 @@ Preconfigured compose files are available in [`examples/docker-compose/`](../exa
 ```yaml
 services:
   docling-serve:
-    image: ghcr.io/docling-project/docling-serve-rs:latest
+    image: ghcr.io/docling-project/docling-rs-serve:latest
     container_name: docling-serve
     restart: unless-stopped
     ports:

--- a/examples/docker-compose/docker-compose.caddy.yml
+++ b/examples/docker-compose/docker-compose.caddy.yml
@@ -1,6 +1,6 @@
 services:
   docling-serve:
-    image: ${DOCLING_IMAGE:-ghcr.io/docling-project/docling-serve-rs:latest}
+    image: ${DOCLING_IMAGE:-ghcr.io/docling-project/docling-rs-serve:latest}
     container_name: docling-serve
     restart: unless-stopped
     # Expose internally to the docker network only (Caddy fronts it)

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   docling-serve:
-    image: ${DOCLING_IMAGE:-ghcr.io/docling-project/docling-serve-rs:latest}
+    image: ${DOCLING_IMAGE:-ghcr.io/docling-project/docling-rs-serve:latest}
     container_name: docling-serve
     restart: unless-stopped
     ports:


### PR DESCRIPTION


`docling-rs` was a second name for the very same server image as `docling-rs-serve` — `docker run ghcr.io/docling-project/docling-rs` started docling-serve. Make the name mean what it says: the `docling-rs` CLI with the same models and pdfium baked in, so local files convert without a Rust toolchain:

  docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs report.pdf --to md
  docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs --input docs --output out --to latex

- Dockerfile: `cargo chef cook` / `cargo build` cover `-p docling-serve -p docling-cli`; a shared `runtime` stage (ffmpeg, curl, assets) feeds two targets — `cli` (ENTRYPOINT docling-rs, WORKDIR /data, DOCLING_RS_MODELS_DIR=/app/.models so `.models/…` resolves off the user's mount) and `serve` (unchanged behaviour, last stage so an untargeted build still yields the server).
- docker-publish.yml: build both targets per arch (the second build reuses every layer but the last), smoke-test the CLI image on a Markdown fixture and a small PDF (models must resolve through the env override), push both by digest under separate artifact names, and assemble one manifest list per image in the merge job. `PRIMARY_IMAGE`/`ALIAS_IMAGE` become `SERVE_IMAGE`/`CLI_IMAGE`.
- Docs: README and docs/DEPLOYMENT.md describe the two images and the CLI usage; DEPLOYMENT.md and the docker-compose examples referenced a `docling-serve-rs` image that was never published — corrected to `docling-rs-serve`.

Refs #315



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT