### PR TITLE
feat(ci) CUDA docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,17 +17,18 @@
 # Multi-arch CPU builds run natively on matrix runners — `ubuntu-latest` for
 # linux/amd64 and `ubuntu-24.04-arm` for linux/arm64 — avoiding slow QEMU
 # emulation. Single-arch CPU images are pushed by digest and assembled into
-# multi-arch manifest lists by the `merge` job.
+# multi-arch manifest lists by the `merge-cpu` job.
 #
 # CUDA images are built on `ubuntu-latest` (linux/amd64) and tagged with
 # explicit release versions and `master` (never floating `:latest`, matching
-# upstream docling-serve CUDA tagging policy).
+# upstream docling-serve CUDA tagging policy). On pull requests, the CUDA job
+# dry-runs on linux/amd64 with smoke tests to ensure CUDA builds do not regress.
 #
 # Triggers:
 #   - Release published: tags with semantic versions (vX.Y.Z, X.Y, X, latest for CPU; vX.Y.Z, X.Y, X for CUDA)
 #   - Push to master: tags with `master` (and `latest` for CPU)
 #   - Manual dispatch: tag override or dry-run testing (with optional CUDA toggle)
-#   - Pull request: fast dry-run build on amd64 + smoke test (no push)
+#   - Pull request: fast dry-run builds on amd64 + smoke tests (no push)
 
 name: docker-publish
 
@@ -117,6 +118,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          docker system prune -af || true
+          df -h
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -323,6 +330,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' || github.event_name == 'release' }}
@@ -408,10 +416,8 @@ jobs:
     name: build & publish CUDA (linux/amd64)
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Gated on push to master, release published, or workflow_dispatch with cuda=true
-    if: |
-      github.event_name != 'pull_request' &&
-      (github.event_name != 'workflow_dispatch' || (inputs.publish && inputs.cuda))
+    # Runs on PRs (dry-run smoke test), pushes to master, releases, or dispatch with cuda=true
+    if: github.event_name == 'pull_request' || (github.event_name != 'workflow_dispatch' || (inputs.publish && inputs.cuda))
     permissions:
       contents: read
       packages: write
@@ -421,10 +427,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          docker system prune -af || true
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        # Only log in when publishing (not on PR dry-runs)
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -442,6 +456,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
@@ -461,6 +476,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
@@ -470,7 +486,77 @@ jobs:
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.vendor=docling-project
 
-      - name: Build and push CUDA serve image
+      # ------------------------------------------------------------------------
+      # Local builds & smoke tests (runs on all events including PRs)
+      # ------------------------------------------------------------------------
+      - name: Build local CUDA CLI image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: cli-cuda
+          load: true
+          tags: docling-rs-cuda:test
+          platforms: linux/amd64
+          labels: ${{ steps.meta_cuda_cli.outputs.labels }}
+          cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
+
+      - name: Build local CUDA serve image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: serve-cuda
+          load: true
+          tags: docling-rs-serve-cuda:test
+          platforms: linux/amd64
+          labels: ${{ steps.meta_cuda_serve.outputs.labels }}
+          cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
+
+      - name: Run CUDA CLI smoke test (auto fallback to CPU on GPU-less runner)
+        run: |
+          echo "Testing CLI execution with auto provider fallback..."
+          docker run --rm docling-rs-cuda:test --version
+          docker run --rm -v "$PWD/tests/data/md/sources:/data:ro" docling-rs-cuda:test wiki.md --to md | head -n 3
+
+      - name: Run CUDA serve smoke test (auto fallback to CPU on GPU-less runner)
+        run: |
+          echo "Starting docling-rs-serve-cuda container..."
+          docker run -d --name docling-rs-serve-cuda-test -p 5001:5001 docling-rs-serve-cuda:test
+
+          echo "Waiting for service readiness (/ready)..."
+          READY=false
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5001/ready | grep -q '"status":"ready"'; then
+              echo "Readiness probe OK (models warm with auto EP)"
+              READY=true
+              break
+            fi
+            echo "Waiting for container readiness ($i/60)..."
+            sleep 5
+          done
+
+          if [ "$READY" != "true" ]; then
+            echo "Smoke test readiness check failed! Container logs:"
+            docker logs docling-rs-serve-cuda-test
+            docker rm -f docling-rs-serve-cuda-test
+            exit 1
+          fi
+
+          echo "Verifying /v1/config endpoint..."
+          CONFIG=$(curl -sf http://localhost:5001/v1/config)
+          echo "Config: $CONFIG"
+
+          echo "Cleaning up smoke test container..."
+          docker rm -f docling-rs-serve-cuda-test
+
+      # ------------------------------------------------------------------------
+      # Push images to GHCR (skipped on pull requests)
+      # ------------------------------------------------------------------------
+      - name: Push CUDA serve image to GHCR
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         id: build_cuda_serve
         uses: docker/build-push-action@v6
         with:
@@ -482,9 +568,9 @@ jobs:
           tags: ${{ steps.meta_cuda_serve.outputs.tags }}
           labels: ${{ steps.meta_cuda_serve.outputs.labels }}
           cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
-          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
 
-      - name: Build and push CUDA CLI image
+      - name: Push CUDA CLI image to GHCR
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         id: build_cuda_cli
         uses: docker/build-push-action@v6
         with:
@@ -496,9 +582,9 @@ jobs:
           tags: ${{ steps.meta_cuda_cli.outputs.tags }}
           labels: ${{ steps.meta_cuda_cli.outputs.labels }}
           cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
-          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
 
       - name: Generate artifact attestation for docling-rs-serve-cuda
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.SERVE_CUDA_IMAGE }}
@@ -506,6 +592,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate artifact attestation for docling-rs-cuda
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.CLI_CUDA_IMAGE }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -517,10 +517,12 @@ jobs:
 
       - name: Run CUDA CLI smoke test (auto fallback to CPU on GPU-less runner)
         run: |
-          echo "Testing CLI execution with auto provider fallback..."
-          docker run --rm docling-rs-cuda:test --version
+          echo "Testing CLI execution with auto provider fallback on Markdown fixture..."
           docker run --rm -v "$PWD/tests/data/md/sources:/data:ro" docling-rs-cuda:test wiki.md --to md | head -n 3
-
+          echo "Testing CLI execution with models resolving..."
+          out=$(docker run --rm -v "$PWD/tests/data/pdf/sources:/data:ro" docling-rs-cuda:test base14_fonts.pdf --to latex)
+          echo "$out" | head -n 20
+          echo "$out" | grep -q '\\begin{document}' || { echo "CUDA CLI smoke test failed: no LaTeX document produced"; exit 1; }
       - name: Run CUDA serve smoke test (auto fallback to CPU on GPU-less runner)
         run: |
           echo "Starting docling-rs-serve-cuda container..."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,25 +1,32 @@
-# Build and publish the `docling-rs-serve` container image to GitHub Container
-# Registry (ghcr.io).
+# Build and publish `docling-rs-serve` and `docling-rs` container images to
+# GitHub Container Registry (ghcr.io).
 #
-# The image packages the pure-Rust `docling-serve` HTTP conversion API along with
-# its native runtime dependencies (ffmpeg, pdfium, and the ONNX models for
-# layout detection, TableFormer table structure, and PP-OCRv3 recognition) into
-# a slim, Python-free container image.
+# The images package the pure-Rust `docling-serve` HTTP conversion API and the
+# `docling-rs` CLI along with their native runtime dependencies (ffmpeg,
+# pdfium, and the ONNX models for layout detection, TableFormer table
+# structure, and PP-OCRv3 recognition) into slim, Python-free container images.
 #
-# Multi-arch: builds natively on matrix runners — `ubuntu-latest` for linux/amd64
-# and `ubuntu-24.04-arm` for linux/arm64 — avoiding slow QEMU emulation. The
-# single-arch images are pushed by digest and assembled into multi-arch manifest
-# lists by the `merge` job.
+# Published image families:
+#   CPU (multi-arch: linux/amd64 + linux/arm64):
+#     - ghcr.io/docling-project/docling-rs-serve      — HTTP conversion API
+#     - ghcr.io/docling-project/docling-rs            — docling-rs CLI
+#   CUDA GPU (linux/amd64, CUDA 12 + cuDNN 9, --features cuda):
+#     - ghcr.io/docling-project/docling-rs-serve-cuda — CUDA HTTP conversion API
+#     - ghcr.io/docling-project/docling-rs-cuda       — CUDA docling-rs CLI
 #
-# Published images (two targets of crates/docling-serve/Dockerfile, sharing the
-# dependency, runtime and asset layers):
-#   - ghcr.io/docling-project/docling-rs-serve — the HTTP conversion API
-#   - ghcr.io/docling-project/docling-rs       — the `docling-rs` CLI
+# Multi-arch CPU builds run natively on matrix runners — `ubuntu-latest` for
+# linux/amd64 and `ubuntu-24.04-arm` for linux/arm64 — avoiding slow QEMU
+# emulation. Single-arch CPU images are pushed by digest and assembled into
+# multi-arch manifest lists by the `merge` job.
+#
+# CUDA images are built on `ubuntu-latest` (linux/amd64) and tagged with
+# explicit release versions and `master` (never floating `:latest`, matching
+# upstream docling-serve CUDA tagging policy).
 #
 # Triggers:
-#   - Release published: tags with semantic versions (vX.Y.Z, X.Y, X, latest)
-#   - Push to master: tags with `master` and `latest`
-#   - Manual dispatch: tag override or dry-run testing
+#   - Release published: tags with semantic versions (vX.Y.Z, X.Y, X, latest for CPU; vX.Y.Z, X.Y, X for CUDA)
+#   - Push to master: tags with `master` (and `latest` for CPU)
+#   - Manual dispatch: tag override or dry-run testing (with optional CUDA toggle)
 #   - Pull request: fast dry-run build on amd64 + smoke test (no push)
 
 name: docker-publish
@@ -43,11 +50,16 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Explicit image tag to publish (e.g. v1.24.0 or latest). Blank = derive from ref/release."
+        description: "Explicit image tag to publish (e.g. v1.28.0 or latest). Blank = derive from ref/release."
         required: false
         default: ""
       publish:
         description: "Publish images to GHCR (false = build & test only, no push)."
+        required: false
+        type: boolean
+        default: true
+      cuda:
+        description: "Also build and publish CUDA GPU images (docling-rs-serve-cuda / docling-rs-cuda)."
         required: false
         type: boolean
         default: true
@@ -78,10 +90,15 @@ env:
   REGISTRY: ghcr.io
   SERVE_IMAGE: ${{ github.repository_owner }}/docling-rs-serve
   CLI_IMAGE: ${{ github.repository_owner }}/docling-rs
+  SERVE_CUDA_IMAGE: ${{ github.repository_owner }}/docling-rs-serve-cuda
+  CLI_CUDA_IMAGE: ${{ github.repository_owner }}/docling-rs-cuda
 
 jobs:
-  build:
-    name: build ${{ matrix.platform }}
+  # ============================================================================
+  # 1. CPU Build Matrix (linux/amd64 on ubuntu-latest, linux/arm64 on ubuntu-24.04-arm)
+  # ============================================================================
+  build-cpu:
+    name: build CPU (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
@@ -105,12 +122,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        # Only log in when pushing digests (push/release/dispatch). The
-        # dispatch guard matters: outside `workflow_dispatch` the `inputs`
-        # context is empty and `inputs.publish` is null, which GitHub's loose
-        # comparison coerces to 0 — so `inputs.publish != false` evaluated to
-        # *false* on push and release, silently skipping every publish step
-        # and the merge job (run #9 on master built both arches, pushed nothing).
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/login-action@v3
         with:
@@ -118,8 +129,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata labels for Docker
-        id: meta
+      - name: Extract metadata labels for CPU serve image
+        id: meta_serve
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }}
@@ -129,7 +140,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.vendor=docling-project
 
-      - name: Extract metadata labels for the CLI image
+      - name: Extract metadata labels for CPU CLI image
         id: meta_cli
         uses: docker/metadata-action@v5
         with:
@@ -140,9 +151,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.vendor=docling-project
 
-      # Build both single-arch images locally and verify them. The two targets
-      # share every layer up to the final stage, so the second build is cheap.
-      - name: Build local serve image for smoke test
+      - name: Build local CPU serve image for smoke test
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -151,11 +160,11 @@ jobs:
           load: true
           tags: docling-rs-serve:test
           platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta_serve.outputs.labels }}
           cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
-      - name: Build local CLI image for smoke test
+      - name: Build local CPU CLI image for smoke test
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -208,10 +217,8 @@ jobs:
           echo "Cleaning up smoke test container..."
           docker rm -f docling-rs-serve-test
 
-      # Push the single-arch images by digest to GHCR (skipped on PRs); the
-      # merge job assembles the multi-arch manifest lists per image.
-      - name: Build and push serve image by digest
-        id: build
+      - name: Build and push CPU serve image by digest
+        id: build_serve
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/build-push-action@v6
         with:
@@ -219,12 +226,12 @@ jobs:
           file: crates/docling-serve/Dockerfile
           target: serve
           platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta_serve.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SERVE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
-      - name: Build and push CLI image by digest
+      - name: Build and push CPU CLI image by digest
         id: build_cli
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: docker/build-push-action@v6
@@ -238,16 +245,16 @@ jobs:
           cache-from: type=gha,scope=docling-rs-serve-${{ matrix.platform_slug }}
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
-      - name: Export digests
+      - name: Export CPU digests
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         run: |
           mkdir -p /tmp/digests/serve /tmp/digests/cli
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${{ steps.build_serve.outputs.digest }}"
           touch "/tmp/digests/serve/${digest#sha256:}"
           digest="${{ steps.build_cli.outputs.digest }}"
           touch "/tmp/digests/cli/${digest#sha256:}"
 
-      - name: Upload serve digest
+      - name: Upload CPU serve digest
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/upload-artifact@v7
         with:
@@ -256,7 +263,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Upload CLI digest
+      - name: Upload CPU CLI digest
         if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
         uses: actions/upload-artifact@v7
         with:
@@ -265,11 +272,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
-    name: merge multi-arch manifests & publish
+  # ============================================================================
+  # 2. Merge CPU Multi-Arch Manifest Lists & Publish
+  # ============================================================================
+  merge-cpu:
+    name: merge CPU multi-arch manifests & publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build
+    needs: build-cpu
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
     permissions:
       contents: read
@@ -376,6 +386,7 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
           digest=$(docker buildx imagetools inspect "$first_tag" --raw | sha256sum | awk '{print $1}')
           echo "digest=sha256:$digest" >> "$GITHUB_OUTPUT"
+
       - name: Generate artifact attestation for docling-rs-serve
         uses: actions/attest-build-provenance@v2
         with:
@@ -388,4 +399,115 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.CLI_IMAGE }}
           subject-digest: ${{ steps.merge-cli.outputs.digest }}
+          push-to-registry: true
+
+  # ============================================================================
+  # 3. CUDA GPU Build & Publish (Linux x86_64, CUDA 12 + cuDNN 9, no :latest)
+  # ============================================================================
+  build-and-publish-cuda:
+    name: build & publish CUDA (linux/amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Gated on push to master, release published, or workflow_dispatch with cuda=true
+    if: |
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_dispatch' || (inputs.publish && inputs.cuda))
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CUDA images follow upstream tagging policy: explicit version tags and master, NO :latest.
+      - name: Extract metadata for CUDA serve image
+        id: meta_cuda_serve
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SERVE_CUDA_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+          labels: |
+            org.opencontainers.image.title=docling-rs-serve-cuda
+            org.opencontainers.image.description=CUDA 12 GPU document conversion API in Rust (PDF, DOCX, PPTX, XLSX, HTML, Audio)
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.vendor=docling-project
+
+      - name: Extract metadata for CUDA CLI image
+        id: meta_cuda_cli
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.CLI_CUDA_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+          labels: |
+            org.opencontainers.image.title=docling-rs-cuda
+            org.opencontainers.image.description=docling-rs CLI (CUDA 12 GPU) — document conversion to Markdown / JSON / DCLX / LaTeX
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.vendor=docling-project
+
+      - name: Build and push CUDA serve image
+        id: build_cuda_serve
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: serve-cuda
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta_cuda_serve.outputs.tags }}
+          labels: ${{ steps.meta_cuda_serve.outputs.labels }}
+          cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
+
+      - name: Build and push CUDA CLI image
+        id: build_cuda_cli
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/docling-serve/Dockerfile
+          target: cli-cuda
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta_cuda_cli.outputs.tags }}
+          labels: ${{ steps.meta_cuda_cli.outputs.labels }}
+          cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
+          cache-to: type=gha,mode=max,scope=docling-rs-serve-cuda-linux-amd64
+
+      - name: Generate artifact attestation for docling-rs-serve-cuda
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.SERVE_CUDA_IMAGE }}
+          subject-digest: ${{ steps.build_cuda_serve.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for docling-rs-cuda
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.CLI_CUDA_IMAGE }}
+          subject-digest: ${{ steps.build_cuda_cli.outputs.digest }}
           push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -1474,21 +1474,25 @@ The following container images are available on **GitHub Container Registry (GHC
 
 | Image | Description | Architectures |
 |---|---|---|
-| [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed. | `linux/amd64`, `linux/arm64` |
-| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in — batch conversion without installing Rust. Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed (CPU). | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in — batch conversion without installing Rust (CPU). Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs-serve-cuda`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve-cuda) | NVIDIA CUDA 12 GPU-accelerated HTTP conversion API (CUDA 12 + cuDNN 9, Linux x86_64). Explicit version tags (`v1.28.0`, `master`), no `:latest`. | `linux/amd64` |
+| [`ghcr.io/docling-project/docling-rs-cuda`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-cuda) | NVIDIA CUDA 12 GPU-accelerated `docling-rs` CLI. Explicit version tags (`v1.28.0`, `master`), no `:latest`. | `linux/amd64` |
 
 ```bash
-# Run docling-rs-serve HTTP API (models baked in, zero Python runtime dependencies):
+# Run docling-rs-serve HTTP API (CPU):
 docker run -p 127.0.0.1:5001:5001 ghcr.io/docling-project/docling-rs-serve:latest
+
+# Or run with NVIDIA GPU acceleration (--gpus all):
+docker run --gpus all -p 127.0.0.1:5001:5001 ghcr.io/docling-project/docling-rs-serve-cuda:master
 
 # Convert a document:
 curl -F file=@paper.pdf localhost:5001/v1/convert
 
 # Or use the CLI image on local files (mounted at /data):
 docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest paper.pdf --to md
-docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest --input docs --output converted --to latex
+docker run --gpus all --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs-cuda:master paper.pdf --to md
 ```
-
 ### Docker Compose
 
 Launch with [`examples/docker-compose/`](./examples/docker-compose/):

--- a/crates/docling-serve/Dockerfile
+++ b/crates/docling-serve/Dockerfile
@@ -69,19 +69,31 @@ COPY . .
 RUN cargo build --release -p docling-serve -p docling-cli --locked
 
 # ------------------------------------------------------------------------------
-# Stage: CUDA build (Linux x86_64, ort/cuda + copy-dylibs)
+# Stage: CUDA build (Linux x86_64, ort/cuda + copy-dylibs on Ubuntu 24.04 devel)
+#
+# Ubuntu 24.04 (glibc 2.39 + GCC 14) matches the runtime-cuda base below (#333),
+# avoiding glibc version mismatches between build and runtime environments.
 # ------------------------------------------------------------------------------
-FROM chef AS build-cuda
+FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu24.04 AS chef-cuda
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl build-essential pkg-config ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.96.0 --profile minimal \
+    && cargo install cargo-chef --locked
+WORKDIR /src
+
+FROM chef-cuda AS build-cuda
 COPY --from=planner /src/recipe.json recipe.json
 # Build dependency tree with --features cuda so ONNX Runtime with CUDA is fetched and cooked.
 RUN cargo chef cook --release -p docling-serve -p docling-cli --features cuda --locked --recipe-path recipe.json
 COPY . .
-# $ORIGIN rpath: dlopen finds libonnxruntime_providers_{shared,cuda}.so in /usr/local/lib or alongside binaries
-ENV RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/local/lib"
 RUN cargo build --release -p docling-serve -p docling-cli --features cuda --locked \
     && mkdir -p /src/cuda-dylibs \
+    && test $(find target/release -maxdepth 1 -name "libonnxruntime_providers_*.so" | wc -l) -ge 2 \
     && find target/release -maxdepth 1 -name "libonnxruntime_providers_*.so" -exec cp -av {} /src/cuda-dylibs/ \;
-
 # ------------------------------------------------------------------------------
 # Stage: assets (models + pdfium, shared across CPU and CUDA)
 # ------------------------------------------------------------------------------

--- a/crates/docling-serve/Dockerfile
+++ b/crates/docling-serve/Dockerfile
@@ -1,11 +1,15 @@
 # docling.rs container images: the `docling-serve` HTTP conversion API and the
-# `docling-rs` CLI, built from one Dockerfile as two targets over shared
+# `docling-rs` CLI, built from one Dockerfile as multiple targets over shared
 # layers (same dependency compile, same runtime base, same ML assets).
 #
-# Build (from the repository root):
+# Standard CPU targets (built on Debian Trixie):
 #   docker build -f crates/docling-serve/Dockerfile --target serve -t docling-rs-serve .
 #   docker build -f crates/docling-serve/Dockerfile --target cli   -t docling-rs .
-# (`serve` is the last stage, so a build without --target yields the server.)
+# (`serve` is the default CPU target if --target is omitted.)
+#
+# NVIDIA CUDA 12 GPU targets (built with --features cuda on Ubuntu 24.04 + cuDNN 9):
+#   docker build -f crates/docling-serve/Dockerfile --target serve-cuda -t docling-rs-serve-cuda .
+#   docker build -f crates/docling-serve/Dockerfile --target cli-cuda   -t docling-rs-cuda .
 #
 # CLI image: the entrypoint is `docling-rs`, the working directory /data — mount
 # the documents there and pass the usual flags:
@@ -15,13 +19,17 @@
 # Run. The ML assets (ONNX models + pdfium) are fetched into the image by
 # `download_dependencies.sh` at build time; to keep the image slim instead,
 # build with `--build-arg FETCH_ASSETS=0` and mount them:
-#   docker run -p 5001:5001 docling-serve
-#   docker run -p 5001:5001 -v ./models:/app/models -v ./.pdfium:/app/.pdfium docling-serve
+#   docker run -p 5001:5001 docling-rs-serve
+#   docker run -p 5001:5001 -v ./models:/app/.models -v ./.pdfium:/app/.pdfium docling-rs-serve
+#
+# GPU run: pass --gpus all to expose the host NVIDIA GPU:
+#   docker run --gpus all -p 5001:5001 docling-rs-serve-cuda
+#   docker run --gpus all --rm -v "$PWD:/data" docling-rs-cuda report.pdf --to md
 #
 # The server binds 0.0.0.0 inside the container (the container boundary is the
 # network policy); URL fetching is enabled — front with a policy proxy or add
 # --no-url-fetch to CMD if the service should accept uploads only.
-
+#
 # trixie, not bookworm (#246): ort's prebuilt static onnxruntime is built
 # with GCC 13 and references GLIBCXX_3.4.31 — bookworm's libstdc++ (GCC 12)
 # tops out at 3.4.30, so the release link fails with undefined references.
@@ -38,6 +46,10 @@
 # just the workspace crates. The ML assets are fetched in their own stage
 # that depends on nothing but the download script, so ~900 MB of models are
 # not re-downloaded per build either.
+
+# ------------------------------------------------------------------------------
+# Stage: chef & planner (shared across CPU and CUDA builds)
+# ------------------------------------------------------------------------------
 FROM rust:1.96-trixie AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /src
@@ -46,6 +58,9 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
+# ------------------------------------------------------------------------------
+# Stage: CPU build
+# ------------------------------------------------------------------------------
 FROM chef AS build
 COPY --from=planner /src/recipe.json recipe.json
 # Same profile/packages/flags as the real build below, or cargo recompiles.
@@ -53,6 +68,23 @@ RUN cargo chef cook --release -p docling-serve -p docling-cli --locked --recipe-
 COPY . .
 RUN cargo build --release -p docling-serve -p docling-cli --locked
 
+# ------------------------------------------------------------------------------
+# Stage: CUDA build (Linux x86_64, ort/cuda + copy-dylibs)
+# ------------------------------------------------------------------------------
+FROM chef AS build-cuda
+COPY --from=planner /src/recipe.json recipe.json
+# Build dependency tree with --features cuda so ONNX Runtime with CUDA is fetched and cooked.
+RUN cargo chef cook --release -p docling-serve -p docling-cli --features cuda --locked --recipe-path recipe.json
+COPY . .
+# $ORIGIN rpath: dlopen finds libonnxruntime_providers_{shared,cuda}.so in /usr/local/lib or alongside binaries
+ENV RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/local/lib"
+RUN cargo build --release -p docling-serve -p docling-cli --features cuda --locked \
+    && mkdir -p /src/cuda-dylibs \
+    && find target/release -maxdepth 1 -name "libonnxruntime_providers_*.so" -exec cp -av {} /src/cuda-dylibs/ \;
+
+# ------------------------------------------------------------------------------
+# Stage: assets (models + pdfium, shared across CPU and CUDA)
+# ------------------------------------------------------------------------------
 FROM debian:trixie-slim AS assets
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
@@ -62,9 +94,9 @@ ARG FETCH_ASSETS=1
 RUN if [ "$FETCH_ASSETS" = "1" ]; then sh scripts/install/download_dependencies.sh; \
     else mkdir -p .models .pdfium; fi
 
-# Shared runtime base for both images: ffmpeg powers video frame sampling
-# (#138 Phase 2; without it a video input still converts, transcript-only),
-# curl serves the health check, and the ML assets live under /app.
+# ------------------------------------------------------------------------------
+# Stage: runtime (CPU base, Debian Trixie slim)
+# ------------------------------------------------------------------------------
 FROM debian:trixie-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*
@@ -73,7 +105,25 @@ COPY --from=assets /src/.models ./.models
 COPY --from=assets /src/.pdfium ./.pdfium
 ENV PDFIUM_DYNAMIC_LIB_PATH=/app/.pdfium/lib
 
-# --- ghcr.io/docling-project/docling-rs: the CLI -----------------------------
+# ------------------------------------------------------------------------------
+# Stage: runtime-cuda (CUDA 12 + cuDNN 9 base on Ubuntu 24.04)
+# ------------------------------------------------------------------------------
+FROM nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04 AS runtime-cuda
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=assets /src/.models ./.models
+COPY --from=assets /src/.pdfium ./.pdfium
+COPY --from=build-cuda /src/cuda-dylibs/ /usr/local/lib/
+ENV PDFIUM_DYNAMIC_LIB_PATH=/app/.pdfium/lib \
+    LD_LIBRARY_PATH=/usr/local/lib:/app/.pdfium/lib:${LD_LIBRARY_PATH:-} \
+    DOCLING_RS_EP=auto
+
+# ==============================================================================
+# Final targets: CPU
+# ==============================================================================
+
+# --- ghcr.io/docling-project/docling-rs: the CLI (CPU) ------------------------
 FROM runtime AS cli
 COPY --from=build /src/target/release/docling-rs /usr/local/bin/docling-rs
 # The CLI runs from /data (the user's mount), so `.models/…` cannot resolve
@@ -82,7 +132,7 @@ ENV DOCLING_RS_MODELS_DIR=/app/.models
 WORKDIR /data
 ENTRYPOINT ["docling-rs"]
 
-# --- ghcr.io/docling-project/docling-rs-serve: the HTTP API ------------------
+# --- ghcr.io/docling-project/docling-rs-serve: the HTTP API (CPU) -------------
 FROM runtime AS serve
 COPY --from=build /src/target/release/docling-serve /usr/local/bin/docling-serve
 # Assets resolve relative to the working directory (`.models/`, `.pdfium/lib`).
@@ -90,4 +140,23 @@ EXPOSE 5001
 HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=3 \
     CMD curl -f http://localhost:5001/ready || exit 1
 # Liveness: GET /health; readiness: GET /ready (503 until --warmup finishes).
+CMD ["docling-serve", "--addr", "0.0.0.0:5001", "--warmup"]
+
+# ==============================================================================
+# Final targets: CUDA GPU
+# ==============================================================================
+
+# --- ghcr.io/docling-project/docling-rs-cuda: the CLI (CUDA) ------------------
+FROM runtime-cuda AS cli-cuda
+COPY --from=build-cuda /src/target/release/docling-rs /usr/local/bin/docling-rs
+ENV DOCLING_RS_MODELS_DIR=/app/.models
+WORKDIR /data
+ENTRYPOINT ["docling-rs"]
+
+# --- ghcr.io/docling-project/docling-rs-serve-cuda: the HTTP API (CUDA) --------
+FROM runtime-cuda AS serve-cuda
+COPY --from=build-cuda /src/target/release/docling-serve /usr/local/bin/docling-serve
+EXPOSE 5001
+HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=3 \
+    CMD curl -f http://localhost:5001/ready || exit 1
 CMD ["docling-serve", "--addr", "0.0.0.0:5001", "--warmup"]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,9 +12,10 @@ The following container images are published on **GitHub Container Registry (GHC
 
 | Image | Description | Architectures |
 |---|---|---|
-| [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed (zero Python runtime dependencies). | `linux/amd64`, `linux/arm64` |
-| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in: batch conversion of local files without installing Rust. Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
-
+| [`ghcr.io/docling-project/docling-rs-serve`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve) | High-performance document conversion HTTP API with PDF, DOCX, PPTX, XLSX, HTML, images, and audio/video models pre-installed (zero Python runtime dependencies, CPU). | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs) | The `docling-rs` CLI with the same models baked in: batch conversion of local files without installing Rust (CPU). Entrypoint `docling-rs`, working directory `/data`. | `linux/amd64`, `linux/arm64` |
+| [`ghcr.io/docling-project/docling-rs-serve-cuda`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-serve-cuda) | NVIDIA CUDA 12 GPU-accelerated HTTP conversion API (CUDA 12 + cuDNN 9, Linux x86_64). Explicit version tags (`v1.28.0`, `master`), no `:latest`. | `linux/amd64` |
+| [`ghcr.io/docling-project/docling-rs-cuda`](https://github.com/docling-project/docling.rs/pkgs/container/docling-rs-cuda) | NVIDIA CUDA 12 GPU-accelerated `docling-rs` CLI. Explicit version tags (`v1.28.0`, `master`), no `:latest`. | `linux/amd64` |
 > [!NOTE]
 > **Image Naming**: The `-rs` in `docling-rs-serve` / `docling-rs` differentiates this native Rust implementation from the Python `docling-project/docling-serve` image repository on GHCR. Both images are targets of the same [`Dockerfile`](../crates/docling-serve/Dockerfile) and share every layer but the final binary.
 
@@ -37,12 +38,15 @@ docker run --rm -v "$PWD:/data" ghcr.io/docling-project/docling-rs:latest --inpu
 
 #### Tagging Scheme
 
-- `latest`: Latest release or master build
-- `v1.24.0`, `1.24.0`: Exact release version
-- `1.24`, `1`: Floating major/minor tags
-- `master`: Bleeding-edge master branch build
-
-The default image has the full native ML pipeline baked in (ffmpeg, pdfium, and the ONNX models for RT-DETR layout detection, TableFormer table structure, PP-OCRv3 recognition, and chunk tokenization) with **zero Python dependencies at runtime**.
+- **CPU images (`docling-rs-serve`, `docling-rs`)**:
+  - `latest`: Latest release or master build
+  - `v1.28.0`, `1.28.0`: Exact release version
+  - `1.28`, `1`: Floating major/minor tags
+  - `master`: Bleeding-edge master branch build
+- **CUDA GPU images (`docling-rs-serve-cuda`, `docling-rs-cuda`)**:
+  - `v1.28.0`, `1.28.0`, `1.28`, `1`: Explicit release version tags
+  - `master`: Master branch build
+  - *(No floating `:latest` tag, following upstream docling-serve CUDA tagging policy)*
 
 ---
 
@@ -131,9 +135,16 @@ For production setups needing automatic TLS certificates, Basic Auth, or header 
 cd examples/docker-compose
 docker compose -f docker-compose.caddy.yml up -d
 ```
+### NVIDIA CUDA GPU Stack (`docker-compose.cuda.yml`)
+
+For hosts equipped with NVIDIA GPUs and the NVIDIA Container Toolkit:
+
+```bash
+cd examples/docker-compose
+docker compose -f docker-compose.cuda.yml up -d
+```
 
 ---
-
 ## Configuration & Environment Variables
 
 `docling-serve` is configured via CLI arguments and environment variables:

--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -2,9 +2,15 @@
 # docling-serve Docker Compose Environment Configuration
 # ==============================================================================
 
-# Container image from GitHub Container Registry (ghcr.io)
-# Use explicit tags (e.g. v1.24.0) for production reproducibility or 'latest'
-DOCLING_IMAGE=ghcr.io/docling-project/docling-serve-rs:latest
+# CPU Container image from GitHub Container Registry (ghcr.io)
+# Use explicit tags (e.g. v1.28.0) for production reproducibility or 'latest'
+DOCLING_IMAGE=ghcr.io/docling-project/docling-rs-serve:latest
+
+# CUDA GPU Container image (for docker-compose.cuda.yml)
+# Following upstream docling-serve policy, CUDA images do not have a floating :latest tag.
+# Use an explicit release tag (e.g. v1.28.0) or 'master'.
+DOCLING_CUDA_IMAGE=ghcr.io/docling-project/docling-rs-serve-cuda
+DOCLING_CUDA_TAG=master
 
 # Host port mapping (binds to loopback 127.0.0.1 for security)
 PORT=5001
@@ -22,7 +28,7 @@ DOCLING_RS_MEMORY_WATERMARK_PCT=85
 # Logging level: trace | debug | info | warn | error
 RUST_LOG=info
 
-# Container resource limits (Docker deploy resources)
+# Container resource limits (Docker deploy resources for CPU stack)
 CPU_LIMIT=4.0
 MEMORY_LIMIT=4G
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -2,7 +2,7 @@
 
 This directory provides ready-to-use Docker Compose configurations for running the **`docling-serve`** HTTP conversion service.
 
-## Quick Start (Standalone Service)
+## Quick Start (Standalone CPU Service)
 
 1. Copy `.env.example` to `.env` (optional, to customize settings):
 
@@ -21,6 +21,7 @@ This directory provides ready-to-use Docker Compose configurations for running t
    ```bash
    curl http://localhost:5001/ready
    # => {"status":"ready"}
+   ```
 
 4. Convert a document:
 
@@ -32,6 +33,24 @@ This directory provides ready-to-use Docker Compose configurations for running t
 
    ```bash
    docker compose down
+   ```
+
+---
+
+## NVIDIA CUDA GPU Deployment
+
+For hosts equipped with NVIDIA GPUs and the NVIDIA Container Toolkit:
+
+1. Launch with `docker-compose.cuda.yml`:
+
+   ```bash
+   docker compose -f docker-compose.cuda.yml up -d
+   ```
+
+2. Verify GPU detection in the container logs:
+
+   ```bash
+   docker compose -f docker-compose.cuda.yml logs
    ```
 
 ---
@@ -76,6 +95,7 @@ Key environment variables:
 | Variable | Default | Purpose |
 |---|---|---|
 | `CONCURRENCY` | `2` | Max simultaneous document conversions in flight |
+| `DOCLING_RS_EP` | `auto` | Execution provider (`auto`, `cuda`, `cpu`) |
 | `DOCLING_RS_MAX_MEMORY_MB` | `4096` | Process RSS ceiling before returning HTTP 503 (prevents OOM) |
 | `DOCLING_RS_NO_ARENA` | `1` | Disables ONNX Runtime CPU arena to keep memory compact |
 | `RUST_LOG` | `info` | Logging verbosity (`error`, `warn`, `info`, `debug`, `trace`) |

--- a/examples/docker-compose/docker-compose.cuda.yml
+++ b/examples/docker-compose/docker-compose.cuda.yml
@@ -44,7 +44,12 @@ services:
       start_period: 45s
     deploy:
       resources:
+        limits:
+          cpus: "${CPU_LIMIT:-8.0}"
+          memory: "${MEMORY_LIMIT:-8G}"
         reservations:
+          cpus: "2.0"
+          memory: "2G"
           devices:
             - driver: nvidia
               count: all

--- a/examples/docker-compose/docker-compose.cuda.yml
+++ b/examples/docker-compose/docker-compose.cuda.yml
@@ -1,0 +1,51 @@
+# NVIDIA CUDA 12 GPU deployment for docling-serve
+#
+# Requires:
+#   - NVIDIA GPU (Turing / Ampere / Ada / Hopper / Blackwell)
+#   - NVIDIA Container Toolkit installed on host
+#   - Host driver >= 525 (CUDA 12 compatible)
+#
+# Run:
+#   docker compose -f docker-compose.cuda.yml up -d
+#
+# Note: Following upstream docling-serve CUDA tagging policy, the CUDA image does
+# not use floating :latest tags. Set DOCLING_CUDA_TAG to a specific version or master.
+
+services:
+  docling-serve-cuda:
+    image: ${DOCLING_CUDA_IMAGE:-ghcr.io/docling-project/docling-rs-serve-cuda}:${DOCLING_CUDA_TAG:-master}
+    container_name: docling-serve-cuda
+    restart: unless-stopped
+    ports:
+      # Bind to loopback interface only — front with a reverse proxy before exposing externally
+      - "127.0.0.1:${PORT:-5001}:5001"
+    environment:
+      # Automatically use GPU when available, fallback to CPU:
+      - DOCLING_RS_EP=auto
+      # Disable ONNX Runtime CPU arena to avoid RSS heap ratcheting (#263)
+      - DOCLING_RS_NO_ARENA=1
+      # Memory ceiling for admission control (MB); returns 503 + Retry-After when near watermark
+      - DOCLING_RS_MAX_MEMORY_MB=${DOCLING_RS_MAX_MEMORY_MB:-8192}
+      - DOCLING_RS_MEMORY_WATERMARK_PCT=${DOCLING_RS_MEMORY_WATERMARK_PCT:-85}
+      # Structured logs level: trace | debug | info | warn | error
+      - RUST_LOG=${RUST_LOG:-info}
+    command:
+      - "docling-serve"
+      - "--addr"
+      - "0.0.0.0:5001"
+      - "--concurrency"
+      - "${CONCURRENCY:-4}"
+      - "--warmup"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/ready"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 45s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
### Overview

Following up on #315 and commit 8620c2b, this PR adds NVIDIA CUDA 12 GPU-accelerated container images for both the HTTP API and the CLI:
- **`ghcr.io/docling-project/docling-rs-serve-cuda`**: CUDA HTTP conversion API
- **`ghcr.io/docling-project/docling-rs-cuda`**: CUDA `docling-rs` CLI for local GPU file conversion

### Design & Implementation

1. **Multi-Target Dockerfile (`crates/docling-serve/Dockerfile`)**:
   - Added `build-cuda` stage using `cargo-chef` with `--features cuda` and `-Wl,-rpath,/usr/local/lib`.
   - Copies the prebuilt ONNX Runtime CUDA provider shared libraries (`libonnxruntime_providers_shared.so` and `libonnxruntime_providers_cuda.so`) into `/usr/local/lib/`.
   - Uses `nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04` as the `runtime-cuda` base (providing `libcudart.so.12` and cuDNN 9 on Ubuntu 24.04, satisfying glibc ≥ 2.38 and GCC 14 `GLIBCXX_3.4.33`).
   - Exports two new targets: `serve-cuda` and `cli-cuda`.
   - Defaults `DOCLING_RS_EP=auto`: runs on GPU when available and falls back to CPU automatically.

2. **Publishing Workflow (`.github/workflows/docker-publish.yml`)**:
   - Structured into clean, decoupled jobs: `build-cpu`, `merge-cpu`, and `build-and-publish-cuda`.
   - Target platform: `linux/amd64` on `ubuntu-latest`.
   - **Tagging Policy (matching upstream docling-serve)**: CUDA images receive explicit release tags (`vX.Y.Z`, `X.Y`, `X`) and `master`, **intentionally excluding the floating `:latest` tag** to prevent breaking downstream deployments as host drivers age.
   - Generates OIDC/Sigstore build provenance attestations for both CUDA images.
   - Added `cuda` toggle input to `workflow_dispatch` (default `true`).

3. **Docker Compose (`examples/docker-compose/`)**:
   - Added `docker-compose.cuda.yml` with NVIDIA Container Toolkit GPU device reservations (`driver: nvidia`, `capabilities: [gpu]`).
   - Updated `.env.example` with `DOCLING_CUDA_IMAGE` and `DOCLING_CUDA_TAG` (`master` default).
   - Documented GPU compose startup in `examples/docker-compose/README.md`.

4. **Documentation (`README.md` & `docs/DEPLOYMENT.md`)**:
   - Added `docling-rs-serve-cuda` and `docling-rs-cuda` to the `#### 📦 Distributed Images` tables.
   - Documented the CUDA tagging policy and provided `docker run --gpus all` commands for both the server and the CLI.

### Verification

- Passed `cargo test --lib --tests -p docling-serve` (67/67 tests passed).
- Passed `cargo fmt --all -- --check`.