### PR TITLE
docs: README badges, Integration guide, complete Layout; LaTeX + latest options in wasm, FFI and the serve playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
   <img src="https://raw.githubusercontent.com/docling-project/docling.rs/refs/heads/master/docs/assets/logo.svg" alt="docling.rs — a duck feeding a document into a meat grinder" width="240">
 </p>
 
+<p align="center">
+  <a href="https://github.com/docling-project/docling.rs/actions/workflows/ci.yml"><img src="https://github.com/docling-project/docling.rs/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://docling-project.github.io/docling.rs/"><img src="https://img.shields.io/badge/demo-live-brightgreen" alt="Live browser demo"></a>
+  <a href="https://docs.rs/docling"><img src="https://img.shields.io/docsrs/docling?logo=docs.rs" alt="docs.rs"></a>
+  <a href="https://crates.io/crates/docling"><img src="https://img.shields.io/crates/v/docling?logo=rust&color=e6b04a" alt="crates.io version"></a>
+  <a href="https://crates.io/crates/docling"><img src="https://img.shields.io/crates/msrv/docling?logo=rust&label=rust" alt="Rust MSRV"></a>
+  <a href="https://crates.io/crates/docling"><img src="https://img.shields.io/crates/d/docling?label=crates.io%20downloads" alt="crates.io downloads"></a>
+  <br>
+  <a href="https://www.npmjs.com/package/docling.rs"><img src="https://img.shields.io/npm/v/docling.rs?logo=npm&logoColor=fff&label=npm%20docling.rs" alt="npm docling.rs"></a>
+  <a href="https://www.npmjs.com/package/docling.rs"><img src="https://img.shields.io/npm/dm/docling.rs?label=npm%20downloads" alt="npm downloads/month"></a>
+  <a href="https://www.npmjs.com/package/docling.rs-wasm"><img src="https://img.shields.io/npm/v/docling.rs-wasm?logo=webassembly&logoColor=fff&label=npm%20docling.rs-wasm" alt="npm docling.rs-wasm"></a>
+  <a href="https://pypi.org/project/docling-rs/"><img src="https://img.shields.io/pypi/v/docling-rs?logo=pypi&logoColor=fff" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/docling-rs/"><img src="https://img.shields.io/pypi/pyversions/docling-rs" alt="Python versions"></a>
+  <a href="https://pepy.tech/projects/docling-rs"><img src="https://static.pepy.tech/badge/docling-rs/month" alt="PyPI downloads/month"></a>
+  <br>
+  <a href="https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve"><img src="https://img.shields.io/badge/ghcr.io-docling--rs--serve-2496ED?logo=docker&logoColor=fff" alt="GHCR docling-rs-serve"></a>
+  <a href="https://github.com/docling-project/docling.rs/pkgs/container/docling-rs"><img src="https://img.shields.io/badge/ghcr.io-docling--rs-2496ED?logo=docker&logoColor=fff" alt="GHCR docling-rs (CLI)"></a>
+  <a href="https://github.com/docling-project/docling.rs/releases"><img src="https://img.shields.io/github/v/release/docling-project/docling.rs?label=release&logo=github" alt="GitHub release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/github/license/docling-project/docling.rs" alt="License MIT"></a>
+  <a href="https://lfaidata.foundation/projects/"><img src="https://img.shields.io/badge/LF%20AI%20%26%20Data-003778?logo=linuxfoundation&logoColor=fff&color=0094ff&labelColor=003778" alt="LF AI &amp; Data"></a>
+</p>
+
 A Rust port of [docling](https://github.com/docling-project/docling): convert
 documents into a unified `DoclingDocument` for downstream AI workflows.
 
@@ -20,7 +42,7 @@ mapping, and per-format conformance.
 
 **▶ [Try it in your browser](https://docling-project.github.io/docling.rs/)** —
 the whole converter compiled to wasm: drop a DOCX, PDF, XLSX, EPUB … and get
-Markdown, docling JSON or DocLang XML back. Nothing is uploaded; the page runs
+Markdown, docling JSON, DocLang XML or LaTeX back. Nothing is uploaded; the page runs
 entirely on your device, phone included. Scanned pages can be OCR'd there too
 (layout + PP-OCR + TableFormer via ONNX Runtime Web) once you point it at the
 models. See [`crates/docling-wasm`](./crates/docling-wasm/README.md).
@@ -260,7 +282,7 @@ env var the feature is inert.
 The declarative converters (everything except the PDF/image/audio ML
 pipelines) compile to `wasm32-unknown-unknown`:
 [`crates/docling-wasm`](./crates/docling-wasm) exposes
-`convert(bytes, filename, to)` → Markdown / docling JSON / DocLang via
+`convert(bytes, filename, to)` → Markdown / docling JSON / DocLang / LaTeX via
 `wasm-bindgen`, so DOCX/HTML/XLSX/PPTX/EPUB/… convert **fully client-side** —
 no server, ~3.4 MB gzipped module, no models to download for the declarative
 formats (the default-on browser-OCR feature does fetch its ONNX models) —
@@ -282,6 +304,71 @@ document. The crate ships a drop-a-file demo page under
 [`www/`](./crates/docling-wasm/www). Native builds are untouched: the
 feature slices behind this (`pdf` / `asr` / `fetch-images`) all stay in the
 `docling` default set, so a plain `cargo build` is unchanged.
+
+## Integration — using docling.rs from your language
+
+One engine, several front doors. Every surface takes the same options
+(`to`, `strict`, `images`, `no_ocr`, `ocr_mode`, `heading_hierarchy`,
+`pages`, …) and returns the same outputs (Markdown, docling JSON, DocLang
+`.dclx`, LaTeX, chunk records).
+
+| You write… | Use | Install | Details |
+|---|---|---|---|
+| Rust | the `docling` crate: `DocumentConverter` + `SourceDocument` | `cargo add docling` | [The API](#the-api) |
+| a shell / CI job | the `docling-rs` CLI (`--to md\|json\|dclx\|chunks\|latex\|images`, `--input`/`--output` batch mode) | `cargo install docling-cli` · [release binaries](https://github.com/docling-project/docling.rs/releases) · `ghcr.io/docling-project/docling-rs` | [Batch conversion](#batch-conversion--input----output), [Install](#install-locally--in-ci-one-liner) |
+| anything that speaks HTTP | `docling-serve`: `POST /v1/convert` (multipart or JSON), async jobs, OpenAPI 3.1 | `docker run -p 5001:5001 ghcr.io/docling-project/docling-rs-serve` · `cargo install docling-serve` | [HTTP conversion API](#http-conversion-api--docling-rs-serve), [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md) |
+| Node.js / Bun / Electron | `docling.rs` (N-API addon): `convertFile`, `convert`, streaming, chunking, warm `Pipeline` | `npm i docling.rs` (`docling.rs-cuda` for GPU) | [Node bindings](#nodejs--bun-bindings), [crate README](./crates/docling-node/README.md) |
+| Python | `docling-rs` — a drop-in for docling's `DocumentConverter` over the Rust engine | `pip install docling-rs` (`docling-rs-cuda` for GPU) | [Python bindings](#python-bindings), [migration guide](./crates/docling-py/README.md#migrating-from-python-docling) |
+| the browser / Tauri / a PWA | `docling.rs-wasm`: `convert(bytes, name, to)` fully client-side, optional in-browser OCR/layout | `npm i docling.rs-wasm` | [In the browser](#in-the-browser--docling-wasm), [crate README](./crates/docling-wasm/README.md) |
+| C, C++, C#/.NET, Go, Java, Swift, Zig, … | `docling-ffi`: `docling_convert(bytes, len, filename, options_json)` behind one `docling.h` | [release archives](https://github.com/docling-project/docling.rs/releases) `docling-ffi-<tag>-<target>` (library + header) | [C ABI](#c-abi-for-embedders--docling-ffi), [language quickstarts](./crates/docling-ffi/README.md#language-quickstarts) |
+| a RAG stack | `docling-rag`: chunk → embed → search, REST API and web UI | `cargo install docling-rag` | [RAG subsystem](#rag-subsystem) |
+
+Which one to pick: **Rust** when you're already in Cargo; **CLI** for scripts
+and batch jobs (the ML models load once per run); **serve** when several
+services or languages share one warm pipeline — models stay loaded, admission
+control keeps memory bounded, and every language has an HTTP client;
+**Node / Python** for in-process use from those runtimes with zero extra
+services; **wasm** when the document must not leave the user's machine;
+**FFI** for everything else that can call a C function. The ML assets
+(`.models/`, `.pdfium/`) are the same for all of them — see
+[Getting the ML models](#getting-the-ml-models); the Python and Node packages
+fetch them on first use, the container images ship them baked in.
+
+```bash
+# CLI
+docling-rs report.pdf --to md
+docling-rs --input ./docs --output ./out --to latex
+
+# HTTP
+curl -F file=@report.pdf 'localhost:5001/v1/convert?to=json&heading_hierarchy=true'
+```
+
+```js
+// Node.js / Bun
+import { convertFile } from 'docling.rs'
+const { content } = convertFile('report.pdf', { to: 'markdown' })
+```
+
+```python
+# Python — docling-shaped
+from docling_rs import DocumentConverter
+doc = DocumentConverter().convert("report.pdf").document
+print(doc.export_to_markdown())
+```
+
+```js
+// Browser (wasm) — nothing leaves the page
+import init, { convert } from "docling.rs-wasm/web";
+await init();
+const tex = convert(new Uint8Array(await file.arrayBuffer()), file.name, "latex");
+```
+
+```c
+/* C ABI — any language with FFI */
+DoclingResult *r = docling_convert(bytes, len, "report.docx", "{\"to\":\"json\"}");
+if (!docling_result_error(r)) fwrite(docling_result_output(r), 1, docling_result_output_len(r), stdout);
+docling_result_free(r);
+```
 
 ## The API
 
@@ -918,7 +1005,7 @@ imports stays unchanged).
 Embedding from C, C++, C#, Go, Java, Swift or anything else with FFI takes
 one shared (or static) library and one header:
 [`crates/docling-ffi`](./crates/docling-ffi) exposes a minimal `extern "C"`
-surface — `docling_convert()` in, Markdown / docling JSON / DCLX out, with
+surface — `docling_convert()` in, Markdown / docling JSON / DCLX / LaTeX out, with
 conversion options as a single JSON object mirroring docling-serve's request
 options. The [`include/docling.h`](./crates/docling-ffi/include/docling.h)
 header is generated by cbindgen and committed.
@@ -1489,11 +1576,13 @@ models) the same fixture measures 5.2× less memory, a 6.2× warm speedup and
 | `docling` | `DocumentConverter`, source loading, backends | `docling` |
 | `docling-pdf` | PDF/image ML pipeline (pdfium + ONNX layout/table/OCR) | `docling` PDF pipeline |
 | `docling-asr` | audio/ASR pipeline (symphonia + ONNX Whisper) | `docling` ASR pipeline |
-| `docling-cli` | command-line interface | `docling.cli` |
-| `docling-rs-serve` | HTTP conversion API over a warm pipeline | `docling-serve` |
+| `docling-onnx` | shared ONNX Runtime execution-provider selection (`DOCLING_RS_EP`; `cuda` / `tensorrt` / `directml` / `coreml` / `xnnpack` features) for the ML crates | — |
+| `docling-cli` | command-line interface (`docling-rs`, plus the `serve` subcommand behind `--features serve`) | `docling.cli` |
+| `docling-serve` | HTTP conversion API over a warm pipeline (`docling-serve` binary, `ghcr.io/docling-project/docling-rs-serve` image) | `docling-serve` |
+| `docling-ffi` | C ABI (`docling.h` + shared/static library) for C, C++, C#, Go, Java, Swift embedders | — |
 | `docling-node` | Node.js / Bun N-API bindings | https://www.npmjs.com/package/docling.rs |
-| `docling-py` | Python bindings | https://pypi.org/project/docling-rs |
-| `docling-wasm` | WebAssembly bindings (declarative converters + PDF text layer in the browser) | https://www.npmjs.com/package/docling.rs-wasm |
+| `docling-py` | Python bindings (strangler-fig drop-in over docling-core) | https://pypi.org/project/docling-rs |
+| `docling-wasm` | WebAssembly bindings (declarative converters + PDF text layer + browser OCR) | https://www.npmjs.com/package/docling.rs-wasm |
 | `docling-rag` | RAG layer: chunking, embeddings, vector search, REST API | — |
 
 ## Contributing

--- a/crates/docling-ffi/README.md
+++ b/crates/docling-ffi/README.md
@@ -25,8 +25,8 @@ docling_result_free(r);
 ```
 
 - The result is never `NULL`; exactly one of output/error is set.
-- Output is NUL-terminated, so `to` = `md` / `json` reads as a plain C
-  string; `to` = `dclx` is a binary zip — always pair
+- Output is NUL-terminated, so `to` = `md` / `json` / `latex` reads as a plain
+  C string; `to` = `dclx` is a binary zip — always pair
   `docling_result_output()` with `docling_result_output_len()` there.
 - `filename` selects the input format by extension (same table as the CLI).
 - Every call is reentrant and panic-safe; each result is an independent
@@ -39,10 +39,13 @@ mirror [docling-serve](../docling-serve)'s request options:
 
 | Key | Values | Meaning |
 |---|---|---|
-| `to` | `md` (default) \| `json` \| `dclx` | Output format |
+| `to` | `md` (default) \| `json` \| `dclx` \| `latex` | Output format (`latex` = docling 2.124's LaTeX document, #317) |
 | `strict` | bool | Docling-faithful Markdown instead of the readable default |
 | `images` | `placeholder` (default) \| `embedded` | Pictures in Markdown: comment placeholder or base64 data URIs |
-| `no_ocr`, `force_full_page_ocr`, `no_table_former`, `no_text_panels` | bool | PDF/image pipeline switches |
+| `no_ocr`, `skip_ocr`, `force_full_page_ocr`, `no_table_former`, `no_text_panels`, `heading_hierarchy` | bool | PDF/image pipeline switches (`skip_ocr` #244: layout + TableFormer, never OCR; `heading_hierarchy` #302: infer section-header levels) |
+| `ocr_mode` | `default` \| `full_page` \| `layout_regions` \| `pdf_aware_layout_regions` | Which regions feed the OCR (docling's `OcrMode`, #254) |
+| `ocr_scale` | float | OCR render scale in px per PDF point (docling's default 3; unset reads the 2.0 px/pt pipeline render) |
+| `compact_tables`, `skip_empty_cells` | bool | Unpadded Markdown tables / drop empty cells from sparse spreadsheet grids (#271) |
 | `fetch_images` | bool | Resolve external `<img src>` for HTML/EPUB (the embedder owns its network policy) |
 | `asr_model`, `asr_lang` | string | Whisper preset / transcription language for audio & video |
 | `video_frames` | int | Max sampled video frames (0 = transcript only) |

--- a/crates/docling-ffi/include/docling.h
+++ b/crates/docling-ffi/include/docling.h
@@ -39,7 +39,7 @@ struct DoclingResult *docling_convert(const uint8_t *bytes,
                                       const char *options_json);
 
 // The converted output, or NULL when the conversion failed. NUL-terminated
-// (readable as a C string for `to` = `md` / `json`); for binary output
+// (readable as a C string for `to` = `md` / `json` / `latex`); for binary output
 // (`dclx`) pair it with [`docling_result_output_len`]. Owned by the result —
 // valid until [`docling_result_free`].
 //

--- a/crates/docling-ffi/src/lib.rs
+++ b/crates/docling-ffi/src/lib.rs
@@ -41,7 +41,7 @@ use serde::Deserialize;
 #[derive(Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Output format: `md` (default) | `json` | `dclx`.
+    /// Output format: `md` (default) | `json` | `dclx` | `latex`.
     to: Option<String>,
     /// Strict (docling-faithful) Markdown instead of the readable default.
     strict: Option<bool>,
@@ -62,6 +62,21 @@ struct Options {
     pages: Option<String>,
     /// OCR recognition language for scanned pages: `en` (default) | `ch`.
     ocr_lang: Option<String>,
+    /// Keep layout + TableFormer, never OCR (docling's independent
+    /// `do_ocr=False`, #244).
+    skip_ocr: Option<bool>,
+    /// Infer section-header levels (docling's HeadingHierarchyModel, #302).
+    heading_hierarchy: Option<bool>,
+    /// Which regions feed the OCR (docling's `OcrMode`, #254): `default` |
+    /// `full_page` | `layout_regions` | `pdf_aware_layout_regions`.
+    ocr_mode: Option<String>,
+    /// OCR render scale in px per PDF point (docling's `OcrOptions.scale`,
+    /// #254); unset reads the pipeline's own 2.0 px/pt render.
+    ocr_scale: Option<f32>,
+    /// Unpadded `| a | b |` Markdown tables (#271, docling.rs extension).
+    compact_tables: Option<bool>,
+    /// Omit empty cells from sparse XLSX/XLS grids (#271, docling.rs extension).
+    skip_empty_cells: Option<bool>,
 }
 
 /// An opaque conversion result. Exactly one of output/error is set; the
@@ -106,7 +121,17 @@ fn convert_impl(bytes: &[u8], filename: &str, options_json: &str) -> Result<Vec<
         .no_ocr(options.no_ocr.unwrap_or(false))
         .force_full_page_ocr(options.force_full_page_ocr.unwrap_or(false))
         .no_table_former(options.no_table_former.unwrap_or(false))
-        .no_text_panels(options.no_text_panels.unwrap_or(false));
+        .no_text_panels(options.no_text_panels.unwrap_or(false))
+        .skip_ocr(options.skip_ocr.unwrap_or(false))
+        .heading_hierarchy(options.heading_hierarchy.unwrap_or(false))
+        .compact_tables(options.compact_tables.unwrap_or(false))
+        .skip_empty_cells(options.skip_empty_cells.unwrap_or(false));
+    if let Some(mode) = &options.ocr_mode {
+        converter = converter.ocr_mode(mode.clone());
+    }
+    if let Some(scale) = options.ocr_scale {
+        converter = converter.ocr_scale(scale);
+    }
     if let Some(pages) = &options.pages {
         let (first, last) = docling::parse_page_range(pages).map_err(|e| format!("pages: {e}"))?;
         converter = converter.page_range(first, last);
@@ -142,7 +167,10 @@ fn convert_impl(bytes: &[u8], filename: &str, options_json: &str) -> Result<Vec<
         // A binary OPC zip — read it through output + output_len, never as a
         // C string.
         "dclx" => Ok(docling::dclx::to_dclx_bytes(&document)),
-        other => Err(format!("unknown to={other:?} (expected: md, json, dclx)")),
+        "latex" => Ok(document.export_to_latex().into_bytes()),
+        other => Err(format!(
+            "unknown to={other:?} (expected: md, json, dclx, latex)"
+        )),
     }
 }
 
@@ -212,7 +240,7 @@ pub unsafe extern "C" fn docling_convert(
 }
 
 /// The converted output, or NULL when the conversion failed. NUL-terminated
-/// (readable as a C string for `to` = `md` / `json`); for binary output
+/// (readable as a C string for `to` = `md` / `json` / `latex`); for binary output
 /// (`dclx`) pair it with [`docling_result_output_len`]. Owned by the result —
 /// valid until [`docling_result_free`].
 ///
@@ -333,6 +361,11 @@ mod tests {
 
         // DCLX is a binary zip: starts with the PK local-file magic and the
         // length accessor is the only safe way to read it.
+        let r = convert(md, "note.md", r#"{"to":"latex"}"#);
+        let tex = output_string(r);
+        assert!(tex.starts_with("\\documentclass"), "{tex}");
+        assert!(tex.ends_with("\\end{document}"), "{tex}");
+        unsafe { docling_result_free(r) };
         let r = convert(md, "note.md", r#"{"to":"dclx"}"#);
         unsafe {
             assert!(docling_result_error(r).is_null());

--- a/crates/docling-serve/src/index.html
+++ b/crates/docling-serve/src/index.html
@@ -74,7 +74,7 @@
   </nav>
 </header>
 <main>
-<p class="sub">Convert documents to Markdown, docling JSON, DocLang archives, or chunk records —
+<p class="sub">Convert documents to Markdown, docling JSON, DocLang archives, LaTeX, or chunk records —
 over <a href="https://github.com/docling-project/docling.rs">docling.rs</a>, on this server.
 The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (OpenAPI 3.1).</p>
 
@@ -98,6 +98,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
         <option value="json">docling JSON</option>
         <option value="chunks">chunk records</option>
         <option value="dclx">DocLang archive (.dclx)</option>
+        <option value="latex">LaTeX (.tex)</option>
         <option value="images">page images (PDF → PNG)</option>
       </select>
     </label>
@@ -108,6 +109,36 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
     <label title="Keep layout + TableFormer, never OCR (docling's do_ocr=False): structure survives, pixel-only text comes back empty"><input type="checkbox" id="skip_ocr"> skip OCR</label>
     <label><input type="checkbox" id="no_table_former"> no TableFormer</label>
     <label title="Keep every detected picture as a picture (disable text-panel demotion)"><input type="checkbox" id="no_text_panels"> keep pictures</label>
+    <label title="OCR every page from its render, ignoring the embedded text layer (docling's force_full_page_ocr)"><input type="checkbox" id="force_full_page_ocr"> force full-page OCR</label>
+    <label title="Infer section-header levels from font size / numbering (docling's HeadingHierarchyModel, #302)"><input type="checkbox" id="heading_hierarchy"> heading levels</label>
+    <label title="Unpadded | a | b | Markdown tables (#271)"><input type="checkbox" id="compact_tables"> compact tables</label>
+    <label title="Omit empty cells from sparse XLSX/XLS grids (#271)"><input type="checkbox" id="skip_empty_cells"> skip empty cells</label>
+  </div>
+  <div class="row">
+    <label title="PDF page window, 1-based inclusive: 3 or 2-5">Pages <input type="text" id="pages" size="6" placeholder="all"></label>
+    <label title="OCR recognition language for scanned pages">OCR language
+      <select id="ocr_lang"><option value="">en (default)</option><option value="ch">ch (multilingual)</option></select>
+    </label>
+    <label title="Which regions feed the OCR (docling's OcrMode, #254); full_page / layout_regions discard the text layer">OCR mode
+      <select id="ocr_mode"><option value="">default</option><option value="full_page">full_page</option><option value="layout_regions">layout_regions</option><option value="pdf_aware_layout_regions">pdf_aware_layout_regions</option></select>
+    </label>
+    <label title="OCR render scale in px per PDF point (docling's default 3 = 216 dpi; empty = the pipeline's 2.0 render)">OCR scale <input type="number" id="ocr_scale" step="0.5" min="0.5" max="6" size="4" placeholder="2.0"></label>
+    <label title="Whisper transcription language for audio/video (empty = auto)">ASR lang <input type="text" id="asr_lang" size="4" placeholder="auto"></label>
+    <label title="Max sampled video frames (0 = transcript only)">Video frames <input type="number" id="video_frames" min="0" size="3" placeholder="default"></label>
+  </div>
+  <div class="row">
+    <label title="PDF pipeline: the standard layout/TableFormer/OCR pipeline, or a remote vision-language model (docling's VlmPipeline over an OpenAI-compatible endpoint, #304)">Pipeline
+      <select id="pipeline"><option value="">standard</option><option value="vlm">vlm (remote endpoint)</option></select>
+    </label>
+    <span id="vlm_fields" style="display:none">
+      <input type="text" id="vlm_endpoint" size="28" placeholder="http://localhost:8000/v1 (endpoint)">
+      <input type="text" id="vlm_model" size="14" placeholder="model">
+      <input type="password" id="vlm_api_key" size="12" placeholder="api key">
+      <input type="text" id="vlm_prompt" size="18" placeholder="prompt (optional)">
+      <input type="number" id="vlm_max_tokens" size="6" min="1" placeholder="max tokens">
+    </span>
+  </div>
+  <div class="row">
     <button id="go">Convert</button>
   </div>
   <div class="hint" id="fetch-images-disabled-note" style="display:none">
@@ -154,7 +185,7 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
 <p>As query parameters, multipart text fields, or JSON keys (body wins over query):</p>
 <table>
   <tr><th>Option</th><th>Values</th><th>Description</th></tr>
-  <tr><td><code>to</code></td><td><code>md</code> (default) | <code>json</code> | <code>dclx</code> | <code>chunks</code> | <code>images</code></td>
+  <tr><td><code>to</code></td><td><code>md</code> (default) | <code>json</code> | <code>dclx</code> | <code>chunks</code> | <code>latex</code> | <code>images</code></td>
       <td>Markdown (streamed) · docling <code>DoclingDocument</code> JSON · DocLang OPC archive (download) · chunker records (hierarchical + hybrid when a tokenizer is installed) · per-page PNG renders of a PDF (no conversion; combines with <code>pages</code>, capped at 100 pages per request by default).</td></tr>
   <tr><td><code>strict</code></td><td><code>true</code>/<code>false</code></td><td>Cleaner strict Markdown dialect instead of byte-for-byte docling-legacy output.</td></tr>
   <tr><td><code>images</code></td><td><code>placeholder</code> (default) | <code>embedded</code></td><td>Markdown picture handling (embedded = base64 data URIs).</td></tr>
@@ -167,6 +198,17 @@ The API is described by <a href="/openapi.yaml"><code>/openapi.yaml</code></a> (
   <tr><td><code>fetch_images</code></td><td><code>true</code>/<code>false</code></td><td>HTML/EPUB: resolve external <code>&lt;img src&gt;</code> and embed the bytes. Outbound fetch — honored only when the server runs with <code>--allow-url-fetch</code>, otherwise ignored.</td></tr>
   <tr><td><code>asr_lang</code></td><td><code>auto</code> (default) | a Whisper code (<code>en</code>, <code>de</code>, <code>zh</code>, …)</td><td>Audio/video: transcription language; <code>auto</code> detects it from the first 30 seconds. English-only presets always transcribe English.</td></tr>
   <tr><td><code>scale</code></td><td><code>0.1</code>–<code>4.0</code> (default <code>2.0</code>)</td><td><code>to=images</code>: render scale in pixels per PDF point — 2.0 = 144&nbsp;dpi, the ML pipeline's own render scale.</td></tr>
+  <tr><td><code>force_full_page_ocr</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: OCR every page from its render, ignoring the embedded text layer (docling's <code>force_full_page_ocr</code>).</td></tr>
+  <tr><td><code>heading_hierarchy</code></td><td><code>true</code>/<code>false</code></td><td>PDF/image: infer section-header levels (docling's HeadingHierarchyModel, #302) instead of flat <code>##</code> headings.</td></tr>
+  <tr><td><code>pages</code></td><td><code>A-B</code> | <code>N</code></td><td>PDF page window, 1-based inclusive (#80).</td></tr>
+  <tr><td><code>ocr_lang</code></td><td><code>en</code> (default) | <code>ch</code></td><td>OCR recognition language for scanned pages (<code>ch</code> = the multilingual docling-conformance model).</td></tr>
+  <tr><td><code>ocr_mode</code></td><td><code>default</code> | <code>full_page</code> | <code>layout_regions</code> | <code>pdf_aware_layout_regions</code></td><td>Which regions feed the OCR (docling's <code>OcrMode</code>, #254); <code>full_page</code>/<code>layout_regions</code> discard the text layer.</td></tr>
+  <tr><td><code>ocr_scale</code></td><td>float</td><td>OCR render scale in px per PDF point (docling's <code>OcrOptions.scale</code>, default 3 = 216&nbsp;dpi; unset reads the pipeline's own 2.0 render).</td></tr>
+  <tr><td><code>compact_tables</code>, <code>skip_empty_cells</code></td><td><code>true</code>/<code>false</code></td><td>Unpadded <code>| a | b |</code> Markdown tables; drop empty cells from sparse XLSX/XLS grids (#271, docling.rs extensions).</td></tr>
+  <tr><td><code>video_frames</code></td><td>int</td><td>Video: maximum sampled frames (0 = transcript only, #138).</td></tr>
+  <tr><td><code>pipeline</code></td><td><code>standard</code> (default) | <code>vlm</code></td><td>PDF/image: the layout/TableFormer/OCR pipeline, or docling's VlmPipeline over a remote OpenAI-compatible vision-language endpoint (#304).</td></tr>
+  <tr><td><code>vlm_endpoint</code>, <code>vlm_model</code>, <code>vlm_api_key</code>, <code>vlm_prompt</code>, <code>vlm_max_tokens</code></td><td>string / int</td><td><code>pipeline=vlm</code> settings (defaults from <code>DOCLING_RS_VLM_*</code>); the endpoint is an outbound fetch, so it is honored only under <code>--allow-url-fetch</code>.</td></tr>
+  <tr><td><code>chunker</code>, <code>chunk_tokenizer</code>, <code>chunk_max_tokens</code>, <code>chunk_merge_peers</code></td><td><code>hierarchical</code> | <code>hybrid</code> / path / int / bool</td><td><code>to=chunks</code>: pick one chunker (unset = both), a server-local <code>tokenizer.json</code>, the hybrid token budget and peer merging (#256).</td></tr>
 </table>
 
 <h2>Examples</h2>
@@ -282,6 +324,9 @@ function renderImages(text, to) {
   $('result').textContent = parts.join('');
 }
 
+$('pipeline').addEventListener('change', () => {
+  $('vlm_fields').style.display = $('pipeline').value === 'vlm' ? '' : 'none';
+});
 $('go').addEventListener('click', async () => {
   const out = $('result');
   out.style.display = '';
@@ -298,7 +343,18 @@ $('go').addEventListener('click', async () => {
     skip_ocr: $('skip_ocr').checked,
     no_table_former: $('no_table_former').checked,
     no_text_panels: $('no_text_panels').checked,
+    force_full_page_ocr: $('force_full_page_ocr').checked,
+    heading_hierarchy: $('heading_hierarchy').checked,
+    compact_tables: $('compact_tables').checked,
+    skip_empty_cells: $('skip_empty_cells').checked,
   };
+  // Free-form options ride along only when set, so the server keeps its
+  // defaults (and its validation messages) for everything left blank.
+  for (const id of ['pages', 'ocr_lang', 'ocr_mode', 'ocr_scale', 'asr_lang', 'video_frames',
+                    'pipeline', 'vlm_endpoint', 'vlm_model', 'vlm_api_key', 'vlm_prompt', 'vlm_max_tokens']) {
+    const v = $(id).value.trim();
+    if (v) opts[id] = v;
+  }
   let request;
   if (document.querySelector('input[name=mode]:checked').value === 'file') {
     const files = $('file').files;

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -52,7 +52,7 @@ limits).
 convert(
   bytes: Uint8Array,
   filename: string,
-  to?: "md" | "json" | "doclang",          // default "md"
+  to?: "md" | "json" | "doclang" | "latex", // default "md"
   images?: "placeholder" | "embedded",     // default "placeholder", Markdown only
   max_pages?: number,                      // convert only the first N PDF pages
 ): string
@@ -165,7 +165,7 @@ converters and text-layer PDFs work straight away and OCR starts once you give
 the page models (device picker or Hugging Face — see below).
 
 [`www/index.html`](./www/index.html) is the whole thing on one page: drop a
-file, pick the output (Markdown / JSON / DocLang), pick how images render, and
+file, pick the output (Markdown / JSON / DocLang / LaTeX), pick how images render, and
 optionally turn on OCR for scanned pages. A **Force OCR** toggle (docling's
 `force_full_page_ocr`) sends a PDF straight to the OCR pipeline, ignoring
 whatever text layer it claims to have — for layers that exist but lie. A

--- a/crates/docling-wasm/src/digital.rs
+++ b/crates/docling-wasm/src/digital.rs
@@ -134,7 +134,7 @@ impl DigitalConverter {
     }
 
     /// Assemble the converted pages into a document and render it as `"md"`
-    /// (default), `"json"` or `"doclang"`, with `images` picking how pictures
+    /// (default), `"json"`, `"doclang"` or `"latex"`, with `images` picking how pictures
     /// render in Markdown. Resets the converter.
     pub fn finish(
         &mut self,

--- a/crates/docling-wasm/src/lib.rs
+++ b/crates/docling-wasm/src/lib.rs
@@ -72,8 +72,9 @@ fn convert_impl(
             .0),
         "json" => Ok(result.document.export_to_json()),
         "doclang" => Ok(result.document.export_to_doclang()),
+        "latex" => Ok(result.document.export_to_latex()),
         other => Err(format!(
-            "unknown output format {other:?} (expected \"md\", \"json\" or \"doclang\")"
+            "unknown output format {other:?} (expected \"md\", \"json\", \"doclang\" or \"latex\")"
         )),
     }
 }
@@ -94,8 +95,9 @@ fn image_mode(images: Option<&str>) -> Result<ImageMode, String> {
 
 /// Convert a document (as bytes + filename, the extension drives format
 /// detection) to `to`: `"md"` (Markdown, default), `"json"` (docling-core's
-/// `DoclingDocument` wire format, schema 1.10.0) or `"doclang"` (docling's
-/// DocLang XML serialization).
+/// `DoclingDocument` wire format, schema 1.10.0), `"doclang"` (docling's
+/// DocLang XML serialization) or `"latex"` (docling 2.124's LaTeX document,
+/// #317).
 ///
 /// `images` controls how pictures render in Markdown — `"placeholder"`
 /// (default) or `"embedded"` (base64 data URIs), the same option

--- a/crates/docling-wasm/src/ocr.rs
+++ b/crates/docling-wasm/src/ocr.rs
@@ -110,8 +110,9 @@ pub async fn ocr_image(
         "md" | "markdown" => Ok(doc.export_to_markdown()),
         "json" => Ok(doc.export_to_json()),
         "doclang" => Ok(doc.export_to_doclang()),
+        "latex" => Ok(doc.export_to_latex()),
         other => Err(JsError::new(&format!(
-            "unknown output format {other:?} (expected \"md\", \"json\" or \"doclang\")"
+            "unknown output format {other:?} (expected \"md\", \"json\", \"doclang\" or \"latex\")"
         ))),
     }
 }

--- a/crates/docling-wasm/src/scanned.rs
+++ b/crates/docling-wasm/src/scanned.rs
@@ -304,7 +304,7 @@ impl ScannedConverter {
     }
 
     /// Assemble the accumulated pages into the final document and render it
-    /// as `"md"` (default), `"json"` or `"doclang"` — the same three the
+    /// as `"md"` (default), `"json"`, `"doclang"` or `"latex"` — the same four the
     /// declarative [`crate::convert`] entry point offers. `images` picks how
     /// cropped figures render in Markdown (`"placeholder"` | `"embedded"`),
     /// like [`crate::convert`]. Resets the converter.
@@ -334,8 +334,9 @@ pub(crate) fn render(
         }
         "json" => Ok(doc.export_to_json()),
         "doclang" => Ok(doc.export_to_doclang()),
+        "latex" => Ok(doc.export_to_latex()),
         other => Err(JsError::new(&format!(
-            "unknown output format {other:?} (expected \"md\", \"json\" or \"doclang\")"
+            "unknown output format {other:?} (expected \"md\", \"json\", \"doclang\" or \"latex\")"
         ))),
     }
 }

--- a/crates/docling-wasm/www/index.html
+++ b/crates/docling-wasm/www/index.html
@@ -104,6 +104,7 @@
         <option value="md" selected>Markdown</option>
         <option value="json">docling JSON</option>
         <option value="doclang">DocLang XML</option>
+        <option value="latex">LaTeX</option>
       </select>
     </label>
     <label title="How pictures render in Markdown — the same option docling-serve exposes.">Images


### PR DESCRIPTION
README:
- badge rows under the logo: CI, live demo, docs.rs, crates.io version / MSRV / downloads, npm docling.rs (+ downloads/month) and docling.rs-wasm, PyPI version / Python versions / downloads, the two GHCR images, GitHub release, license, LF AI & Data
- new "Integration — using docling.rs from your language" section: one table (Rust crate, CLI, HTTP serve, Node/Bun, Python, browser wasm, C ABI for C/C++/C#/Go/Java/Swift, RAG) with install channels and links, guidance on which door to pick, and a snippet per surface
- Layout table gains docling-onnx and docling-ffi, and names the server crate `docling-serve` (the image is docling-rs-serve); wasm/FFI sections list LaTeX among the outputs

wasm: `to: "latex"` on convert() and on the digital/scanned/OCR paths, the demo page's output picker and the README signature.

FFI: `to: "latex"` plus the options the C ABI was missing against docling-serve — skip_ocr, heading_hierarchy, ocr_mode, ocr_scale, compact_tables, skip_empty_cells — documented in the README table and the header comment; the round-trip test covers LaTeX.

serve playground: LaTeX output; controls for force full-page OCR, heading levels, compact tables, skip empty cells, pages, OCR language / mode / scale, ASR language, video frames, and the VLM pipeline with its endpoint / model / key / prompt / max-tokens fields (shown when pipeline=vlm); blank fields are not sent so server defaults and validation stay in charge. The options table documents every request option the server accepts.

Refs #317



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT