### PR TITLE
fix(ci): mirror the last third-party assets into the models release

### DIFF
--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -10,7 +10,11 @@
 # — a numeric re-encoding of the weights, no retraining; conformance-validated
 # in PDF_PERFORMANCE.md). pdfium and the OCR model are re-hosted third-party
 # binaries, unmodified, from their own public releases — mirrored here only so
-# `download_dependencies.sh` needs one host instead of three.
+# `download_dependencies.sh` needs one host instead of three. Everything a
+# *default* install fetches is mirrored (both OCR pairs, Whisper tiny, the
+# chunk tokenizer, the picture classifier): third-party hosts answer 429 to
+# shared CI egress, which used to break container builds outright. Only the
+# opt-in extras (--asr-model presets, --embed) still come from upstream.
 #
 # Trigger: manual only (workflow_dispatch) — it installs torch and exports two
 # models, several GB and 10-20 minutes, not something to run on every push.
@@ -120,22 +124,45 @@ jobs:
       # The tokenizer is all-MiniLM-L6-v2's tokenizer.json (Apache-2.0), the
       # default docling's HybridChunker counts tokens with; re-hosted so the
       # hybrid chunker works out of the box after download_dependencies.sh.
-      - name: Fetch pdfium + OCR + chunk tokenizer assets
+      - name: Fetch pdfium + OCR + ASR + chunk tokenizer assets
         run: |
-          mkdir -p third-party
-          curl -fsSL -o /tmp/pdfium.tgz \
+          mkdir -p third-party third-party/asr
+          # Same backoff download_dependencies.sh uses: Hugging Face and
+          # raw.githubusercontent answer 429 to shared CI egress often enough
+          # to fail an unretried fetch.
+          RETRY="--retry 5 --connect-timeout 30"
+          curl -fsSL $RETRY -o /tmp/pdfium.tgz \
             "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz"
           tar -xzf /tmp/pdfium.tgz -C third-party
-          curl -fsSL -o third-party/ocr_rec.onnx \
+          curl -fsSL $RETRY -o third-party/ocr_rec.onnx \
             "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/ch_PP-OCRv3_rec_infer.onnx"
-          curl -fsSL -o third-party/ppocr_keys_v1.txt \
+          curl -fsSL $RETRY -o third-party/ppocr_keys_v1.txt \
             "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/ppocr_keys_v1.txt"
-          curl -fsSL -o third-party/chunk_tokenizer.json \
+          curl -fsSL $RETRY -o third-party/chunk_tokenizer.json \
             "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
           # DocumentFigureClassifier-v2.5 (Apache-2.0) ships its ONNX graph
           # upstream — re-hosted as-is for --enrich-picture-classes.
-          curl -fsSL -o third-party/picture_classifier.onnx \
+          curl -fsSL $RETRY -o third-party/picture_classifier.onnx \
             "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx"
+          # English PP-OCRv3 recognition pair — the *runtime default* OCR
+          # model (the ch_ pair above is the conformance one). Unmirrored, it
+          # was the last required asset a container build pulled from Hugging
+          # Face, and a 429 there failed the image publish outright.
+          curl -fsSL $RETRY -o third-party/ocr_rec_en.onnx \
+            "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/en_PP-OCRv3_rec_infer.onnx"
+          curl -fsSL $RETRY -o third-party/en_dict.txt \
+            "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/en_dict.txt"
+          # Whisper tiny (the ASR default, ~150 MB): same reasoning — a
+          # default install fetches it, so mirror it here and leave Hugging
+          # Face as download_dependencies.sh's fallback host.
+          for f in encoder_model decoder_model; do
+            curl -fsSL $RETRY -o "third-party/asr/$f.onnx" \
+              "https://huggingface.co/onnx-community/whisper-tiny/resolve/main/onnx/$f.onnx"
+          done
+          curl -fsSL $RETRY -o third-party/asr/vocab.json \
+            "https://huggingface.co/onnx-community/whisper-tiny/resolve/main/vocab.json"
+          curl -fsSL $RETRY -o third-party/asr/added_tokens.json \
+            "https://huggingface.co/onnx-community/whisper-tiny/resolve/main/added_tokens.json"
 
       # --- stage + publish -------------------------------------------------
       # GitHub release assets can't contain "/", so tableformer/*.onnx is
@@ -166,6 +193,15 @@ jobs:
           stage .models/tableformer/decoder_kv_int8.onnx decoder_kv_int8.onnx
           stage .models/tableformer/bbox.onnx bbox.onnx
           stage third-party/picture_classifier.onnx picture_classifier.onnx
+          stage third-party/ocr_rec_en.onnx ocr_rec_en.onnx
+          stage third-party/en_dict.txt en_dict.txt
+          # Whisper tiny flattens with an asr_ prefix (release assets are one
+          # flat namespace; download_dependencies.sh maps them back into
+          # .models/asr/).
+          stage third-party/asr/encoder_model.onnx asr_encoder_model.onnx
+          stage third-party/asr/decoder_model.onnx asr_decoder_model.onnx
+          stage third-party/asr/vocab.json asr_vocab.json
+          stage third-party/asr/added_tokens.json asr_added_tokens.json
           # CodeFormula graphs flatten with a cf_ prefix (release assets are
           # one flat namespace).
           stage .models/code_formula/vision.onnx cf_vision.onnx

--- a/README.md
+++ b/README.md
@@ -1080,9 +1080,12 @@ instead — same models plus `pdfium.dll` — and see
 Idempotent — safe to re-run; it skips files already on disk. Pass `--force` to
 re-fetch everything, `--no-chunk` to skip the chunker tokenizer, `--embed` to
 also fetch the RAG embedder, or set `$DOCLING_RS_MODELS_URL` to fetch from a
-different host (your own export, an internal mirror, …); the Whisper assets
-come from Hugging Face (`$DOCLING_RS_ASR_MODELS_URL` overrides, or point
-`DOCLING_ASR_{ENCODER,DECODER,VOCAB}` at explicit files). pdfium is Linux x64
+different host (your own export, an internal mirror, …). Everything a default
+install needs is served from that one host; where the release tag predates a
+mirrored asset the script falls back to its upstream home (Hugging Face for
+the Whisper and OCR models, PaddleOCR for the dictionaries) —
+`$DOCLING_RS_ASR_MODELS_URL` overrides the Whisper host outright, or point
+`DOCLING_ASR_{ENCODER,DECODER,VOCAB}` at explicit files. pdfium is Linux x64
 only for now — other platforms, or building the models from source, need
 [`scripts/install/pdf_setup.sh`](#testing) instead.
 

--- a/docs/MODELS_NOTICE.md
+++ b/docs/MODELS_NOTICE.md
@@ -13,8 +13,9 @@ tokenizer). All are licensed separately from docling.rs's own MIT code (see
 | TableFormer (`tableformer/{encoder,decoder,bbox}.onnx`) | [`docling-project/docling-models`](https://huggingface.co/docling-project/docling-models) (`model_artifacts/tableformer/accurate`) | CDLA-Permissive-2.0 / Apache-2.0 |
 | DocumentFigureClassifier (`picture_classifier.onnx`) | [`docling-project/DocumentFigureClassifier-v2.5`](https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5) (upstream's own ONNX, re-hosted unmodified) | Apache-2.0 |
 | CodeFormulaV2 (`cf_{vision,embed,decoder_kv}.onnx` + `cf_tokenizer.json`; `cf_decoder_kv_int8.onnx` is a post-training quantization of the same export) | [`docling-project/CodeFormulaV2`](https://huggingface.co/docling-project/CodeFormulaV2) | Apache-2.0 |
-| PP-OCRv3 recognition model + dictionary (`ocr_rec.onnx`, `ppocr_keys_v1.txt`) | [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)'s `ch_PP-OCRv3_rec_infer`, taken as the ready ONNX conversion re-hosted by [`SWHL/RapidOCR`](https://huggingface.co/SWHL/RapidOCR) (unmodified) | Apache-2.0 |
-| Whisper tiny (`asr/{encoder_model,decoder_model}.onnx`, `vocab.json`) | [`onnx-community/whisper-tiny`](https://huggingface.co/onnx-community/whisper-tiny), the community ONNX export of [`openai/whisper-tiny`](https://huggingface.co/openai/whisper-tiny) (fetched directly, unmodified) | Apache-2.0 |
+| PP-OCRv3 recognition model + dictionary, multilingual (`ocr_rec.onnx`, `ppocr_keys_v1.txt`) | [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)'s `ch_PP-OCRv3_rec_infer`, taken as the ready ONNX conversion re-hosted by [`SWHL/RapidOCR`](https://huggingface.co/SWHL/RapidOCR) (unmodified) | Apache-2.0 |
+| PP-OCRv3 recognition model + dictionary, English (`ocr_rec_en.onnx`, `en_dict.txt`) | The same pair for PaddleOCR's `en_PP-OCRv3_rec_infer`, with the dictionary taken from [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) itself (`ppocr/utils/en_dict.txt`); both re-hosted unmodified | Apache-2.0 |
+| Whisper tiny (`asr/{encoder_model,decoder_model}.onnx`, `vocab.json`) | [`onnx-community/whisper-tiny`](https://huggingface.co/onnx-community/whisper-tiny), the community ONNX export of [`openai/whisper-tiny`](https://huggingface.co/openai/whisper-tiny) (re-hosted unmodified as `asr_*`; Hugging Face stays the fallback host) | Apache-2.0 |
 | Hybrid-chunker tokenizer (`chunk/tokenizer.json`) | [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)'s `tokenizer.json` (a tokenizer definition, no weights) | Apache-2.0 |
 
 (The `pdfium` shared library re-hosted alongside the models is not a model but
@@ -25,7 +26,9 @@ builds of Google's PDFium, BSD-3-Clause / Apache-2.0.)
 `scripts/install/export_code_formula.py` do the conversion (PyTorch → ONNX via
 `torch.onnx.export`); no weights are retrained, fine-tuned, or otherwise
 altered. `.github/workflows/publish-models.yml` runs
-that conversion (and re-hosts pdfium + the OCR model alongside it) and
+that conversion (and re-hosts pdfium plus the third-party models a default
+install needs — both OCR pairs, Whisper tiny, the chunk tokenizer, the picture
+classifier — alongside it) and
 publishes everything as GitHub Release assets on this repo (tag `models-v1`),
 fetched by `scripts/install/download_dependencies.sh` — see that script and
 `crates/docling-node/deps.js` — purely to spare downstream users the

--- a/scripts/install/download_dependencies.bat
+++ b/scripts/install/download_dependencies.bat
@@ -18,6 +18,8 @@ setlocal enabledelayedexpansion
 set "BASE_URL=https://github.com/docling-project/docling.rs/releases/download/models-v1"
 if not "%DOCLING_RS_MODELS_URL%"=="" set "BASE_URL=%DOCLING_RS_MODELS_URL%"
 set "ASR_BASE_URL=https://huggingface.co/onnx-community/whisper-tiny/resolve/main"
+set "OCR_EN_URL=https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/en_PP-OCRv3_rec_infer.onnx"
+set "EN_DICT_URL=https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/en_dict.txt"
 set "PDFIUM_URL=https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-win-x64.tgz"
 
 set WITH_ASR=1
@@ -43,8 +45,11 @@ where curl >nul 2>nul || (echo error: curl.exe not found ^(ships with Windows 10
 
 rem Never hang forever on a dead mirror: cap the connect phase, abort a
 rem transfer stalled below 1 KiB/s for a minute, retry transient failures
-rem (docling proper added the same guard, issue #3784).
-set "CURL_TIMEOUTS=--connect-timeout 30 --speed-limit 1024 --speed-time 60 --retry 3 --retry-delay 2"
+rem (docling proper added the same guard, issue #3784). No --retry-delay: a
+rem fixed delay bunches every attempt into a few seconds, which is useless
+rem against the per-IP 429 the third-party hosts answer shared CI/office
+rem egress with - curl's default doubling spreads them out (as in the .sh).
+set "CURL_TIMEOUTS=--connect-timeout 30 --speed-limit 1024 --speed-time 60 --retry 5"
 
 if not exist .models\tableformer mkdir .models\tableformer
 if not exist .models\asr mkdir .models\asr
@@ -73,6 +78,15 @@ rem --- required models --------------------------------------------------------
 call :fetch "%BASE_URL%/layout_heron.onnx"              .models\layout_heron.onnx           || goto :fail
 call :fetch "%BASE_URL%/ocr_rec.onnx"                   .models\ocr_rec.onnx                || goto :fail
 call :fetch "%BASE_URL%/ppocr_keys_v1.txt"              .models\ppocr_keys_v1.txt           || goto :fail
+rem English PP-OCRv3 pair - the runtime *default* OCR model (the ch_ pair
+rem above is the conformance one). Release first, upstream second: the mirror
+rem only exists on tags published after it was added, and both hosts answer
+rem 429 under load. Optional either way - the pipeline degrades to the ch_
+rem model with a warning when the pair is missing.
+call :fetch_opt "%BASE_URL%/ocr_rec_en.onnx"            .models\ocr_rec_en.onnx
+if not exist .models\ocr_rec_en.onnx call :fetch_opt "%OCR_EN_URL%" .models\ocr_rec_en.onnx
+call :fetch_opt "%BASE_URL%/en_dict.txt"                .models\en_dict.txt
+if not exist .models\en_dict.txt call :fetch_opt "%EN_DICT_URL%" .models\en_dict.txt
 call :fetch "%BASE_URL%/encoder.onnx"                   .models\tableformer\encoder.onnx    || goto :fail
 call :fetch_opt "%BASE_URL%/encoder.onnx.data"          .models\tableformer\encoder.onnx.data
 call :fetch "%BASE_URL%/decoder.onnx"                   .models\tableformer\decoder.onnx    || goto :fail
@@ -87,12 +101,25 @@ call :fetch_opt "%BASE_URL%/picture_classifier.onnx"    .models\picture_classifi
 call :fetch_opt "%BASE_URL%/chunk_tokenizer.json"       .models\chunk\tokenizer.json
 
 rem --- ASR (Whisper tiny) -----------------------------------------------------
-if %WITH_ASR%==1 (
-  call :fetch "%ASR_BASE_URL%/onnx/encoder_model.onnx"  .models\asr\encoder_model.onnx      || goto :fail
-  call :fetch "%ASR_BASE_URL%/onnx/decoder_model.onnx"  .models\asr\decoder_model.onnx      || goto :fail
-  call :fetch "%ASR_BASE_URL%/vocab.json"               .models\asr\vocab.json              || goto :fail
-  call :fetch_opt "%ASR_BASE_URL%/added_tokens.json"    .models\asr\added_tokens.json
-)
+rem Release mirror (asr_*) first, Hugging Face second - same order as the .sh
+rem twin, so a rate-limited HF doesn't sink the install. A goto guard rather
+rem than an "if (...)" block, and each tier on its own line: cmd binds a "||"
+rem written after an "if" to the whole if-statement, so a skipped fallback
+rem would inherit a stale errorlevel and jump to :fail. The required files
+rem are guarded by their own "if not exist ... goto :fail" instead.
+if %WITH_ASR%==0 goto :asr_done
+call :fetch_opt "%BASE_URL%/asr_encoder_model.onnx"     .models\asr\encoder_model.onnx
+if not exist .models\asr\encoder_model.onnx call :fetch "%ASR_BASE_URL%/onnx/encoder_model.onnx" .models\asr\encoder_model.onnx
+if not exist .models\asr\encoder_model.onnx goto :fail
+call :fetch_opt "%BASE_URL%/asr_decoder_model.onnx"     .models\asr\decoder_model.onnx
+if not exist .models\asr\decoder_model.onnx call :fetch "%ASR_BASE_URL%/onnx/decoder_model.onnx" .models\asr\decoder_model.onnx
+if not exist .models\asr\decoder_model.onnx goto :fail
+call :fetch_opt "%BASE_URL%/asr_vocab.json"             .models\asr\vocab.json
+if not exist .models\asr\vocab.json call :fetch "%ASR_BASE_URL%/vocab.json" .models\asr\vocab.json
+if not exist .models\asr\vocab.json goto :fail
+call :fetch_opt "%BASE_URL%/asr_added_tokens.json"      .models\asr\added_tokens.json
+if not exist .models\asr\added_tokens.json call :fetch_opt "%ASR_BASE_URL%/added_tokens.json" .models\asr\added_tokens.json
+:asr_done
 
 rem --- INT8 variants (preferred automatically when present; DOCLING_RS_FP32=1 opts out)
 if %WITH_INT8%==1 (

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -22,7 +22,8 @@
 #   .pdfium/lib/libpdfium.so (libpdfium.dylib on macOS)
 #   .models/layout_heron.onnx
 #   .models/ocr_rec_en.onnx + .models/en_dict.txt   (English PP-OCRv3
-#     recognition — the runtime default; from upstream PP-OCRv3 hosting)
+#     recognition — the runtime default; from the release when the tag mirrors
+#     it, else straight from upstream PP-OCRv3 hosting)
 #   .models/ocr_rec.onnx + .models/ppocr_keys_v1.txt (multilingual ch_ pair —
 #     what docling conformance is measured with; DOCLING_RS_OCR_LANG=ch)
 #   .models/tableformer/encoder.onnx (+ .data, if the export needs it)
@@ -30,7 +31,8 @@
 #   .models/tableformer/decoder_kv.onnx (+ .data; preferred when hosted)
 #   .models/tableformer/bbox.onnx (+ .data, if the export needs it)
 #   .models/asr/{encoder_model,decoder_model}.onnx + vocab.json   (Whisper tiny,
-#     from Hugging Face; skip with --no-asr)
+#     from the release when the tag mirrors it, else Hugging Face; skip with
+#     --no-asr)
 #   .models/chunk/tokenizer.json                   (all-MiniLM-L6-v2's tokenizer,
 #     the HybridChunker's default token counter; falls back to Hugging Face when
 #     the release doesn't host it; skip with --no-chunk)
@@ -66,11 +68,16 @@
 set -eu
 
 BASE_URL="${DOCLING_RS_MODELS_URL:-https://github.com/docling-project/docling.rs/releases/download/models-v1}"
-# Whisper tiny (docling's ASR default) for the audio pipeline, fetched straight
-# from the onnx-community export on Hugging Face (~150 MB). Override the base
-# with $DOCLING_RS_ASR_MODELS_URL (e.g. to re-host alongside the other models);
-# skip entirely with --no-asr.
+# Whisper tiny (docling's ASR default) for the audio pipeline: the
+# onnx-community export (~150 MB), mirrored into the models release as
+# asr_*, with Hugging Face as the fallback host. Override the base with
+# $DOCLING_RS_ASR_MODELS_URL (e.g. an internal re-host) — an explicit override
+# is used alone, without the release mirror. Skip entirely with --no-asr.
 ASR_BASE_URL="${DOCLING_RS_ASR_MODELS_URL:-https://huggingface.co/onnx-community/whisper-tiny/resolve/main}"
+ASR_MIRROR_URL="$BASE_URL"
+if [ -n "${DOCLING_RS_ASR_MODELS_URL:-}" ]; then
+  ASR_MIRROR_URL=
+fi
 # bge-m3 ONNX export for docling-rag's local embedder (--embed): community
 # export with a pooled `dense_vecs` output, fetched straight from HF.
 EMBED_BASE_URL="${DOCLING_RS_EMBED_MODELS_URL:-https://huggingface.co/aapot/bge-m3-onnx/resolve/main}"
@@ -115,7 +122,12 @@ fi
 # Never hang forever on a dead mirror: cap the connect phase, abort a transfer
 # that stalls below 1 KiB/s for a minute, and retry transient failures with
 # curl's built-in backoff (docling proper added the same guard, issue #3784).
-CURL_TIMEOUTS="--connect-timeout 30 --speed-limit 1024 --speed-time 60 --retry 3 --retry-delay 2"
+# No --retry-delay: a fixed delay pins every attempt to the same short wait —
+# the container build's four tries at 2s landed inside six seconds, which is
+# nothing against the per-IP 429 Hugging Face answers CI runners with. Curl's
+# default doubling (1s, 2s, 4s, …) spreads five attempts over half a minute
+# instead; a server-sent Retry-After still overrides either way.
+CURL_TIMEOUTS="--connect-timeout 30 --speed-limit 1024 --speed-time 60 --retry 5"
 
 fetch() { # <url> <dest>
   if [ "$FORCE" = false ] && [ -f "$2" ]; then
@@ -129,7 +141,8 @@ fetch() { # <url> <dest>
 }
 
 fetch_optional() { # <url> <dest> — ignore a missing/failed asset (sidecar files)
-  if [ "$FORCE" = false ] && [ -f "$2" ]; then
+  # An empty URL is a mirror that doesn't apply to this run (see fetch_mirrored).
+  if [ -z "$1" ] || { [ "$FORCE" = false ] && [ -f "$2" ]; }; then
     return 0
   fi
   # shellcheck disable=SC2086
@@ -139,6 +152,30 @@ fetch_optional() { # <url> <dest> — ignore a missing/failed asset (sidecar fil
   else
     rm -f "$2.download"
   fi
+}
+
+fetch_mirrored() { # <dest> <url>... — first URL that lands wins
+  dest=$1
+  shift
+  if [ "$FORCE" = false ] && [ -f "$dest" ]; then
+    echo "  = $dest (already present)"
+    return 0
+  fi
+  for url in "$@"; do
+    # An empty entry is a mirror that doesn't apply to this run (e.g. the
+    # release mirror when $DOCLING_RS_ASR_MODELS_URL overrides the host).
+    [ -n "$url" ] || continue
+    # shellcheck disable=SC2086
+    if curl -fsSL $CURL_TIMEOUTS -o "$dest.download" "$url"; then
+      mv "$dest.download" "$dest"
+      echo "  > $dest"
+      return 0
+    fi
+    rm -f "$dest.download"
+    echo "  ! $url unavailable — trying the next mirror" >&2
+  done
+  echo "error: could not fetch $dest from any mirror" >&2
+  return 1
 }
 
 echo "fetching docling.rs ML dependencies from $BASE_URL"
@@ -182,10 +219,16 @@ fetch "$BASE_URL/layout_heron.onnx" .models/layout_heron.onnx
 fetch "$BASE_URL/ocr_rec.onnx" .models/ocr_rec.onnx
 fetch "$BASE_URL/ppocr_keys_v1.txt" .models/ppocr_keys_v1.txt
 # English PP-OCRv3 recognition pair — the runtime default (the ch_ pair above
-# stays the conformance model, selected with DOCLING_RS_OCR_LANG=ch). Fetched
-# from upstream PP-OCRv3 hosting, not the models release.
-fetch "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/en_PP-OCRv3_rec_infer.onnx" .models/ocr_rec_en.onnx
-fetch "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/en_dict.txt" .models/en_dict.txt
+# stays the conformance model, selected with DOCLING_RS_OCR_LANG=ch). The
+# release mirrors both (publish-models.yml re-hosts them unmodified); the
+# upstream hosts stay as the fallback for release tags that predate the
+# mirror.
+fetch_mirrored .models/ocr_rec_en.onnx \
+  "$BASE_URL/ocr_rec_en.onnx" \
+  "https://huggingface.co/SWHL/RapidOCR/resolve/main/PP-OCRv3/en_PP-OCRv3_rec_infer.onnx"
+fetch_mirrored .models/en_dict.txt \
+  "$BASE_URL/en_dict.txt" \
+  "https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/en_dict.txt"
 fetch "$BASE_URL/encoder.onnx" .models/tableformer/encoder.onnx
 fetch_optional "$BASE_URL/encoder.onnx.data" .models/tableformer/encoder.onnx.data
 fetch "$BASE_URL/decoder.onnx" .models/tableformer/decoder.onnx
@@ -202,9 +245,16 @@ if [ "$WITH_ASR" = true ]; then
   # Whisper tiny for audio/ASR: encoder + (cache-less) decoder + vocabulary;
   # added_tokens.json feeds non-English language selection and the special-
   # token layout, so a missing asset there is not fatal for the default model.
-  fetch "$ASR_BASE_URL/onnx/encoder_model.onnx" .models/asr/encoder_model.onnx
-  fetch "$ASR_BASE_URL/onnx/decoder_model.onnx" .models/asr/decoder_model.onnx
-  fetch "$ASR_BASE_URL/vocab.json" .models/asr/vocab.json
+  fetch_mirrored .models/asr/encoder_model.onnx \
+    "${ASR_MIRROR_URL:+$ASR_MIRROR_URL/asr_encoder_model.onnx}" \
+    "$ASR_BASE_URL/onnx/encoder_model.onnx"
+  fetch_mirrored .models/asr/decoder_model.onnx \
+    "${ASR_MIRROR_URL:+$ASR_MIRROR_URL/asr_decoder_model.onnx}" \
+    "$ASR_BASE_URL/onnx/decoder_model.onnx"
+  fetch_mirrored .models/asr/vocab.json \
+    "${ASR_MIRROR_URL:+$ASR_MIRROR_URL/asr_vocab.json}" \
+    "$ASR_BASE_URL/vocab.json"
+  fetch_optional "${ASR_MIRROR_URL:+$ASR_MIRROR_URL/asr_added_tokens.json}" .models/asr/added_tokens.json
   fetch_optional "$ASR_BASE_URL/added_tokens.json" .models/asr/added_tokens.json
 fi
 
@@ -237,11 +287,9 @@ if [ "$WITH_CHUNK" = true ]; then
   # given. Fetched from the release when hosted (newer tags), else straight
   # from Hugging Face.
   mkdir -p .models/chunk
-  fetch_optional "$BASE_URL/chunk_tokenizer.json" .models/chunk/tokenizer.json
-  if [ ! -f .models/chunk/tokenizer.json ]; then
-    fetch "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json" \
-      .models/chunk/tokenizer.json
-  fi
+  fetch_mirrored .models/chunk/tokenizer.json \
+    "$BASE_URL/chunk_tokenizer.json" \
+    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
 fi
 
 # DocumentFigureClassifier (picture classification enrichment, ~17 MB): the
@@ -249,11 +297,9 @@ fi
 # fetched by default — from the release when hosted, else the upstream ONNX
 # straight from Hugging Face (docling-project/DocumentFigureClassifier-v2.5
 # ships the graph itself).
-fetch_optional "$BASE_URL/picture_classifier.onnx" .models/picture_classifier.onnx
-if [ ! -f .models/picture_classifier.onnx ]; then
-  fetch "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx" \
-    .models/picture_classifier.onnx
-fi
+fetch_mirrored .models/picture_classifier.onnx \
+  "$BASE_URL/picture_classifier.onnx" \
+  "https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5/resolve/main/model.onnx"
 
 if [ "$WITH_ENRICH" = true ]; then
   # CodeFormulaV2 (code/formula enrichment, ~1.3 GB fp32): the


### PR DESCRIPTION
The CUDA image build died in the shared `assets` stage: four curl attempts at `en_PP-OCRv3_rec_infer.onnx` all came back 429 inside six seconds and the Dockerfile step exited 22. Nothing about that asset is special — it is simply one of the few a *default* install still pulls from a third-party host, and Hugging Face rate-limits shared CI egress per IP.

So mirror the rest into the models release, which is what publish-models.yml already exists to do: the English PP-OCRv3 pair (`ocr_rec_en.onnx` + `en_dict.txt` — the *runtime default* OCR model; only the conformance `ch_` pair was mirrored before) and Whisper tiny (`asr_*`, the ASR default). After a re-run of that workflow, a default install and every container build fetch from one host; only the opt-in extras (`--asr-model` presets, `--embed`) still reach upstream.

download_dependencies.sh grows a `fetch_mirrored` helper — release first, upstream second, the first URL that lands wins — so it keeps working on release tags that predate the mirror (verified end-to-end: today's models-v1 404s both new names and falls through to Hugging Face / PaddleOCR). It also replaces the hand-rolled two-tier fetch the chunk tokenizer and picture classifier already had. An explicit $DOCLING_RS_ASR_MODELS_URL still wins alone, without the mirror in front of it.

Both scripts also drop `--retry-delay 2`: a fixed delay pins every attempt to the same short wait — the failing build's four tries all landed inside six seconds — where curl's default doubling spreads five attempts over half a minute. A server-sent Retry-After is honoured either way (checked against a local 429 responder, curl 8.5). The publish workflow's own fetches, which had no retry at all, take the same policy.

The Windows twin gains the same mirror-first order for the English pair and the ASR files; its ASR block becomes a goto guard with one command per line, because cmd binds a `||` written after an `if` to the whole if-statement and a skipped fallback would then jump to :fail on a stale errorlevel.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT