### PR TITLE
ci(docker): run docker-publish only on master merges, releases and dispatch — not on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,14 +21,15 @@
 #
 # CUDA images are built on `ubuntu-latest` (linux/amd64) and tagged with
 # explicit release versions and `master` (never floating `:latest`, matching
-# upstream docling-serve CUDA tagging policy). On pull requests, the CUDA job
-# dry-runs on linux/amd64 with smoke tests to ensure CUDA builds do not regress.
+# upstream docling-serve CUDA tagging policy).
 #
 # Triggers:
 #   - Release published: tags with semantic versions (vX.Y.Z, X.Y, X, latest for CPU; vX.Y.Z, X.Y, X for CUDA)
 #   - Push to master: tags with `master` (and `latest` for CPU)
 #   - Manual dispatch: tag override or dry-run testing (with optional CUDA toggle)
-#   - Pull request: fast dry-run builds on amd64 + smoke tests (no push)
+#   - Pull requests do NOT run this workflow: images build only on merge to
+#     master, release, or manual dispatch — the smoke tests below still gate
+#     every publish (a failing smoke test fails the run before any push).
 
 name: docker-publish
 
@@ -64,20 +65,6 @@ on:
         required: false
         type: boolean
         default: true
-  pull_request:
-    branches: [master]
-    paths:
-      - "crates/docling-serve/**"
-      - "crates/docling/**"
-      - "crates/docling-core/**"
-      - "crates/docling-pdf/**"
-      - "crates/docling-onnx/**"
-      - "crates/docling-asr/**"
-      - "scripts/install/download_dependencies.sh"
-      - ".github/workflows/docker-publish.yml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-
 # Least privilege at the workflow level: read checkout only.
 # Write permissions are granted explicitly at the job level.
 permissions:
@@ -85,7 +72,9 @@ permissions:
 
 concurrency:
   group: docker-publish-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Publishing runs are never cancelled mid-flight; a superseded master push
+  # simply queues behind the running one.
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -129,7 +118,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -226,7 +215,7 @@ jobs:
 
       - name: Build and push CPU serve image by digest
         id: build_serve
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -240,7 +229,7 @@ jobs:
 
       - name: Build and push CPU CLI image by digest
         id: build_cli
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -253,7 +242,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=docling-rs-serve-${{ matrix.platform_slug }}
 
       - name: Export CPU digests
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         run: |
           mkdir -p /tmp/digests/serve /tmp/digests/cli
           digest="${{ steps.build_serve.outputs.digest }}"
@@ -262,7 +251,7 @@ jobs:
           touch "/tmp/digests/cli/${digest#sha256:}"
 
       - name: Upload CPU serve digest
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: digests-serve-${{ matrix.platform_slug }}
@@ -271,7 +260,7 @@ jobs:
           retention-days: 1
 
       - name: Upload CPU CLI digest
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: digests-cli-${{ matrix.platform_slug }}
@@ -287,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build-cpu
-    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
     permissions:
       contents: read
       packages: write
@@ -448,8 +437,8 @@ jobs:
     name: build & publish CUDA (linux/amd64)
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Runs on PRs (dry-run smoke test), pushes to master, releases, or dispatch with cuda=true
-    if: github.event_name == 'pull_request' || (github.event_name != 'workflow_dispatch' || (inputs.publish && inputs.cuda))
+    # Runs on pushes to master, releases, or dispatch with cuda=true
+    if: github.event_name != 'workflow_dispatch' || (inputs.publish && inputs.cuda)
     permissions:
       contents: read
       packages: write
@@ -469,8 +458,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        # Only log in when publishing (not on PR dry-runs)
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        # Only log in when publishing (dispatch may opt out)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -587,10 +576,10 @@ jobs:
           docker rm -f docling-rs-serve-cuda-test
 
       # ------------------------------------------------------------------------
-      # Push images to GHCR (skipped on pull requests)
+      # Push images to GHCR (after the smoke tests above pass)
       # ------------------------------------------------------------------------
       - name: Push CUDA serve image to GHCR
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         id: build_cuda_serve
         uses: docker/build-push-action@v6
         with:
@@ -604,7 +593,7 @@ jobs:
           cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
 
       - name: Push CUDA CLI image to GHCR
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         id: build_cuda_cli
         uses: docker/build-push-action@v6
         with:
@@ -618,7 +607,7 @@ jobs:
           cache-from: type=gha,scope=docling-rs-serve-cuda-linux-amd64
 
       - name: Generate artifact attestation for docling-rs-serve-cuda
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.SERVE_CUDA_IMAGE }}
@@ -626,7 +615,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate artifact attestation for docling-rs-cuda
-        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish)
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.CLI_CUDA_IMAGE }}


### PR DESCRIPTION
The pull_request trigger rebuilt both CPU images and, since #333, both CUDA images on every PR touching the crates — ~25 minutes of runner time per push for a dry-run whose smoke tests run again anyway on the merge commit, where they still gate every publish (a failing smoke test fails the run before anything is pushed).

Drop the trigger and the now-dead `github.event_name != 'pull_request'` arms from the twelve step/job guards and the CUDA job gate; concurrency keeps cancel-in-progress off, since only publishing runs remain.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT