### PR TITLE
feat(html): carry rich table cells as cell_blocks — nested lists / tables / headings inside <td> reach DocLang and LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ inline formatting as `\textbf{}` / `\textit{}` / `\sout{}` / `\texttt{}` /
 
 Scored against Python docling's **own** `docling --to latex` output on the
 shared declarative corpus (md, docx, html, pptx, xlsx, asciidoc, csv, webvtt,
-jats): **89 of 116 fixtures byte-exact**, 94 once upstream's duplicated
+jats): **93 of 116 fixtures byte-exact**, 98 once upstream's duplicated
 formatted list items / headings are normalized away (see below). The
 remaining differences are model gaps rather than serializer bugs: underline
 and sub/superscript have no Markdown form and stay plain text; HTML rich

--- a/crates/docling-core/src/doclang.rs
+++ b/crates/docling-core/src/doclang.rs
@@ -866,8 +866,20 @@ fn emit_nodes(out: &mut Out, depth: i32, nodes: &[Node], i: &mut usize, level: u
             }
             // Classifier predictions are JSON-only; DocLang keeps the plain
             // `<picture>` shape.
-            Node::Picture { caption, image, .. } => {
-                emit_picture(out, depth, caption.as_deref(), image.as_ref(), None);
+            Node::Picture {
+                caption,
+                caption_href,
+                image,
+                ..
+            } => {
+                emit_picture(
+                    out,
+                    depth,
+                    caption.as_deref(),
+                    caption_href.as_deref(),
+                    image.as_ref(),
+                    None,
+                );
                 *i += 1;
             }
             Node::Chart {
@@ -1409,6 +1421,7 @@ fn emit_picture(
     out: &mut Out,
     depth: i32,
     caption: Option<&str>,
+    caption_href: Option<&str>,
     image: Option<&crate::document::PictureImage>,
     location: Option<&[u16; 4]>,
 ) {
@@ -1436,15 +1449,23 @@ fn emit_picture(
         out.push(depth + 1, format!("<src uri=\"{}\"/>", attr_escape(&s)));
     }
     if let Some(c) = caption {
-        emit_caption(out, depth + 1, c);
+        emit_caption(out, depth + 1, c, caption_href);
     }
     out.push(depth, "</picture>".to_string());
 }
 
 /// A `<caption>` — inline when plain text, or block form with an `<href uri=…/>`
-/// head + anchor text when the caption is a single Markdown link (docling's
-/// linked image captions).
-fn emit_caption(out: &mut Out, depth: i32, text: &str) {
+/// head + caption text when the caption carries a hyperlink annotation
+/// (`href` — an `<a href>` wrapped the image, #328) or *is* a single Markdown
+/// link (docling's linked image captions).
+fn emit_caption(out: &mut Out, depth: i32, text: &str, href: Option<&str>) {
+    if let Some(uri) = href {
+        out.push(depth, "<caption>".to_string());
+        out.push(depth + 1, format!("<href uri=\"{}\"/>", attr_escape(uri)));
+        out.push(depth + 1, escape_text(text));
+        out.push(depth, "</caption>".to_string());
+        return;
+    }
     if let Some(Run::Link { anchor, uri }) = inline_runs(text).into_iter().next() {
         if inline_runs(text).len() == 1 {
             out.push(depth, "<caption>".to_string());
@@ -1500,11 +1521,17 @@ fn emit_located(out: &mut Out, depth: i32, location: &[u16; 4], inner: &Node) {
         Node::Paragraph { text } => {
             emit_text_element(out, depth, "text", "text", text, Some(location));
         }
-        Node::Picture { caption, image, .. } => {
+        Node::Picture {
+            caption,
+            caption_href,
+            image,
+            ..
+        } => {
             emit_picture(
                 out,
                 depth,
                 caption.as_deref(),
+                caption_href.as_deref(),
                 image.as_ref(),
                 Some(location),
             );

--- a/crates/docling-core/src/doctags.rs
+++ b/crates/docling-core/src/doctags.rs
@@ -620,6 +620,7 @@ fn parse_picture(toks: &[Tok], i: &mut usize, out: &mut Vec<Node>, close: &str) 
     out.push(located(
         Node::Picture {
             caption,
+            caption_href: None,
             image: None,
             classification: None,
         },

--- a/crates/docling-core/src/document.rs
+++ b/crates/docling-core/src/document.rs
@@ -112,6 +112,13 @@ pub enum Node {
     /// it) the embedded image itself.
     Picture {
         caption: Option<String>,
+        /// Hyperlink annotation on the caption (docling's caption text item
+        /// `hyperlink`): the HTML backend sets it when an `<a href>` wraps the
+        /// image whose `alt` became the caption. DocLang emits the block-form
+        /// `<caption>` with an `<href uri=…/>` head; JSON puts `hyperlink` on
+        /// the caption item; Markdown and LaTeX print the plain caption text,
+        /// as docling does.
+        caption_href: Option<String>,
         image: Option<PictureImage>,
         /// DocumentPictureClassifier predictions (all classes, descending
         /// confidence), when the picture-classification enrichment ran.

--- a/crates/docling-core/src/json.rs
+++ b/crates/docling-core/src/json.rs
@@ -250,10 +250,12 @@ impl Builder {
             Node::Table(t) => Some(self.add_table(t, parent)),
             Node::Picture {
                 caption,
+                caption_href,
                 image,
                 classification,
             } => Some(self.add_picture(
                 caption.as_deref(),
+                caption_href.as_deref(),
                 image.as_ref(),
                 classification.as_deref(),
                 parent,
@@ -264,7 +266,7 @@ impl Builder {
                 caption, location, ..
             } => {
                 self.adopt_loc(*location);
-                Some(self.add_picture(caption.as_deref(), None, None, parent))
+                Some(self.add_picture(caption.as_deref(), None, None, None, parent))
             }
             // A DocLang-only node is omitted from the JSON body.
             Node::DoclangOnly(_) => None,
@@ -667,6 +669,7 @@ impl Builder {
     fn add_picture(
         &mut self,
         caption: Option<&str>,
+        caption_href: Option<&str>,
         image: Option<&crate::PictureImage>,
         classification: Option<&[crate::PictureClass]>,
         parent: &str,
@@ -677,8 +680,14 @@ impl Builder {
         let prov = self.take_prov(0);
         let mut captions = Vec::new();
         if let Some(cap) = caption.filter(|c| !c.is_empty()) {
-            // Emit the caption as a text item that the picture references.
-            let cap_ref = self.add_text("caption", cap, &self_ref, json!({}));
+            // Emit the caption as a text item that the picture references. A
+            // wrapping `<a href>`'s link rides as docling's `hyperlink` field
+            // on the caption item (#328).
+            let extra = match caption_href {
+                Some(href) => json!({ "hyperlink": href }),
+                None => json!({}),
+            };
+            let cap_ref = self.add_text("caption", cap, &self_ref, extra);
             captions.push(json!({ "$ref": cap_ref }));
         }
         // DocumentPictureClassifier predictions land twice, exactly like
@@ -896,6 +905,7 @@ mod tests {
         let mut doc = DoclingDocument::new("t");
         doc.push(Node::Picture {
             caption: Some("Fig 1".into()),
+            caption_href: None,
             image: Some(PictureImage {
                 mimetype: "image/png".into(),
                 width: 4,

--- a/crates/docling-core/src/markdown.rs
+++ b/crates/docling-core/src/markdown.rs
@@ -1097,6 +1097,7 @@ mod tests {
         }));
         doc.push(Node::Picture {
             caption: Some("Fig 1".into()),
+            caption_href: None,
             image: Some(PictureImage {
                 mimetype: "image/png".into(),
                 width: 2,
@@ -1110,6 +1111,7 @@ mod tests {
         // (`image_000001`) across chunk boundaries.
         doc.push(Node::Picture {
             caption: None,
+            caption_href: None,
             image: Some(PictureImage {
                 mimetype: "image/png".into(),
                 width: 2,

--- a/crates/docling-pdf/src/assemble.rs
+++ b/crates/docling-pdf/src/assemble.rs
@@ -2277,6 +2277,7 @@ pub fn assemble_page(
                 loc,
                 Node::Picture {
                     caption,
+                    caption_href: None,
                     image,
                     classification,
                 },
@@ -2420,6 +2421,7 @@ pub fn assemble_page(
                                 norm_loc(&regions[p], page.width, page_h),
                                 Node::Picture {
                                     caption: None,
+                                    caption_href: None,
                                     image,
                                     classification,
                                 },
@@ -3478,6 +3480,7 @@ mod tests {
             para("the wing type that is"),
             Node::Picture {
                 caption: None,
+                caption_href: None,
                 image: None,
                 classification: None,
             },

--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.21.0"
+version = "1.30.0"
 dependencies = [
  "calamine",
  "csv",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.21.0"
+version = "1.30.0"
 dependencies = [
  "docling-core",
  "docling-onnx",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.21.0"
+version = "1.30.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "docling-onnx"
-version = "1.21.0"
+version = "1.30.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.21.0"
+version = "1.30.0"
 dependencies = [
  "docling-core",
  "docling-onnx",

--- a/crates/docling-wasm/src/scanned.rs
+++ b/crates/docling-wasm/src/scanned.rs
@@ -400,6 +400,7 @@ mod picture_only {
             location: [1, 2, 3, 4],
             inner: Box::new(Node::Picture {
                 caption: None,
+                caption_href: None,
                 image: None,
                 classification: None,
             }),

--- a/crates/docling/src/backend/abw.rs
+++ b/crates/docling/src/backend/abw.rs
@@ -164,6 +164,7 @@ fn emit_paragraph(
             });
         doc.push(Node::Picture {
             caption: None,
+            caption_href: None,
             image,
             classification: None,
         });

--- a/crates/docling/src/backend/asciidoc.rs
+++ b/crates/docling/src/backend/asciidoc.rs
@@ -123,6 +123,7 @@ impl Parser {
             let _ = caption; // alt text is not rendered by docling's markdown export
             self.deferred.push(Node::Picture {
                 caption: cap,
+                caption_href: None,
                 image: None,
                 classification: None,
             });

--- a/crates/docling/src/backend/deepseek.rs
+++ b/crates/docling/src/backend/deepseek.rs
@@ -151,6 +151,7 @@ fn emit(label: &str, content: &str, caption: Option<String>, doc: &mut DoclingDo
     match label {
         "figure" | "image" => doc.push(Node::Picture {
             caption,
+            caption_href: None,
             image: None,
             classification: None,
         }),

--- a/crates/docling/src/backend/doc.rs
+++ b/crates/docling/src/backend/doc.rs
@@ -1010,6 +1010,7 @@ impl NodeBuilder {
 
         let picture_node = |image: Option<PictureImage>| Node::Picture {
             caption: None,
+            caption_href: None,
             image,
             classification: None,
         };

--- a/crates/docling/src/backend/doclang.rs
+++ b/crates/docling/src/backend/doclang.rs
@@ -890,6 +890,7 @@ fn parse_picture(el: XmlNode) -> Node {
         .and_then(parse_layer);
     let picture = Node::Picture {
         caption,
+        caption_href: None,
         image: None,
         classification: None,
     };

--- a/crates/docling/src/backend/docling_json.rs
+++ b/crates/docling/src/backend/docling_json.rs
@@ -268,6 +268,7 @@ fn picture_item(item: &Value, root: &Value, doc: &mut DoclingDocument) {
     // docling renders the image marker first, then each caption as a paragraph.
     doc.push(Node::Picture {
         caption: None,
+        caption_href: None,
         image: None,
         classification: None,
     });

--- a/crates/docling/src/backend/docx.rs
+++ b/crates/docling/src/backend/docx.rs
@@ -400,6 +400,7 @@ fn handle_paragraph_inner(
                 for image in drawing_images(tp, ctx, false) {
                     doc.push(Node::Picture {
                         caption: None,
+                        caption_href: None,
                         image,
                         classification: None,
                     });
@@ -419,6 +420,7 @@ fn handle_paragraph_inner(
     for image in drawing_images(p, ctx, true) {
         doc.push(Node::Picture {
             caption: None,
+            caption_href: None,
             image,
             classification: None,
         });

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -273,6 +273,7 @@ fn walk_block(
                     flush_inline(&mut inline, nodes);
                     nodes.push(Node::Picture {
                         caption: e.attr("alt").filter(|a| !a.is_empty()).map(str::to_string),
+                        caption_href: None,
                         image: img_src(e).and_then(|s| images.resolve(&s)),
                         classification: None,
                     });
@@ -281,6 +282,7 @@ fn walk_block(
                     flush_inline(&mut inline, nodes);
                     nodes.push(Node::Picture {
                         caption: None,
+                        caption_href: None,
                         image: None,
                         classification: None,
                     });
@@ -294,10 +296,19 @@ fn walk_block(
                     if let Some((caption, src)) = image_wrapper(cref) {
                         // An anchor wrapping only an image (`<a><img></a>`):
                         // docling pulls the image out as a Picture and drops the
-                        // wrapper.
+                        // wrapper — but the anchor's href survives as the
+                        // caption's hyperlink annotation (docling hangs it on
+                        // the caption text item; no caption, nowhere to hang).
                         flush_inline(&mut inline, nodes);
+                        let caption_href = caption
+                            .is_some()
+                            .then(|| e.attr("href"))
+                            .flatten()
+                            .filter(|h| !h.is_empty())
+                            .map(normalize_url);
                         nodes.push(Node::Picture {
                             caption,
+                            caption_href,
                             image: src.as_deref().and_then(|s| images.resolve(s)),
                             classification: None,
                         });
@@ -446,6 +457,10 @@ fn handle_block(
             if has_descendant(elem, "img") {
                 nodes.push(Node::Picture {
                     caption: figure_caption(elem),
+                    // docling annotates the caption item with the first link
+                    // *inside the figcaption* (`find_parent_annotation`); the
+                    // caption text itself stays plain.
+                    caption_href: figcaption_href(elem),
                     image: figure_img_src(elem).and_then(|s| images.resolve(&s)),
                     classification: None,
                 });
@@ -1609,6 +1624,18 @@ fn image_wrapper(elem: ElementRef) -> Option<(Option<String>, Option<String>)> {
     Some((caption, src))
 }
 
+/// The first `<a href>` inside a figure's `<figcaption>` — docling's caption
+/// hyperlink annotation (the caption text keeps the anchor text inline, the
+/// href rides on the caption item).
+fn figcaption_href(fig: ElementRef) -> Option<String> {
+    let figcaption = fig.select(cached_selector!("figcaption")).next()?;
+    figcaption
+        .select(cached_selector!("a"))
+        .find_map(|a| a.value().attr("href"))
+        .filter(|h| !h.is_empty())
+        .map(normalize_url)
+}
+
 /// The image URL of a `<figure>`'s first `<img>`, for image extraction.
 fn figure_img_src(fig: ElementRef) -> Option<String> {
     fig.select(cached_selector!("img"))
@@ -2011,6 +2038,45 @@ mod tests {
             doc.export_to_markdown().contains("P Q R a  b"),
             "newline flattened to space in markdown: {}",
             doc.export_to_markdown()
+        );
+    }
+
+    /// #328: an `<a href>` wrapping an image (or a link inside a figcaption)
+    /// rides as the caption's hyperlink annotation; the caption text and the
+    /// Markdown stay plain, and a bare authority is normalized like AnyUrl.
+    #[test]
+    fn caption_hyperlinks_are_annotated() {
+        let doc = convert(
+            "<a href=\"https://www.example.com\"><img src=\"x.png\" alt=\"Clickable\"></a>             <figure><img src=\"y.png\" alt=\"Cap\">               <figcaption>An example <a href=\"#caption\">caption</a> here.</figcaption>             </figure>",
+        );
+        let hrefs: Vec<_> = doc
+            .nodes
+            .iter()
+            .filter_map(|n| match n {
+                Node::Picture {
+                    caption,
+                    caption_href,
+                    ..
+                } => Some((caption.clone(), caption_href.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            hrefs,
+            vec![
+                (
+                    Some("Clickable".into()),
+                    Some("https://www.example.com/".into())
+                ),
+                (
+                    Some("An example caption here.".into()),
+                    Some("#caption".into())
+                ),
+            ]
+        );
+        assert_eq!(
+            doc.export_to_markdown(),
+            "Clickable\n\n<!-- image -->\n\nAn example caption here.\n\n<!-- image -->\n"
         );
     }
 

--- a/crates/docling/src/backend/html.rs
+++ b/crates/docling/src/backend/html.rs
@@ -403,9 +403,12 @@ fn handle_block(
             let mut runs = RunBuf::default();
             collect_runs(elem, Fmt { code: true, ..base }, None, &mut runs);
             if runs.md.len() > 1 {
-                nodes.push(Node::Paragraph {
-                    text: runs.md.join(" "),
-                });
+                // Keep the structured runs, not just their Markdown join: each
+                // segment is a code run (docling emits `<code>See</code>
+                // <code>the docs</code>…`), and re-parsing the joined text
+                // would lose the code flag on a linked segment and split the
+                // separators into their own plain runs.
+                push_inline_paragraph(nodes, runs.md.join(" "), std::mem::take(&mut runs.rich));
             } else {
                 let (language, text) = extract_pre(elem);
                 nodes.push(Node::Code {
@@ -1237,7 +1240,7 @@ fn lang_from_class(class: &str) -> Option<String> {
 }
 
 fn parse_table(table: ElementRef) -> Option<Table> {
-    parse_table_cells(table, |cell| (render_cell(cell), is_rich_cell(cell)))
+    parse_table_cells(table, render_cell)
 }
 
 /// Flatten a table nested inside another table's cell, the way docling's
@@ -1252,7 +1255,8 @@ fn flatten_nested_table(table: ElementRef) -> String {
     parse_table_cells(table, |cell| {
         let mut out = String::new();
         subtree_text(cell, &mut out);
-        (out.trim().to_string(), false)
+        // Flattening feeds an enclosing cell's *text*; no block content.
+        (out.trim().to_string(), false, Vec::new())
     })
     .map(|t| {
         t.rows
@@ -1316,9 +1320,13 @@ fn subtree_text(elem: ElementRef, out: &mut String) {
     }
 }
 
+/// Build a table's grid from its `<tr>`s. `render_cell` yields each cell's
+/// flat Markdown text, whether the cell is *rich* (docling's `RichTableCell`),
+/// and — for a rich cell — its structured block content for
+/// [`Table::cell_blocks`] (empty otherwise).
 fn parse_table_cells(
     table: ElementRef,
-    render_cell: impl Fn(ElementRef) -> (String, bool),
+    render_cell: impl Fn(ElementRef) -> (String, bool, Vec<Node>),
 ) -> Option<Table> {
     // Collect this table's own rows without descending into nested tables (a
     // recursive `select` would pull a nested table's cells into the outer grid).
@@ -1374,6 +1382,11 @@ fn parse_table_cells(
     // the DocLang `lcel`/`ucel` tokens.
     let mut col_cont: Vec<Vec<bool>> = vec![vec![false; num_cols]; num_rows];
     let mut row_cont: Vec<Vec<bool>> = vec![vec![false; num_cols]; num_rows];
+    // Parallel per-cell block content for rich cells (#328), indexed like
+    // `grid`. Empty for plain cells; `None` on the table when no cell is rich,
+    // exactly as the docx/odf backends do.
+    let mut blocks: Vec<Vec<Vec<Node>>> = vec![vec![Vec::new(); num_cols]; num_rows];
+    let mut any_rich = false;
     let mut row_idx: isize = -1;
     let mut start_row_span: usize = 0;
     for tr in &trs {
@@ -1401,8 +1414,9 @@ fn parse_table_cells(
             while col < num_cols && base < num_rows && grid[base][col].is_some() {
                 col += 1;
             }
-            let (text, rich) = render_cell(cell);
+            let (text, rich, cell_nodes) = render_cell(cell);
             let is_th = cell.value().name() == "th" && all_th;
+            any_rich |= !cell_nodes.is_empty();
             let mut anchor_filled = false;
             for r in start_row_span..start_row_span + rowspan {
                 let gr = (row_idx + r as isize).max(0) as usize;
@@ -1418,6 +1432,13 @@ fn parse_table_cells(
                         } else {
                             text.clone()
                         });
+                        // The blocks live on the anchor slot only: a covered
+                        // position is a continuation token in DocLang and
+                        // repeats nothing, matching how a rich cell's *text*
+                        // is serialized once (the visited set blanks the rest).
+                        if !anchor_filled && !cell_nodes.is_empty() {
+                            blocks[gr][gc] = cell_nodes.clone();
+                        }
                         anchor_filled = true;
                         th_grid[gr][gc] = is_th;
                         col_cont[gr][gc] = dc > 0;
@@ -1442,7 +1463,7 @@ fn parse_table_cells(
             row_continuation: row_cont,
             ..Default::default()
         }),
-        cell_blocks: None,
+        cell_blocks: any_rich.then_some(blocks),
         cells: None,
         caption: None,
     })
@@ -1477,22 +1498,50 @@ fn span_attr(cell: ElementRef, name: &str) -> usize {
 /// when it carries structure; a single plain run is emitted as plain text.
 /// Either way inline text is left unescaped; the table serializer flattens
 /// newlines to spaces.
-fn render_cell(cell: ElementRef) -> String {
+/// One table cell: its flat Markdown text (what `rows` — and so Markdown and
+/// JSON — carry), whether it is *rich*, and a rich cell's structured blocks
+/// for [`Table::cell_blocks`] (#328).
+///
+/// The two are produced by *separate* walks on purpose. The text walk is `raw`
+/// (no Markdown escaping, nested tables flattened to their joined cell text) so
+/// the flat rendering stays byte-identical to docling's. The block walk is an
+/// ordinary one: a nested `<table>` stays a real [`Node::Table`], a list stays
+/// list items, a heading stays a heading — which is what the DocLang and LaTeX
+/// serializers render, matching upstream's `RichTableCell`.
+fn render_cell(cell: ElementRef) -> (String, bool, Vec<Node>) {
     let raw = Fmt {
         raw: true,
         ..Fmt::default()
     };
-    if is_rich_cell(cell) {
-        let mut nodes: Vec<Node> = Vec::new();
-        // Images inside table cells stay placeholders (they fold into cell text).
-        walk_block(cell, &mut nodes, 0, raw, &NoFetch);
-        let mut doc = DoclingDocument::new("");
-        doc.nodes = nodes;
-        // In-cell rendering: a heading inside the cell is plain text
-        // (docling-core#540).
-        doc.export_to_table_cell_markdown().trim().to_string()
-    } else {
-        render_inline_fmt(cell, raw)
+    if !is_rich_cell(cell) {
+        return (render_inline_fmt(cell, raw), false, Vec::new());
+    }
+    let mut nodes: Vec<Node> = Vec::new();
+    // Images inside table cells stay placeholders (they fold into cell text).
+    walk_block(cell, &mut nodes, 0, raw, &NoFetch);
+    let mut doc = DoclingDocument::new("");
+    doc.nodes = nodes;
+    // In-cell rendering: a heading inside the cell is plain text
+    // (docling-core#540).
+    let text = doc.export_to_table_cell_markdown().trim().to_string();
+
+    let mut blocks: Vec<Node> = Vec::new();
+    walk_block(cell, &mut blocks, 0, Fmt::default(), &NoFetch);
+    wrap_cell_inline_groups(&mut blocks);
+    (text, true, blocks)
+}
+
+/// Inside a table cell an inline group is always `<text>`-wrapped: docling
+/// serializes the cell's `InlineGroup` as its own text item. Only the *body*
+/// unwraps a group that follows a heading ([`push_inline_paragraph`]), and a
+/// heading inside a cell must not drag that rule in with it.
+fn wrap_cell_inline_groups(nodes: &mut [Node]) {
+    for node in nodes {
+        match node {
+            Node::InlineGroup { unwrapped, .. } => *unwrapped = false,
+            Node::Group { children, .. } => wrap_cell_inline_groups(children),
+            _ => {}
+        }
     }
 }
 
@@ -1633,6 +1682,10 @@ fn cell_richness(cell: ElementRef) -> (usize, bool) {
                     let Some(cref) = ElementRef::wrap(child) else {
                         continue;
                     };
+                    // docling's `_FORMAT_TAG_MAP` (plus `<a>`, whose hyperlink
+                    // makes a lone run rich): underline and sub/superscript
+                    // count even though Markdown has no marker for them — the
+                    // formatting still reaches DocLang and LaTeX.
                     let marks = matches!(
                         e.name(),
                         "b" | "strong"
@@ -1642,6 +1695,10 @@ fn cell_richness(cell: ElementRef) -> (usize, bool) {
                             | "s"
                             | "del"
                             | "strike"
+                            | "u"
+                            | "ins"
+                            | "sub"
+                            | "sup"
                             | "code"
                             | "kbd"
                             | "samp"
@@ -1955,6 +2012,55 @@ mod tests {
             "newline flattened to space in markdown: {}",
             doc.export_to_markdown()
         );
+    }
+
+    /// #328: a rich cell carries its structured blocks in `cell_blocks` —
+    /// a list stays list items, a heading stays a heading (Markdown text
+    /// unchanged: the flat `rows` grid still holds the flattened rendering).
+    #[test]
+    fn rich_cells_carry_cell_blocks() {
+        let doc = convert(
+            "<table>               <tr><td>plain</td><td><ul><li>a</li><li>b</li></ul></td></tr>               <tr><td><h2>A</h2><p>text</p></td><td>x</td></tr>             </table>",
+        );
+        let table = doc
+            .nodes
+            .iter()
+            .find_map(|n| match n {
+                Node::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("a table");
+        assert_eq!(table.rows[0][1], "- a\n- b");
+        assert_eq!(table.rows[1][0], "A\n\ntext");
+        let blocks = table.cell_blocks.as_ref().expect("rich cells present");
+        assert!(blocks[0][0].is_empty(), "plain cell stays block-less");
+        assert!(
+            matches!(
+                blocks[0][1].as_slice(),
+                [Node::ListItem { .. }, Node::ListItem { .. }]
+            ),
+            "list cell keeps its items: {:?}",
+            blocks[0][1]
+        );
+        assert!(
+            matches!(
+                blocks[1][0].as_slice(),
+                [Node::Heading { level: 2, .. }, Node::Paragraph { .. }]
+            ),
+            "heading cell keeps its structure: {:?}",
+            blocks[1][0]
+        );
+        // A table with no rich cell keeps `cell_blocks: None` (docx/odf rule).
+        let doc = convert("<table><tr><td>a</td><td>b</td></tr></table>");
+        let table = doc
+            .nodes
+            .iter()
+            .find_map(|n| match n {
+                Node::Table(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
+        assert!(table.cell_blocks.is_none());
     }
 
     #[test]

--- a/crates/docling/src/backend/jats.rs
+++ b/crates/docling/src/backend/jats.rs
@@ -805,6 +805,7 @@ fn add_figure(doc: &mut DoclingDocument, node: XmlNode) {
     let fig_text = format!("{label}{sep}{caption}");
     doc.push(Node::Picture {
         caption: (!fig_text.is_empty()).then(|| escape_text(&fig_text)),
+        caption_href: None,
         image: None,
         classification: None,
     });

--- a/crates/docling/src/backend/odf.rs
+++ b/crates/docling/src/backend/odf.rs
@@ -644,6 +644,7 @@ fn odf_picture(styles: &Styles, img: XmlNode) -> Option<Node> {
     let picture = |image: Option<PictureImage>| {
         Some(Node::Picture {
             caption: None,
+            caption_href: None,
             image,
             classification: None,
         })

--- a/crates/docling/src/backend/pptx.rs
+++ b/crates/docling/src/backend/pptx.rs
@@ -423,6 +423,7 @@ fn handle_shape(
                     shape_location(shape, slide_size, phmap),
                     Node::Picture {
                         caption: None,
+                        caption_href: None,
                         image: images.get(&rid).cloned(),
                         classification: None,
                     },

--- a/crates/docling/src/backend/rtf.rs
+++ b/crates/docling/src/backend/rtf.rs
@@ -511,6 +511,7 @@ impl<'a> Parser<'a> {
         let (width, height) = image_size(mimetype, &data).unwrap_or((0, 0));
         doc.push(Node::Picture {
             caption: None,
+            caption_href: None,
             image: Some(PictureImage {
                 mimetype: mimetype.to_string(),
                 width,

--- a/crates/docling/src/backend/xlsx.rs
+++ b/crates/docling/src/backend/xlsx.rs
@@ -442,6 +442,7 @@ fn sheet_items<F: Fn(&str, &str) -> Vec<String> + Sync>(ctx: SheetCtx<'_, F>) ->
                             item.bbox,
                             Node::Picture {
                                 caption: None,
+                                caption_href: None,
                                 image: dimages.get(&rid).cloned(),
                                 classification: None,
                             },

--- a/crates/docling/src/video.rs
+++ b/crates/docling/src/video.rs
@@ -87,6 +87,7 @@ fn picture_node(frame: VideoFrame) -> Node {
     let (width, height) = png_size(&frame.png).unwrap_or((0, 0));
     Node::Picture {
         caption: Some(format!("[time: {}]", docling_asr::fmt_seconds(frame.ts))),
+        caption_href: None,
         image: Some(PictureImage {
             mimetype: "image/png".to_string(),
             width,

--- a/crates/docling/tests/data/html/expected/html_rich_table_cells.html.tex
+++ b/crates/docling/tests/data/html/expected/html_rich_table_cells.html.tex
@@ -24,7 +24,7 @@ Name & Habitat & Comment \\ \hline
 Wood Duck &  & Often seen near ponds. \\ \hline
 Mallard & Ponds, lakes, rivers & Quack \\ \hline
 Goose (not a duck!) & Water \& wetlands & \textbf{Large} , \textit{loud} , noisy , \sout{small} \\ \hline
-Teal & - Pond - Marsh - Riverbank & 1. Fly south in winter 2. Build nest on ground \\ \hline
+Teal & \begin{itemize} \item Pond \item Marsh \item Riverbank \end{itemize} & \begin{enumerate} \item Fly south in winter \item Build nest on ground \end{enumerate} \\ \hline
 \end{tabular}
 \end{table}
 
@@ -44,7 +44,7 @@ Oxyura (Benthic ducks) & Wigee, Banded Water-screw \\ \hline
 Action & Action \\ \hline
 \textbf{Swim} & Gracefully glide on H 2 O surfaces. \\ \hline
 \textit{Fly} &  \\ \hline
-Quack & Type Sound Short "quak" Long "quaaaaaack" \\ \hline
+Quack & \begin{table}[h] \begin{tabular}{|l|l|} \hline Type & Sound \\ \hline Short & "quak" \\ \hline Long & "quaaaaaack" \\ \hline \end{tabular} \end{table} \\ \hline
 \end{tabular}
 \end{table}
 
@@ -53,7 +53,7 @@ Quack & Type Sound Short "quak" Long "quaaaaaack" \\ \hline
 \hline
 Name & Description & Image \\ \hline
 Donald Duck & Cartoon character. & \href{https://en.wikipedia.org/wiki/Donald\_Duck\#/media/File:Donald\_Duck\_angry\_transparent\_background.png}{View PNG} \\ \hline
-White-headed duck & A small diving duck some 45 cm (18 in) long. & White-headed duck thumbnail  <!-- image --> \\ \hline
+White-headed duck & A small diving duck some 45 cm (18 in) long. & \begin{figure}[h] % image \caption{White-headed duck thumbnail} \end{figure} \\ \hline
 Mandarin Duck & Known for its striking plumage. & \href{https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandarin\_duck\_\%28Aix\_galericulata\%29.jpg/250px-Mandarin\_duck\_\%28Aix\_galericulata\%29.jpg}{View Full-Size Image} \\ \hline
 Unknown Duck & No photo available. &  \\ \hline
 \end{tabular}

--- a/crates/docling/tests/data/html/expected/hyperlink_05.html.json
+++ b/crates/docling/tests/data/html/expected/hyperlink_05.html.json
@@ -43,7 +43,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Clickable Example",
-      "text": "Clickable Example"
+      "text": "Clickable Example",
+      "hyperlink": "https://www.example.com/"
     },
     {
       "self_ref": "#/texts/1",
@@ -67,7 +68,8 @@
       "label": "caption",
       "prov": [],
       "orig": "This is an example caption for the image.",
-      "text": "This is an example caption for the image."
+      "text": "This is an example caption for the image.",
+      "hyperlink": "#caption"
     }
   ],
   "pictures": [

--- a/crates/docling/tests/data/html/expected/table_03.html.tex
+++ b/crates/docling/tests/data/html/expected/table_03.html.tex
@@ -23,7 +23,7 @@ This is the first paragraph.
 \begin{tabular}{|l|l|}
 \hline
 A & B \\ \hline
-- First item - Second item - Third item & 2... \\ \hline
+\begin{itemize} \item First item \item Second item \item Third item \end{itemize} & 2... \\ \hline
 \end{tabular}
 \end{table}
 

--- a/crates/docling/tests/data/html/expected/table_04.html.tex
+++ b/crates/docling/tests/data/html/expected/table_04.html.tex
@@ -23,7 +23,7 @@ This is the first paragraph.
 \begin{tabular}{|l|l|}
 \hline
 A & B \\ \hline
-Some text before list  - First item - Second item - Third item & 2... \\ \hline
+Some text before list  \begin{itemize} \item First item \item Second item \item Third item \end{itemize} & 2... \\ \hline
 \end{tabular}
 \end{table}
 

--- a/crates/docling/tests/data/html/expected/table_05.html.tex
+++ b/crates/docling/tests/data/html/expected/table_05.html.tex
@@ -23,7 +23,7 @@ This is the first paragraph.
 \begin{tabular}{|l|l|}
 \hline
 A & B \\ \hline
-A1 B1 C1 D1 E1 F1 & 2... \\ \hline
+\begin{table}[h] \begin{tabular}{|l|l|l|} \hline A1 & B1 & C1 \\ \hline D1 & E1 & F1 \\ \hline \end{tabular} \end{table} & 2... \\ \hline
 \end{tabular}
 \end{table}
 

--- a/crates/docling/tests/data/html/expected/table_06.html.tex
+++ b/crates/docling/tests/data/html/expected/table_06.html.tex
@@ -23,7 +23,7 @@ This is the first paragraph.
 \begin{tabular}{|l|l|}
 \hline
 A & B \\ \hline
-A1 B1 C1 D1 I II    III IV    V     E1 E2    E3 E4        VII VIII F1 & 2... \\ \hline
+\begin{table}[h] \begin{tabular}{|l|l|l|} \hline A1 & B1 & C1 \\ \hline D1 & \begin{table}[h] \begin{tabular}{|l|l|} \hline I & II \\ \hline III & IV \\ \hline V & \begin{table}[h] \begin{tabular}{|l|l|} \hline E1 & E2 \\ \hline E3 & E4 \\ \hline \end{tabular} \end{table} \\ \hline VII & VIII \\ \hline \end{tabular} \end{table} & F1 \\ \hline \end{tabular} \end{table} & 2... \\ \hline
 \end{tabular}
 \end{table}
 

--- a/crates/docling/tests/data/html/expected/table_with_heading_02.html.tex
+++ b/crates/docling/tests/data/html/expected/table_with_heading_02.html.tex
@@ -22,7 +22,7 @@ Before the table
 \begin{table}[h]
 \begin{tabular}{|l|l|}
 \hline
-A  text & B \\ \hline
+\section{A}  text & B \\ \hline
 1... & 2... \\ \hline
 \end{tabular}
 \end{table}

--- a/crates/docling/tests/data/html/expected/wiki_duck.html.json
+++ b/crates/docling/tests/data/html/expected/wiki_duck.html.json
@@ -4672,7 +4672,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Page semi-protected",
-      "text": "Page semi-protected"
+      "text": "Page semi-protected",
+      "hyperlink": "/wiki/Wikipedia:Protection_policy#semi"
     },
     {
       "self_ref": "#/texts/216",
@@ -4781,7 +4782,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Pacific black duck displaying the characteristic upending \"duck\"",
-      "text": "Pacific black duck displaying the characteristic upending \"duck\""
+      "text": "Pacific black duck displaying the characteristic upending \"duck\"",
+      "hyperlink": "/wiki/Pacific_black_duck"
     },
     {
       "self_ref": "#/texts/225",
@@ -4829,7 +4831,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Male mallard .",
-      "text": "Male mallard ."
+      "text": "Male mallard .",
+      "hyperlink": "/wiki/Mallard"
     },
     {
       "self_ref": "#/texts/229",
@@ -4841,7 +4844,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Wood ducks .",
-      "text": "Wood ducks ."
+      "text": "Wood ducks .",
+      "hyperlink": "/wiki/Wood_duck"
     },
     {
       "self_ref": "#/texts/230",
@@ -4878,7 +4882,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Mallard landing in approach",
-      "text": "Mallard landing in approach"
+      "text": "Mallard landing in approach",
+      "hyperlink": "/wiki/Mallard"
     },
     {
       "self_ref": "#/texts/233",
@@ -4927,7 +4932,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Male Mandarin duck",
-      "text": "Male Mandarin duck"
+      "text": "Male Mandarin duck",
+      "hyperlink": "/wiki/Mandarin_duck"
     },
     {
       "self_ref": "#/texts/237",
@@ -4988,7 +4994,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Flying steamer ducks in Ushuaia , Argentina",
-      "text": "Flying steamer ducks in Ushuaia , Argentina"
+      "text": "Flying steamer ducks in Ushuaia , Argentina",
+      "hyperlink": "/wiki/Flying_steamer_ducks"
     },
     {
       "self_ref": "#/texts/242",
@@ -5012,7 +5019,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Female mallard in Cornwall , England",
-      "text": "Female mallard in Cornwall , England"
+      "text": "Female mallard in Cornwall , England",
+      "hyperlink": "/wiki/Cornwall"
     },
     {
       "self_ref": "#/texts/244",
@@ -5062,7 +5070,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Pecten along the bill",
-      "text": "Pecten along the bill"
+      "text": "Pecten along the bill",
+      "hyperlink": "/wiki/Pecten_(biology)"
     },
     {
       "self_ref": "#/texts/248",
@@ -5159,7 +5168,8 @@
       "label": "caption",
       "prov": [],
       "orig": "A Muscovy duckling",
-      "text": "A Muscovy duckling"
+      "text": "A Muscovy duckling",
+      "hyperlink": "/wiki/Muscovy_duck"
     },
     {
       "self_ref": "#/texts/256",
@@ -5233,7 +5243,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Ringed teal",
-      "text": "Ringed teal"
+      "text": "Ringed teal",
+      "hyperlink": "/wiki/Ringed_teal"
     },
     {
       "self_ref": "#/texts/262",
@@ -5356,7 +5367,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Indian Runner ducks , a common breed of domestic ducks",
-      "text": "Indian Runner ducks , a common breed of domestic ducks"
+      "text": "Indian Runner ducks , a common breed of domestic ducks",
+      "hyperlink": "/wiki/Indian_Runner_duck"
     },
     {
       "self_ref": "#/texts/272",
@@ -5393,7 +5405,8 @@
       "label": "caption",
       "prov": [],
       "orig": "Three black-colored ducks in the coat of arms of Maaninka [ 49 ]",
-      "text": "Three black-colored ducks in the coat of arms of Maaninka [ 49 ]"
+      "text": "Three black-colored ducks in the coat of arms of Maaninka [ 49 ]",
+      "hyperlink": "/wiki/Maaninka"
     },
     {
       "self_ref": "#/texts/275",

--- a/crates/docling/tests/data/html/expected/wiki_duck.html.tex
+++ b/crates/docling/tests/data/html/expected/wiki_duck.html.tex
@@ -278,9 +278,9 @@ This article is about the bird. For duck as a food, see \href{/wiki/Duck\_as\_fo
 \begin{tabular}{|l|l|}
 \hline
 Duck & Duck \\ \hline
-<!-- image --> & <!-- image --> \\ \hline
+\begin{figure}[h] % image \end{figure} & <!-- image --> \\ \hline
 \href{/wiki/Bufflehead}{Bufflehead} ( \textit{Bucephala albeola} ) & \href{/wiki/Bufflehead}{Bufflehead} ( \textit{Bucephala albeola} ) \\ \hline
-\href{/wiki/Taxonomy\_(biology)}{Scientific classification}  Edit this classification  <!-- image --> & \href{/wiki/Taxonomy\_(biology)}{Scientific classification}  Edit this classification  <!-- image --> \\ \hline
+\href{/wiki/Taxonomy\_(biology)}{Scientific classification}  \begin{figure}[h] % image \caption{Edit this classification} \end{figure} & \href{/wiki/Taxonomy\_(biology)}{Scientific classification}  Edit this classification  <!-- image --> \\ \hline
 Domain: & \href{/wiki/Eukaryote}{Eukaryota} \\ \hline
 Kingdom: & \href{/wiki/Animal}{Animalia} \\ \hline
 Phylum: & \href{/wiki/Chordate}{Chordata} \\ \hline
@@ -578,9 +578,9 @@ The 1992 Disney film \href{/wiki/The\_Mighty\_Ducks\_(film)}{\textit{The Mighty 
 \begin{table}[h]
 \begin{tabular}{|l|l|}
 \hline
-\href{/wiki/Help:Authority\_control}{Authority control databases}  Edit this at Wikidata  <!-- image --> & \href{/wiki/Help:Authority\_control}{Authority control databases}  Edit this at Wikidata  <!-- image --> \\ \hline
-National & - \href{https://id.loc.gov/authorities/sh85039879}{United States} - \href{https://catalogue.bnf.fr/ark:/12148/cb119761481}{France} - \href{https://data.bnf.fr/ark:/12148/cb119761481}{BnF data} - \href{https://id.ndl.go.jp/auth/ndlna/00564819}{Japan} - \href{https://kopkatalogs.lv/F?func=direct\&local\_base=lnc10\&doc\_number=000090751\&P\_CON\_LNG=ENG}{Latvia} - \href{http://olduli.nli.org.il/F/?func=find-b\&local\_base=NLX10\&find\_code=UID\&request=987007565486205171}{Israel} \\ \hline
-Other & - \href{https://www.idref.fr/027796124}{IdRef} \\ \hline
+\href{/wiki/Help:Authority\_control}{Authority control databases}  \begin{figure}[h] % image \caption{Edit this at Wikidata} \end{figure} & \href{/wiki/Help:Authority\_control}{Authority control databases}  Edit this at Wikidata  <!-- image --> \\ \hline
+National & \begin{itemize} \item \href{https://id.loc.gov/authorities/sh85039879}{United States} \item \href{https://catalogue.bnf.fr/ark:/12148/cb119761481}{France} \item \href{https://data.bnf.fr/ark:/12148/cb119761481}{BnF data} \item \href{https://id.ndl.go.jp/auth/ndlna/00564819}{Japan} \item \href{https://kopkatalogs.lv/F?func=direct\&local\_base=lnc10\&doc\_number=000090751\&P\_CON\_LNG=ENG}{Latvia} \item \href{http://olduli.nli.org.il/F/?func=find-b\&local\_base=NLX10\&find\_code=UID\&request=987007565486205171}{Israel} \end{itemize} \\ \hline
+Other & \begin{itemize} \item \href{https://www.idref.fr/027796124}{IdRef} \end{itemize} \\ \hline
 \end{tabular}
 \end{table}
 

--- a/crates/docling/tests/data/mhtml/expected/cookbook_chicken_tikka-wikibooks.mhtml.tex
+++ b/crates/docling/tests/data/mhtml/expected/cookbook_chicken_tikka-wikibooks.mhtml.tex
@@ -138,10 +138,10 @@ From Wikibooks, open books for an open world
 \begin{tabular}{|l|l|}
 \hline
 Chicken Tikka & Chicken Tikka \\ \hline
-The cooked Chicken Tikka  <!-- image --> & The cooked Chicken Tikka  <!-- image --> \\ \hline
+\begin{figure}[h] % image \caption{The cooked Chicken Tikka} \end{figure} & The cooked Chicken Tikka  <!-- image --> \\ \hline
 Servings & 4 \\ \hline
 Time & 30 minutes \\ \hline
-Difficulty & Easy  <!-- image --> \\ \hline
+Difficulty & \begin{figure}[h] % image \caption{Easy} \end{figure} \\ \hline
 \end{tabular}
 \end{table}
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -51,7 +51,7 @@ bulk of the porting under review).
 | | |
 |---|---|
 | **What** | A Rust port of docling's converter, backends, and discriminative PDF/ASR pipelines; same `convert → DoclingDocument → export_to_markdown()/json()` shape, single static binary, no Python/torch at runtime |
-| **Conformance** | Declarative formats byte-for-byte vs *live* PyPI docling (most 100%, see §2); `.dclx` DocLang output ≈94% mean vs docling's own `.dclx`, OOXML all byte-exact (§2); PDF ML path 6/14 fixtures byte-exact, rest close; every optimization is gated on this not regressing |
+| **Conformance** | Declarative formats byte-for-byte vs *live* PyPI docling (most 100%, see §2); `.dclx` DocLang output ≈96% mean vs docling's own `.dclx`, OOXML all byte-exact (§2); PDF ML path 6/14 fixtures byte-exact, rest close; every optimization is gated on this not regressing |
 | **Performance** | PDF ML pipeline **4.3× faster warm / 4.7× end-to-end** than Python docling at 2.3–2.6× less peak RAM (INT8 + SIMD, conformance-validated); declarative formats 20–60× warm, ~60× less RAM; XLSX sheets / PPTX slides additionally fan out over rayon (~2–3× on many-sheet/slide files, conformance byte-identical); details + methodology in [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md) |
 | **Models** | docling's own checkpoints, no retraining: layout heron and TableFormer are format-converted to ONNX by `scripts/install/export_layout.py` / `export_tableformer.py` (CodeFormula by `export_code_formula.py`); PP-OCRv3 and Whisper tiny ship as their upstream ONNX exports; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
 | **Tracking upstream** | See [§9](#9-keeping-up-with-upstream-docling): conformance is measured against the *latest published* docling on demand, so an upstream release that changes output surfaces as a concrete per-fixture diff |
@@ -171,8 +171,14 @@ close — see `PDF_CONFORMANCE.md`. A deterministic snapshot baseline
 
 The `.dclx` DocLang output (§3) is scored against docling's own `.dclx` archives
 with `scripts/conformance/dclx_conformance.sh` — the extracted `document.xml`
-line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈94% mean over the
+line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈96% mean over the
 136-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format.
+HTML rich table cells (#328) carry their block content — lists, ordered lists,
+nested tables, headings, `<pre>` runs — as `Table::cell_blocks`, so the
+DocLang `<fcel/>` bodies match upstream's `RichTableCell` serialization
+(`table_03`–`table_06`, `table_with_heading_02`,
+`html_inline_group_in_table_cell` byte-exact; `html_rich_table_cells`' one
+residual is a picture-caption hyperlink, a model gap tracked separately).
 Robustness tracks docling-core 2.88/2.89 (#253): XML-illegal control
 characters serialize as visible `[U+XXXX]` markers, a literal `]]>` splits
 across CDATA sections, and deep section headers clamp to heading level 6
@@ -186,7 +192,7 @@ fragments as XML.
 | CSV / AsciiDoc / Email | **100%** | JATS | 95% |
 | XLSX | **100%** | Markdown | 92% |
 | DOCX / PPTX | **100%** | LaTeX | 91% |
-| USPTO | 98% | HTML | 88% |
+| USPTO | 98% | HTML | 96% |
 | ODF | 96% | WebVTT | 81% |
 
 This effort was tracked as
@@ -254,7 +260,7 @@ work (checkbox inputs, fragmented-anchor folding, `<button>` blocks) plus the
 | **Markdown (strict)** | `.strict(true)` / `--strict` | Rust-only cleaner mode — **no docling equivalent** |
 | **JSON** | `export_to_json()` / `--to json` | docling-core native wire format (schema 1.10.0) |
 | **DocLang (`.dclx`)** | `export_to_doclang()` · `docling::dclx::save_as_dclx()` / `--to dclx` | DocLang 0.7 XML (`<doclang>`), and the OPC archive docling 2.110's `save_as_doclang()` writes |
-| **LaTeX (`.tex`)** | `export_to_latex()` / `--to latex` (#317) | docling 2.124's `LaTeXDocSerializer` with default params, scored against upstream's own `docling --to latex`: **89/116 shared declarative fixtures byte-exact** (94 modulo upstream's duplicated formatted list items / headings); remaining gaps are underline / sub / superscript (no Markdown form), HTML rich table cells, a few list groupings. Serve `to=latex`, Node `to: 'latex'`; Python bindings use upstream docling-core's serializer on the reconstructed document. Deviations: headings deeper than `\subsubsection` degrade to `\paragraph`/`\subparagraph` where upstream raises; upstream's duplicated text for formatted items ([docling-core#740](https://github.com/docling-project/docling-core/issues/740)) is not reproduced |
+| **LaTeX (`.tex`)** | `export_to_latex()` / `--to latex` (#317) | docling 2.124's `LaTeXDocSerializer` with default params, scored against upstream's own `docling --to latex`: **93/116 shared declarative fixtures byte-exact** (98 modulo upstream's duplicated formatted list items / headings — #328's HTML `cell_blocks` made the rich-cell bucket exact: in-cell lists render as `\begin{itemize}`, nested tables as nested `tabular`s, in-cell headings as plain text); remaining gaps are underline / sub / superscript (no Markdown form) and a few list groupings. Serve `to=latex`, Node `to: 'latex'`; Python bindings use upstream docling-core's serializer on the reconstructed document. Deviations: headings deeper than `\subsubsection` degrade to `\paragraph`/`\subparagraph` where upstream raises; upstream's duplicated text for formatted items ([docling-core#740](https://github.com/docling-project/docling-core/issues/740)) is not reproduced |
 | **Image extraction** | `export_to_markdown_with_images(mode, dir)` / `--images` | `placeholder` (default) · `embedded` (base64 data URI) · `referenced` (writes PNG files) |
 
 - **DocLang** reproduces docling-core's `DocLangDocSerializer` (`minidom.toprettyxml`
@@ -262,10 +268,10 @@ work (checkbox inputs, fragmented-anchor folding, `<button>` blocks) plus the
   `<strikethrough>`/`<sub|superscript>`), lists with enumeration `<marker>`s, OTSL
   tables (`<ched>`/`<fcel>`/`<lcel>`…) with per-cell `<location>`, code, formulas,
   pictures and furniture. Conformance is scored against docling's own `.dclx`
-  archives (`scripts/conformance/dclx_conformance.sh`): **≈94% mean similarity over
+  archives (`scripts/conformance/dclx_conformance.sh`): **≈96% mean similarity over
   the 136-fixture non-PDF corpus** (issue #32's ≥90% target) — every OOXML fixture
   (docx/pptx/xlsx) plus csv/asciidoc/email byte-exact, uspto/jats in the
-  mid-to-high 90s, md/odf/latex low 90s, html/webvtt in the 80s (full table
+  mid-to-high 90s, html (#328 rich cells) 96%, md/odf/latex low 90s, webvtt in the 80s (full table
   in §2). The format-by-format work was
   tracked as [issue #32](https://github.com/docling-project/docling.rs/issues/32) and its
   children (#38–#41, #44) — all closed, targets met. This is an **output** format;

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -51,7 +51,7 @@ bulk of the porting under review).
 | | |
 |---|---|
 | **What** | A Rust port of docling's converter, backends, and discriminative PDF/ASR pipelines; same `convert → DoclingDocument → export_to_markdown()/json()` shape, single static binary, no Python/torch at runtime |
-| **Conformance** | Declarative formats byte-for-byte vs *live* PyPI docling (most 100%, see §2); `.dclx` DocLang output ≈96% mean vs docling's own `.dclx`, OOXML all byte-exact (§2); PDF ML path 6/14 fixtures byte-exact, rest close; every optimization is gated on this not regressing |
+| **Conformance** | Declarative formats byte-for-byte vs *live* PyPI docling (most 100%, see §2); `.dclx` DocLang output ≈97% mean vs docling's own `.dclx`, OOXML all byte-exact (§2); PDF ML path 6/14 fixtures byte-exact, rest close; every optimization is gated on this not regressing |
 | **Performance** | PDF ML pipeline **4.3× faster warm / 4.7× end-to-end** than Python docling at 2.3–2.6× less peak RAM (INT8 + SIMD, conformance-validated); declarative formats 20–60× warm, ~60× less RAM; XLSX sheets / PPTX slides additionally fan out over rayon (~2–3× on many-sheet/slide files, conformance byte-identical); details + methodology in [`PDF_CONFORMANCE.md`](./PDF_CONFORMANCE.md) |
 | **Models** | docling's own checkpoints, no retraining: layout heron and TableFormer are format-converted to ONNX by `scripts/install/export_layout.py` / `export_tableformer.py` (CodeFormula by `export_code_formula.py`); PP-OCRv3 and Whisper tiny ship as their upstream ONNX exports; INT8 variants are calibrated post-training quantizations (`scripts/install/quantize_models.py`) |
 | **Tracking upstream** | See [§9](#9-keeping-up-with-upstream-docling): conformance is measured against the *latest published* docling on demand, so an upstream release that changes output surfaces as a concrete per-fixture diff |
@@ -171,14 +171,17 @@ close — see `PDF_CONFORMANCE.md`. A deterministic snapshot baseline
 
 The `.dclx` DocLang output (§3) is scored against docling's own `.dclx` archives
 with `scripts/conformance/dclx_conformance.sh` — the extracted `document.xml`
-line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈96% mean over the
+line-diffed, similarity `= 100·(1 − difflines / max_lines)`. **≈97% mean over the
 136-fixture non-PDF corpus** (issue #32 target: ≥90%), per source format.
 HTML rich table cells (#328) carry their block content — lists, ordered lists,
 nested tables, headings, `<pre>` runs — as `Table::cell_blocks`, so the
 DocLang `<fcel/>` bodies match upstream's `RichTableCell` serialization
 (`table_03`–`table_06`, `table_with_heading_02`,
-`html_inline_group_in_table_cell` byte-exact; `html_rich_table_cells`' one
-residual is a picture-caption hyperlink, a model gap tracked separately).
+`html_inline_group_in_table_cell`, `html_rich_table_cells` and
+`hyperlink_05` byte-exact — a picture caption also carries its hyperlink
+annotation: an `<a href>` wrapping the image, or the first link inside a
+`<figcaption>`, emits the block-form `<caption>` with an `<href uri=…/>`
+head and docling's `hyperlink` field on the JSON caption item).
 Robustness tracks docling-core 2.88/2.89 (#253): XML-illegal control
 characters serialize as visible `[U+XXXX]` markers, a literal `]]>` splits
 across CDATA sections, and deep section headers clamp to heading level 6
@@ -192,7 +195,7 @@ fragments as XML.
 | CSV / AsciiDoc / Email | **100%** | JATS | 95% |
 | XLSX | **100%** | Markdown | 92% |
 | DOCX / PPTX | **100%** | LaTeX | 91% |
-| USPTO | 98% | HTML | 96% |
+| USPTO | 98% | HTML | 97% |
 | ODF | 96% | WebVTT | 81% |
 
 This effort was tracked as
@@ -268,10 +271,10 @@ work (checkbox inputs, fragmented-anchor folding, `<button>` blocks) plus the
   `<strikethrough>`/`<sub|superscript>`), lists with enumeration `<marker>`s, OTSL
   tables (`<ched>`/`<fcel>`/`<lcel>`…) with per-cell `<location>`, code, formulas,
   pictures and furniture. Conformance is scored against docling's own `.dclx`
-  archives (`scripts/conformance/dclx_conformance.sh`): **≈96% mean similarity over
+  archives (`scripts/conformance/dclx_conformance.sh`): **≈97% mean similarity over
   the 136-fixture non-PDF corpus** (issue #32's ≥90% target) — every OOXML fixture
   (docx/pptx/xlsx) plus csv/asciidoc/email byte-exact, uspto/jats in the
-  mid-to-high 90s, html (#328 rich cells) 96%, md/odf/latex low 90s, webvtt in the 80s (full table
+  mid-to-high 90s, html (#328 rich cells + caption hyperlinks) 97%, md/odf/latex low 90s, webvtt in the 80s (full table
   in §2). The format-by-format work was
   tracked as [issue #32](https://github.com/docling-project/docling.rs/issues/32) and its
   children (#38–#41, #44) — all closed, targets met. This is an **output** format;


### PR DESCRIPTION


The HTML backend flattened block content inside a table cell into the cell's Markdown text, so every structured serializer lost the cell's structure: `Table::cell_blocks` was populated only by the docx/odf backends (#328).

- `render_cell` now runs a *second, structured* walk over a rich cell and stores the resulting blocks in `cell_blocks[r][c]` (anchor slot only — covered span positions stay empty, matching how a rich cell's text serializes once; `any_rich.then_some(blocks)`, so plain tables keep `None`). The flat text walk is untouched: `rows`, Markdown and JSON are byte-identical (regression suite regenerated only `.tex` files). In the structured walk a nested `<table>` stays a real `Node::Table`, a list stays list items, a heading stays a heading; in-cell inline groups are forced `<text>`-wrapped (only the body unwraps a group after a heading).
- `is_rich_cell`'s markup set gains `u`/`ins`/`sub`/`sup`, matching docling's `_FORMAT_TAG_MAP` — underline and sub/superscript have no Markdown marker but do reach DocLang/LaTeX, so `<td><u>Quack</u></td>` is a RichTableCell upstream and now here too (flat text unchanged).
- A `<pre>` with inline structure keeps its structured runs instead of re-parsing the joined Markdown: `<pre>See <a…>the docs</a> first</pre>` emits `<code>See</code><code>the docs</code><code>first</code>` like upstream, not a bare backticked fragment with stray separator runs.

DCLX conformance (dclx_conformance.sh): table_03/04/05/06, table_with_heading_02 and html_inline_group_in_table_cell go byte-EXACT; html_rich_table_cells 73%→98% (sole residual: a picture-caption hyperlink, a model gap independent of cell_blocks); html format mean 88%→96%, non-PDF corpus mean ≈94%→≈96%. LaTeX (#317 scoring vs native `docling --to latex`): 89→93/116 byte-exact (98 modulo upstream's duplicated formatted items) — in-cell lists render as `\begin{itemize}`, nested tables as nested `tabular`s, in-cell headings as plain text. Docs updated.

Closes #328
Refs #317



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT