### PR TITLE
fix(models): 7-bit layout INT8 weights so the quant is CPU-independent

### DIFF
--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -75,9 +75,16 @@ jobs:
       # tables) and deletes its output on failure — so a bad quant simply
       # isn't staged and the release stays fp32-only for that model
       # (download_dependencies.sh treats every int8 asset as optional). The
-      # quant itself is deterministic given the fp32 input; what drifts
-      # between runs is the *export* upstream of it, which is exactly what
-      # the gate protects against. Deps pinned to the validated set. Two
+      # quant is deterministic given the fp32 input, and the export upstream
+      # of it is stable too (two exports of the same weights differ only by
+      # ~1e-7 in the constant-folded BatchNorm scales). What used to flip the
+      # gate between runs was the RUNNER'S CPU: it runs int8 inference, and
+      # the previous recipe's full-range weights saturated int16 in the AVX2
+      # kernel on runners without VNNI (83 of 505 detections lost there, 1
+      # on a VNNI box with the same input).
+      # quantize_models.py now emits 7-bit weights and checks that range
+      # hardware-independently, so the outcome no longer depends on which
+      # machine the job landed on. Deps pinned to the validated set. Two
       # separate steps so a TableFormer export failure doesn't block the
       # layout int8.
       - name: Install quantization deps
@@ -88,7 +95,13 @@ jobs:
       - name: Quantize layout model (static INT8, conv-only)
         if: steps.quant-deps.outcome == 'success'
         continue-on-error: true
-        run: python scripts/install/quantize_models.py layout
+        run: |
+          # The accuracy gate infers on this CPU, so record which int8 kernel
+          # it used — VNNI vs plain AVX2 is the first thing to check if the
+          # gate ever disagrees with a local run again.
+          grep -m1 '^model name' /proc/cpuinfo || true
+          echo "int8 ISA: $(grep -o -m1 'avx512_vnni\|avx_vnni\|avx2' /proc/cpuinfo | sort -u | tr '\n' ' ')"
+          python scripts/install/quantize_models.py layout
 
       - name: Quantize TableFormer decoder (dynamic INT8)
         if: steps.quant-deps.outcome == 'success' && steps.tf-export.outcome == 'success'

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -820,6 +820,36 @@ PDF+scanned corpus):
   per-activation quantize ops outweigh the MatMul savings while the conv
   backbone stays fp32.
 
+##### 7-bit weights: the same model on every x86 CPU
+
+The quantizer emits **7-bit** weights (`reduce_range=True`). u8 activations
+times s8 weights go through `VPMADDUBSW` on CPUs without VNNI, and that
+instruction sums two products into one int16 slot: full-range weights reach
+255·127·2 = 64770 and saturate at 32767, so a model that measures perfectly on
+the machine that quantized it can drop whole regions on a plain AVX2 CPU.
+Not hypothetical — a publish run's agreement gate lost **83 of 505** confident
+detections (two of them tables) on a runner without VNNI, while the same recipe
+over a structurally identical export lost **1** on a VNNI box. 7 bits caps the
+pair product at 255·64·2 = 32640, below saturation.
+
+It costs nothing. Same VNNI machine, same corpus, 4 intra-op threads (the
+ratios are the point, not the absolute times — this is a shared container, not
+the benchmark box the table above was measured on):
+
+| layout_heron | agreement gate (505 confident fp32 detections) | 640×640 inference |
+|---|---:|---:|
+| fp32 | — | 548 ms |
+| INT8, full-range weights | 1 lost (0.20%) | 290 ms |
+| **INT8, 7-bit weights** | **0 lost (0.00%)** | **282 ms** |
+
+`quantize_models.py` checks the weight range right after quantizing
+(`check_weight_range`), before the accuracy gate. Reading weights is
+hardware-independent, so a recipe that reintroduces full-range weights fails on
+the publishing machine instead of on a user's laptop — the accuracy gate alone
+cannot catch this, since it only ever exercises the ISA it happens to run on.
+An int8 layout model fetched before this change is full-range: on a non-VNNI
+CPU, refetch after the next models publish, or set `DOCLING_RS_FP32=1`.
+
 #### TableFormer decoder: dynamic INT8 (~10% faster tables, byte-identical)
 
 The autoregressive tag decoder is MatMul-only; weights-only dynamic INT8

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -304,11 +304,12 @@ if [ "$WITH_INT8" = true ]; then
   else
     echo "layout int8 not hosted at $BASE_URL — the fp32 layout model will be used"
     echo "(correct output, ~2.4x slower layout stage on CPU; irrelevant for GPU builds,"
-    echo "which prefer fp32 anyway). The publish gate currently rejects the CI export's"
-    echo "int8 quantization, and quantizing the downloaded fp32 reproduces exactly that"
-    echo "rejected artifact — a good local int8 needs a layout model exported from"
-    echo "source first (scripts/install/pdf_setup.sh), then the self-validating"
+    echo "which prefer fp32 anyway). Publish runs left it unhosted while the quantizer's"
+    echo "gate kept rejecting the result — that was int16 saturation of full-range"
+    echo "weights on runners without VNNI, now fixed with 7-bit weights. Until the next"
+    echo "models publish, build one from the fp32 model this script just fetched:"
     echo "  python scripts/install/quantize_models.py layout"
+    echo "(it self-validates and keeps nothing that fails the gates)."
     echo "See docs/PDF_CONFORMANCE.md."
   fi
 fi

--- a/scripts/install/quantize_models.py
+++ b/scripts/install/quantize_models.py
@@ -11,6 +11,8 @@ docs/PDF_CONFORMANCE.md for the measured speed/quality numbers):
   the 0.3 threshold and visibly degrades output (headers demoted to text,
   page-footers leaking in), while conv-only keeps groundtruth conformance at
   fp32 level. ~2.4x faster layout inference on AVX-512-VNNI CPUs, 172 -> 68 MB.
+  Weights are 7-bit (`reduce_range`), which costs nothing here and keeps the
+  model correct on CPUs *without* VNNI — see `check_weight_range`.
 
 * **tableformer-decoder** — dynamic INT8 (weights-only MatMul) of the
   legacy autoregressive tag decoder (~10% faster than its fp32 file,
@@ -130,12 +132,57 @@ def quantize_layout():
         activation_type=QuantType.QUInt8,
         weight_type=QuantType.QInt8,
         per_channel=True,
+        # 7-bit weights. u8s8 convolutions run through VPMADDUBSW on CPUs
+        # without VNNI, whose int16 pair accumulator saturates at 32767:
+        # full-range weights reach 255*127*2 = 64770 and silently clip, which
+        # is what wrecked a publish run (83 of 505 confident detections lost,
+        # two of them tables, on a runner this recipe passes on elsewhere).
+        # 7 bits caps the pair product at 255*64*2 = 32640 — below the
+        # saturation point, so the model behaves the same on every x86 CPU.
+        reduce_range=True,
         # Conv-only: the RT-DETR decoder/head MatMuls are threshold-sensitive.
         op_types_to_quantize=["Conv"],
     )
     os.remove(pre)
     print(f"layout: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
+    check_weight_range(dst)
     validate_layout(src, dst)
+
+
+# u8 activations times 7-bit weights, two lanes per VPMADDUBSW int16 slot.
+SATURATION_SAFE_MAX = 64  # 255 * 64 * 2 = 32640 <= int16 max (32767)
+
+
+def check_weight_range(dst):
+    """Portability gate: every quantized weight must stay within 7 bits.
+
+    The accuracy gate below only proves the model right on the machine that
+    ran it — int8 convolutions take a different kernel per ISA, and the AVX2
+    one (no VNNI) accumulates u8*s8 products pairwise in int16. A full-range
+    weight saturates there, so a model that looks perfect on the quantizing
+    box can lose whole detections on a plain AVX2 CPU. This check is
+    hardware-independent: it reads the weights, so it fails on the publishing
+    machine rather than on a user's laptop."""
+    import onnx
+    from onnx import numpy_helper
+
+    over = []
+    for init in onnx.load(dst).graph.initializer:
+        arr = numpy_helper.to_array(init)
+        if arr.dtype == np.int8 and arr.size:
+            peak = int(np.abs(arr).max())
+            if peak > SATURATION_SAFE_MAX:
+                over.append((init.name, peak))
+    if over:
+        os.remove(dst)
+        worst = max(p for _, p in over)
+        sys.exit(
+            f"layout: {len(over)} weight tensor(s) exceed {SATURATION_SAFE_MAX}"
+            f" (worst |w| = {worst}, e.g. {over[0][0]}) — int16 saturation on"
+            f" non-VNNI CPUs would corrupt inference; {dst} deleted."
+            " Quantize with reduce_range=True."
+        )
+    print("layout: weights within 7 bits — no int16 saturation on any x86 CPU")
 
 
 # Mirror of layout.rs::LABELS — for the gate's reporting and the table check.
@@ -185,7 +232,11 @@ def validate_layout(src, dst):
     (a dropped table silently degrades to `<!-- image -->` downstream — the
     exact regression this gate exists to stop) and <= 2% for the rest.
     On failure the int8 file is DELETED so a publish run stages fp32 only
-    (download_dependencies.sh falls back gracefully — int8 is fetch_optional)."""
+    (download_dependencies.sh falls back gracefully — int8 is fetch_optional).
+
+    Machine-dependent by construction: it runs both graphs on *this* CPU, so
+    it catches quantization error but not ISA-specific kernel behaviour —
+    that is what check_weight_range covers."""
     import onnxruntime as ort
 
     for path, kind in ((src, "fp32"), (dst, "int8")):


### PR DESCRIPTION
The publish run's layout gate lost 83 of 505 confident detections (two of them tables) and deleted its int8 output, as it has for a while — so the release ships fp32-only and CPU layout runs ~2x slower than it needs to.

The cause is not the export. Exporting layout_heron from source here produces a graph structurally identical to the one in the release — same 3361 nodes, same node names, same initializer set — differing only by ~1e-7 in 193 constant-folded BatchNorm scales. Quantizing the release's own fp32 on this machine passes the gate at 1/505 (0.20%), and the fresh source export passes identically. The variable was the machine: the gate infers, and u8s8 convolutions take a different kernel per ISA. Without VNNI, MLAS goes through VPMADDUBSW, which sums two u8*s8 products into one int16 slot — and 97 of the 194 weight tensors this recipe emitted used the full +/-127 range, so the pair product reached 255*127*2 = 64770 against an int16 ceiling of 32767. The weights saturated on the runner and the detections went with them.

So the shipped artifact was never portable: whenever the gate did pass, it passed on a VNNI machine and the resulting model would have silently degraded layout on any plain-AVX2 CPU. `reduce_range=True` caps weights at 7 bits (255*64*2 = 32640, under the ceiling). Measured on the same VNNI box, same corpus: the gate goes from 1 lost to 0 lost, and inference is unchanged (290 -> 282 ms against 548 ms fp32).

Since an accuracy gate can only ever exercise the ISA it runs on, add `check_weight_range` next to it: it reads the weights, so it is hardware-independent and fails on the publishing machine rather than on a user's laptop. Verified in both directions — it passes the new artifact and rejects the pre-fix one (97 tensors, worst |w| = 127), deleting it as the accuracy gate does.

The publish workflow now logs the runner's int8 ISA, so a future disagreement between CI and a local run is one line away from a diagnosis; its comment claiming the *export* drifts is replaced with what actually varied. download_dependencies.sh's advice to re-export from source before quantizing locally is dropped for the same reason: the fetched fp32 quantizes fine.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT