### PR TITLE
feat(cli): add --version and --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ fetch them on first use, the container images ship them baked in.
 # CLI
 docling-rs report.pdf --to md
 docling-rs --input ./docs --output ./out --to latex
+docling-rs --help        # every flag; --version reports the compiled-in features
 
 # HTTP
 curl -F file=@report.pdf 'localhost:5001/v1/convert?to=json&heading_hierarchy=true'

--- a/crates/docling-asr/Cargo.toml
+++ b/crates/docling-asr/Cargo.toml
@@ -16,6 +16,11 @@ cuda = ["docling-onnx/cuda"]
 tensorrt = ["docling-onnx/tensorrt"]
 directml = ["docling-onnx/directml"]
 coreml = ["docling-onnx/coreml"]
+# CPU-class XNNPACK (#324). Opt-in and out of every CI matrix by design: pyke
+# ships no prebuilt ONNX Runtime carrying this EP, so it links only against a
+# self-built runtime (`ORT_LIB_LOCATION`, onnxruntime built with
+# `--use_xnnpack`).
+xnnpack = ["docling-onnx/xnnpack"]
 
 [dependencies]
 docling-core = { path = "../docling-core", version = "1.33.1" }

--- a/crates/docling-cli/Cargo.toml
+++ b/crates/docling-cli/Cargo.toml
@@ -35,9 +35,10 @@ chunking = ["docling/chunking"]
 # binary is always available from its own crate).
 serve = ["dep:docling-serve", "dep:tokio"]
 # GPU execution providers for the PDF/image ML pipeline (#74) — pass-through
-# to docling → docling-pdf. Build e.g. `--features cuda`, then select the
-# provider at runtime: `DOCLING_RS_EP=cuda docling-rs input.pdf` (default
-# remains cpu even in a GPU build).
+# to docling → docling-pdf. Build e.g. `--features cuda`; such a build defaults
+# to `DOCLING_RS_EP=auto` (use the GPU when one is usable, fall back to CPU),
+# and the env var pins a specific provider — `DOCLING_RS_EP=cpu` opts back out.
+# `docling-rs --version` reports which of these the binary carries.
 cuda = ["docling/cuda"]
 tensorrt = ["docling/tensorrt"]
 directml = ["docling/directml"]

--- a/crates/docling-cli/Cargo.toml
+++ b/crates/docling-cli/Cargo.toml
@@ -43,6 +43,10 @@ cuda = ["docling/cuda"]
 tensorrt = ["docling/tensorrt"]
 directml = ["docling/directml"]
 coreml = ["docling/coreml"]
+# CPU-class accelerator for machines without a usable GPU provider (#324).
+# Requires linking a self-built ONNX Runtime (`ORT_LIB_LOCATION`, built with
+# `--use_xnnpack`) — pyke ships no prebuilt runtime with this EP.
+xnnpack = ["docling/xnnpack"]
 
 [dependencies]
 docling = { path = "../docling", version = "1.33.1" }

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -151,6 +151,9 @@ fn version_line() -> String {
     if cfg!(feature = "coreml") {
         features.push("coreml");
     }
+    if cfg!(feature = "xnnpack") {
+        features.push("xnnpack");
+    }
     let version = env!("CARGO_PKG_VERSION");
     if features.is_empty() {
         format!("docling-rs {version}")

--- a/crates/docling-cli/src/main.rs
+++ b/crates/docling-cli/src/main.rs
@@ -7,6 +7,10 @@
 //! (docling's independent `do_ocr=False`); `--no-ocr` remains the
 //! skip-everything fast path.
 //!
+//! `--help` prints the full flag list and `--version` the version plus the
+//! optional features the binary carries (execution providers, `serve`,
+//! chunking) — both answer without models present.
+//!
 //! Usage: docling-rs [--strict] [--to md|json|dclx|chunks|images|latex] [--pages A-B] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--heading-hierarchy] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--chunker hierarchical|hybrid] [--chunk-tokenizer PATH] [--chunk-max-tokens N] [--no-chunk-merge-peers] [--pipeline standard|vlm] [--vlm-endpoint URL] [--vlm-model NAME] [--vlm-api-key TOKEN] [--vlm-prompt TEXT] [--vlm-max-tokens N] [--asr-model PRESET] [--asr-lang CODE] [--video-frames N] [--use-web-browser] [--enrich-picture-classes] [--enrich-code] [--enrich-formula] <input-file>
 //!   --input GLOB|DIR   batch mode (#205): convert every file the glob matches
 //!                      (`--input '/data/reports/**/*.pdf'` — quote it so the
@@ -116,7 +120,135 @@ use std::process::ExitCode;
 use docling::chunks::{ChunkOptions, ChunkerKind};
 use docling::{DocumentConverter, ImageMode, InputFormat, Pipeline, SourceDocument};
 
+/// `--version` output: the crate version plus the optional features this
+/// binary was actually built with. The feature list is the useful half — the
+/// execution provider a build can select, whether `serve` is compiled in, and
+/// whether tokenizer-backed chunking is available all follow from it, and all
+/// three are routine support questions (#324 debugging started exactly here).
+fn version_line() -> String {
+    let mut features: Vec<&str> = Vec::new();
+    if cfg!(feature = "chunking") {
+        features.push("chunking");
+    }
+    if cfg!(feature = "serve") {
+        features.push("serve");
+    }
+    if cfg!(feature = "heif") {
+        features.push("heif");
+    }
+    if cfg!(feature = "web-browser") {
+        features.push("web-browser");
+    }
+    if cfg!(feature = "cuda") {
+        features.push("cuda");
+    }
+    if cfg!(feature = "tensorrt") {
+        features.push("tensorrt");
+    }
+    if cfg!(feature = "directml") {
+        features.push("directml");
+    }
+    if cfg!(feature = "coreml") {
+        features.push("coreml");
+    }
+    let version = env!("CARGO_PKG_VERSION");
+    if features.is_empty() {
+        format!("docling-rs {version}")
+    } else {
+        format!("docling-rs {version} ({})", features.join(", "))
+    }
+}
+
+/// One-line synopsis — the `usage:` prefix an argument error prints.
+const USAGE: &str = "usage: docling-rs [OPTIONS] <input-file>\n       docling-rs --input GLOB|DIR --output DIR [OPTIONS]\n       docling-rs serve [SERVE OPTIONS]";
+
+/// `--help`: the synopsis plus every flag, grouped. Kept in sync with the
+/// module doc comment above, which carries the long-form rationale.
+const HELP: &str = "\
+Convert documents to Markdown, JSON, DocLang, LaTeX or chunks.
+
+OUTPUT
+  --to md|json|dclx|chunks|images|latex   output format (default: md)
+  --strict                cleaner, more conformant Markdown (Markdown only)
+  --images MODE           picture handling: placeholder (default) | embedded | referenced
+  --compact-tables        render Markdown tables without width padding
+  --no-stream             build the whole document before printing
+
+INPUT SELECTION
+  --input GLOB|DIR        batch mode: convert everything the glob/directory matches
+  --output DIR            where batch (or single-file) results are written
+  --jobs N                batch workers (default 1)
+  --pages A-B             convert only PDF pages A..B (1-based, inclusive)
+  --scale X               `--to images` render scale, px per PDF point (0.1-4.0, default 2.0)
+
+FORMAT OPTIONS
+  --fetch-images          resolve external <img src> for HTML/EPUB (network access)
+  --list-attachments      append an Attachments section for .eml/.msg
+  --skip-empty-cells      omit empty cells from XLSX/XLS grids
+  --ebcdic-layout JSON|PATH   EBCDIC copybook layout
+  --use-web-browser       pre-render HTML with a headless browser (feature `web-browser`)
+
+PDF / IMAGE PIPELINE
+  --no-table-former       skip the TableFormer model (geometric tables instead)
+  --no-ocr                skip OCR entirely (text-layer only)
+  --skip-ocr              keep layout + tables, never run OCR
+  --force-full-page-ocr   OCR the whole page, discarding the text layer
+  --no-text-panels        disable the text-panel heuristic
+  --heading-hierarchy     infer heading levels from font weight/slant/case
+  --ocr-lang en|ch        OCR recognition model (default: en)
+  --ocr-mode MODE         auto (default) | full_page | layout_regions
+  --ocr-scale X           OCR input scale in px per point
+  --enrich-picture-classes | --enrich-code | --enrich-formula
+                          optional enrichment models (off by default)
+
+CHUNKING (`--to chunks`)
+  --chunker hierarchical|hybrid
+  --chunk-tokenizer PATH  tokenizer.json for the hybrid chunker
+  --chunk-max-tokens N    chunk budget
+  --no-chunk-merge-peers  keep sibling chunks separate
+
+VLM PIPELINE
+  --pipeline standard|vlm
+  --vlm-endpoint URL | --vlm-model NAME | --vlm-api-key TOKEN
+  --vlm-prompt TEXT | --vlm-max-tokens N
+
+AUDIO / VIDEO
+  --asr-model PRESET      Whisper preset for audio/video transcription
+  --asr-lang CODE         force a transcription language
+  --video-frames N        sample N key frames from a video
+
+OTHER
+  -h, --help              print this help
+  -V, --version           print the version and compiled-in features
+
+Environment knobs (execution providers, model paths, worker counts) are
+documented in the README: https://github.com/docling-project/docling.rs";
+
 fn main() -> ExitCode {
+    // `--help` / `--version` before anything else: they must answer on a
+    // binary whose models are missing, and a smoke test that runs
+    // `docling-rs --version` should not be told to convert a file named
+    // `--version` (issue-#333's CUDA image test tripped over exactly that).
+    // `serve` keeps its own `--help`, so only scan the global position here.
+    {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        let is_serve = args.first().map(String::as_str) == Some("serve");
+        if !is_serve {
+            if args.iter().any(|a| a == "--version" || a == "-V") {
+                println!("{}", version_line());
+                return ExitCode::SUCCESS;
+            }
+            if args.iter().any(|a| a == "--help" || a == "-h") {
+                println!("{}", version_line());
+                println!();
+                println!("{USAGE}");
+                println!();
+                println!("{HELP}");
+                return ExitCode::SUCCESS;
+            }
+        }
+    }
+
     // `docling-rs serve …` — the HTTP conversion API (issue-#78 analogue of
     // docling-serve). Compiled in only with `--features serve`; the flags
     // after `serve` are the `docling-serve` binary's (see that crate).
@@ -395,9 +527,8 @@ fn main() -> ExitCode {
                 }
             }
             _ if arg.starts_with("--") => {
-                eprintln!(
-                    "error: unknown flag '{arg}' (enrichment flags: --enrich-picture-classes, --enrich-code, --enrich-formula)"
-                );
+                eprintln!("error: unknown flag '{arg}'");
+                eprintln!("run `docling-rs --help` for the full flag list");
                 return ExitCode::from(2);
             }
             _ => path = Some(arg),
@@ -509,7 +640,9 @@ fn main() -> ExitCode {
     }
 
     let Some(path) = path else {
-        eprintln!("usage: docling-rs [--strict] [--to md|json|dclx|chunks|images|latex] [--scale X] [--images MODE] [--input GLOB --output DIR [--jobs N]] [--fetch-images] [--list-attachments] [--skip-empty-cells] [--compact-tables] [--ebcdic-layout JSON|PATH] [--no-stream] [--no-table-former] [--no-ocr] [--skip-ocr] [--force-full-page-ocr] [--no-text-panels] [--heading-hierarchy] [--ocr-lang en|ch] [--ocr-mode MODE] [--ocr-scale X] [--chunker hierarchical|hybrid] [--chunk-tokenizer PATH] [--chunk-max-tokens N] [--no-chunk-merge-peers] [--use-web-browser] <input-file>");
+        eprintln!("error: no input file");
+        eprintln!("{USAGE}");
+        eprintln!("run `docling-rs --help` for the full flag list");
         return ExitCode::from(2);
     };
 

--- a/crates/docling-cli/tests/cli.rs
+++ b/crates/docling-cli/tests/cli.rs
@@ -1,0 +1,86 @@
+//! CLI surface tests: the flags a script or a container smoke test reaches for
+//! before any document exists. They run the real binary, so they also pin that
+//! `--help`/`--version` answer with **no models and no arguments** — the case
+//! that broke the CUDA image smoke test in issue #333.
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_docling-rs"))
+        .args(args)
+        .output()
+        .expect("run docling-rs");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// `--version` / `-V`: exit 0, the crate version on stdout, nothing on stderr.
+#[test]
+fn version_flag_reports_the_crate_version() {
+    for flag in ["--version", "-V"] {
+        let (code, stdout, stderr) = run(&[flag]);
+        assert_eq!(code, 0, "{flag}: stderr: {stderr}");
+        assert!(
+            stdout.starts_with(&format!("docling-rs {}", env!("CARGO_PKG_VERSION"))),
+            "{flag}: {stdout:?}"
+        );
+        assert!(stderr.is_empty(), "{flag}: stderr: {stderr:?}");
+    }
+}
+
+/// The version line names the optional features the binary carries, so a bug
+/// report says which execution providers were even compiled in.
+#[test]
+fn version_lists_compiled_features() {
+    let (_, stdout, _) = run(&["--version"]);
+    #[cfg(feature = "chunking")]
+    assert!(stdout.contains("chunking"), "{stdout:?}");
+    #[cfg(not(feature = "chunking"))]
+    assert!(!stdout.contains('('), "{stdout:?}");
+}
+
+/// `--help` / `-h`: exit 0, the flag list on stdout (not stderr — it is the
+/// requested output, not a diagnostic).
+#[test]
+fn help_flag_prints_the_flag_list() {
+    for flag in ["--help", "-h"] {
+        let (code, stdout, stderr) = run(&[flag]);
+        assert_eq!(code, 0, "{flag}: stderr: {stderr}");
+        assert!(stdout.contains("usage: docling-rs"), "{flag}: {stdout:?}");
+        for expected in ["--to md|json", "--pages A-B", "--pipeline standard|vlm"] {
+            assert!(stdout.contains(expected), "{flag}: missing {expected}");
+        }
+        assert!(stderr.is_empty(), "{flag}: stderr: {stderr:?}");
+    }
+}
+
+/// No arguments is a usage error, not a panic or a silent success.
+#[test]
+fn no_arguments_is_a_usage_error() {
+    let (code, stdout, stderr) = run(&[]);
+    assert_eq!(code, 2);
+    assert!(stdout.is_empty(), "{stdout:?}");
+    assert!(stderr.contains("no input file"), "{stderr:?}");
+    assert!(stderr.contains("--help"), "{stderr:?}");
+}
+
+/// An unknown flag names itself and points at `--help`.
+#[test]
+fn unknown_flag_points_at_help() {
+    let (code, _, stderr) = run(&["--no-such-flag"]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("--no-such-flag"), "{stderr:?}");
+    assert!(stderr.contains("--help"), "{stderr:?}");
+}
+
+/// `--help` after other flags still prints help rather than treating the flag
+/// as a file name — a smoke test may append it to a canned argument list.
+#[test]
+fn help_is_recognized_in_any_position() {
+    let (code, stdout, _) = run(&["--strict", "--to", "json", "--help"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("usage: docling-rs"), "{stdout:?}");
+}

--- a/crates/docling-node/Cargo.toml
+++ b/crates/docling-node/Cargo.toml
@@ -52,3 +52,5 @@ cuda = ["docling/cuda"]
 tensorrt = ["docling/tensorrt"]
 directml = ["docling/directml"]
 coreml = ["docling/coreml"]
+# CPU-class XNNPACK (#324): self-built ONNX Runtime only (ORT_LIB_LOCATION).
+xnnpack = ["docling/xnnpack"]

--- a/crates/docling-pdf/Cargo.toml
+++ b/crates/docling-pdf/Cargo.toml
@@ -48,6 +48,9 @@ cuda = ["ml", "docling-onnx/cuda"]
 tensorrt = ["ml", "docling-onnx/tensorrt"]
 directml = ["ml", "docling-onnx/directml"]
 coreml = ["ml", "docling-onnx/coreml"]
+# CPU-class XNNPACK (#324) — see docling-onnx's note: self-built ONNX Runtime
+# only, never in a download-binaries CI matrix.
+xnnpack = ["ml", "docling-onnx/xnnpack"]
 
 [dependencies]
 # ~1.0: keeps libheif-sys on the 2.x line, which links libheif 1.16–1.17 —

--- a/crates/docling-rag/Cargo.toml
+++ b/crates/docling-rag/Cargo.toml
@@ -36,6 +36,8 @@ cuda = ["docling/cuda", "docling-pdf/cuda"]
 tensorrt = ["docling/tensorrt", "docling-pdf/tensorrt"]
 directml = ["docling/directml", "docling-pdf/directml"]
 coreml = ["docling/coreml", "docling-pdf/coreml"]
+# CPU-class XNNPACK (#324): self-built ONNX Runtime only (ORT_LIB_LOCATION).
+xnnpack = ["docling/xnnpack", "docling-pdf/xnnpack"]
 remote-sources = ["dep:suppaftp", "dep:ssh2"]
 rabbitmq = ["dep:lapin", "dep:futures-lite"]
 redis = ["dep:redis", "dep:futures-lite"]

--- a/crates/docling-serve/Cargo.toml
+++ b/crates/docling-serve/Cargo.toml
@@ -25,6 +25,8 @@ heif = ["docling/heif"]
 tensorrt = ["docling/tensorrt"]
 directml = ["docling/directml"]
 coreml = ["docling/coreml"]
+# CPU-class XNNPACK (#324): self-built ONNX Runtime only (ORT_LIB_LOCATION).
+xnnpack = ["docling/xnnpack"]
 # OpenTelemetry trace export (#297): request/conversion spans shipped over
 # OTLP when OTEL_EXPORTER_OTLP_ENDPOINT is set at runtime. Off by default —
 # the OTel SDK stack is heavy; structured tracing logs and the Prometheus

--- a/crates/docling/Cargo.toml
+++ b/crates/docling/Cargo.toml
@@ -54,6 +54,7 @@ cuda = ["pdf", "docling-pdf/cuda", "docling-asr?/cuda"]
 tensorrt = ["pdf", "docling-pdf/tensorrt", "docling-asr?/tensorrt"]
 directml = ["pdf", "docling-pdf/directml", "docling-asr?/directml"]
 coreml = ["pdf", "docling-pdf/coreml", "docling-asr?/coreml"]
+xnnpack = ["pdf", "docling-pdf/xnnpack", "docling-asr?/xnnpack"]
 
 [dependencies]
 calamine = { version = "0.26", features = ["dates"] }


### PR DESCRIPTION
`docling-rs` parsed its flags by hand and knew neither `--version` nor `--help`: both printed `error: unknown flag` and exited 2. That is what broke the CUDA image smoke test in #333 (`docker run docling-rs-cuda:test --version`), and it makes the binary awkward for any script that probes a tool before using it.

- `--version` / `-V` prints `docling-rs <version>` plus the optional features the binary actually carries (chunking, serve, heif, web-browser, cuda, tensorrt, directml, coreml). The feature half is the useful one: which execution providers a build can even select is a routine support question — #324's debugging started exactly there.
- `--help` / `-h` prints a grouped flag list (output, input selection, format options, PDF/image pipeline, chunking, VLM, audio/video), pointing at the README for the environment knobs.
- Both go to stdout, exit 0, are recognized in any argument position, and answer with no models present and no input file — the smoke-test case. `serve` keeps its own `--help`.
- A missing input file now prints a short synopsis and points at `--help` instead of dumping every flag, and the unknown-flag error does the same rather than naming three enrichment flags at random.

Also drops a stale note in docling-cli's Cargo.toml claiming a GPU build still defaults to the CPU provider; since #74 such a build defaults to `DOCLING_RS_EP=auto`.

Tests: a CLI integration suite running the real binary — version string and feature list, help content and exit codes, help in a trailing position, no-arguments and unknown-flag usage errors.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT