### PR TITLE
perf(pdf): decode a page's tables in one batched TableFormer loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,7 +1070,7 @@ instead — same models plus `pdfium.dll` — and see
 | RT-DETR layout | `.models/layout_heron.onnx` |
 | PP-OCRv3 rec + dictionary, English (the runtime default) | `.models/ocr_rec_en.onnx`, `.models/en_dict.txt` |
 | PP-OCRv3 rec + dictionary, multilingual `ch_` (`DOCLING_RS_OCR_LANG=ch`; the docling-conformance model — weak Latin word spacing) | `.models/ocr_rec.onnx`, `.models/ppocr_keys_v1.txt` |
-| TableFormer (optional) | `.models/tableformer/{encoder,decoder,bbox}.onnx` (+ `.data` sidecars where the export needs them) |
+| TableFormer (optional) | `.models/tableformer/{encoder,decoder,bbox}.onnx` (+ `.data` sidecars where the export needs them); `decoder_kv.onnx` is preferred when present — its current export has a dynamic batch axis, so all tables on a page decode in one lockstep loop (byte-identical to one at a time; an older fixed-batch `decoder_kv.onnx` still works, one table at a time) |
 | Whisper tiny (audio/ASR; skip with `--no-asr`) | `.models/asr/{encoder_model,decoder_model}.onnx`, `.models/asr/vocab.json` (+ `added_tokens.json` for language selection) |
 | Whisper presets (optional; `--asr-model=<preset>`, repeatable) | `.models/asr/<preset>/…` — English-only (`whisper_tiny_en`, `whisper_base_en`, `whisper_small_en`) and Distil-Whisper (`whisper_distil_small_en`) exports, fetched from Hugging Face |
 | INT8 CPU models (fetched by default; skip with `--no-int8`) | `.models/layout_heron_int8.onnx`, `.models/tableformer/decoder_int8.onnx` (+ `.models/code_formula/decoder_kv_int8.onnx` with `--enrich`) |

--- a/crates/docling-pdf/src/lib.rs
+++ b/crates/docling-pdf/src/lib.rs
@@ -992,17 +992,21 @@ impl Worker {
             };
         }
         if let TfSlot::Ready(tf) = guard {
-            // One 1024-px frame per page, shared by all of its tables.
+            // One 1024-px frame per page, shared by all of its tables, and one
+            // call for all of them: with the dynamic-batch decoder their
+            // decode steps are shared (each step costs about the same for B
+            // tables as for one).
             let page1024 = tableformer::TableFormer::page_1024(&page.image);
-            for (i, r) in regions.iter().enumerate() {
-                if assemble::is_table_like(r.label) {
-                    table_rows[i] = tf.predict_table_rows_on(
-                        page.image.height(),
-                        &page1024,
-                        [r.l, r.t, r.r, r.b],
-                        &page.word_cells,
-                    );
-                }
+            let (idx, boxes): (Vec<usize>, Vec<[f32; 4]>) = regions
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| assemble::is_table_like(r.label))
+                .map(|(i, r)| (i, [r.l, r.t, r.r, r.b]))
+                .unzip();
+            let rows =
+                tf.predict_tables_on(page.image.height(), &page1024, &boxes, &page.word_cells);
+            for (i, grid) in idx.into_iter().zip(rows) {
+                table_rows[i] = grid;
             }
         }
         table_rows

--- a/crates/docling-pdf/src/tableformer.rs
+++ b/crates/docling-pdf/src/tableformer.rs
@@ -72,6 +72,11 @@ pub struct TableFormer {
     /// input names (so an explicit `DOCLING_TABLEFORMER_DECODER` override
     /// works with any of them).
     style: DecoderStyle,
+    /// The `KvHoisted` decoder's `tag` input has a symbolic batch axis (the
+    /// dynamic-batch `decoder_kv.onnx` export): a page's tables decode
+    /// together, one step for all of them — see [`Self::predict_tables_on`].
+    /// The older fixed-`[1,1]` export decodes the tables one after another.
+    batched: bool,
 }
 
 /// The three decoder-graph generations the loop supports.
@@ -113,8 +118,12 @@ type EmptyCache = (Tensor<f32>, Option<Tensor<f32>>);
 /// `enc_out` for the bbox decoder. Kept as owned `ort` values so each decode step
 /// (and the bbox run) borrows them directly — no per-step extract/copy/re-wrap.
 struct EncodeOut {
-    ck: DynValue,
-    cv: DynValue,
+    /// Stacked `[N_LAYERS,1,H,S,hd]` cross K/V — the `Legacy`/`KvStacked`
+    /// decoders' inputs. `None` for `KvHoisted`, which reads the per-layer
+    /// tensors instead: the stacked pair is 2×9.6 MB per table, and a page's
+    /// tables are now all held encoded at once for the batched loop.
+    ck: Option<DynValue>,
+    cv: Option<DynValue>,
     eo: DynValue,
     /// `KvHoisted` only: per-layer `[cross_kt_0..N, cross_v_0..N]`, index-aligned
     /// with the decoder's input names, borrowed by every decode step.
@@ -217,11 +226,23 @@ impl TableFormer {
                     );
                     return None;
                 }
+                // Dynamic batch axis on `tag` ⇒ the export batches decode
+                // steps across tables (ort reports a symbolic dim as -1).
+                let batched = style == DecoderStyle::KvHoisted
+                    && decoder.inputs().iter().any(|i| {
+                        i.name() == "tag"
+                            && matches!(i.dtype(), ort::value::ValueType::Tensor { shape, .. }
+                                if shape.first().is_some_and(|d| *d < 0))
+                    });
+                if crate::timing::enabled() && batched {
+                    eprintln!("docling-pdf: tableformer decoder batches a page's tables per step");
+                }
                 Some(Self {
                     encoder,
                     decoder,
                     bbox,
                     style,
+                    batched,
                 })
             }
             _ => None,
@@ -258,9 +279,18 @@ impl TableFormer {
                 .remove(name)
                 .ok_or_else(|| format!("tableformer: encoder output {name} missing"))
         };
+        let hoisted = self.style == DecoderStyle::KvHoisted;
         Ok(EncodeOut {
-            ck: grab("cross_k")?,
-            cv: grab("cross_v")?,
+            ck: if hoisted {
+                None
+            } else {
+                Some(grab("cross_k")?)
+            },
+            cv: if hoisted {
+                None
+            } else {
+                Some(grab("cross_v")?)
+            },
             eo: grab("enc_out")?,
             per_layer,
         })
@@ -293,40 +323,19 @@ impl TableFormer {
         cache: &mut DecodeCache,
         empty: &EmptyCache,
     ) -> Result<(i64, Vec<f32>), String> {
+        if self.style == DecoderStyle::KvHoisted {
+            // #97 graph: one tag; the constant per-layer cross tensors are
+            // borrowed views — the step pays nothing proportional to them.
+            let last = *tags.last().expect("decode starts from <start>");
+            let (raws, hidden) = self.step_kv_hoisted(&[last], &enc.per_layer, cache, empty)?;
+            return Ok((raws[0], hidden));
+        }
+        let (ck, cv) = match (enc.ck.as_ref(), enc.cv.as_ref()) {
+            (Some(k), Some(v)) => (k, v),
+            _ => return Err("tableformer: stacked cross K/V missing".into()),
+        };
         let mut dout = match self.style {
-            DecoderStyle::KvHoisted => {
-                // #97 graph: one tag; the constant per-layer cross tensors are
-                // borrowed views — the step pays nothing proportional to them.
-                let last = *tags.last().expect("decode starts from <start>");
-                let tag_t = Tensor::from_array(([1usize, 1usize], vec![last]))
-                    .map_err(|e| format!("tableformer: tag: {e}"))?;
-                let mut inputs: Vec<(
-                    std::borrow::Cow<'_, str>,
-                    ort::session::SessionInputValue<'_>,
-                )> = Vec::with_capacity(3 + enc.per_layer.len());
-                inputs.push(("tag".into(), tag_t.into()));
-                match (cache.a.as_ref(), cache.b.as_ref()) {
-                    (Some(k), Some(v)) => {
-                        inputs.push(("cache_k".into(), k.into()));
-                        inputs.push(("cache_v".into(), v.into()));
-                    }
-                    _ => {
-                        inputs.push(("cache_k".into(), (&empty.0).into()));
-                        inputs.push((
-                            "cache_v".into(),
-                            empty
-                                .1
-                                .as_ref()
-                                .expect("kv empty cache has both halves")
-                                .into(),
-                        ));
-                    }
-                }
-                for (name, v) in &enc.per_layer {
-                    inputs.push((name.as_str().into(), v.into()));
-                }
-                self.decoder.run(inputs)
-            }
+            DecoderStyle::KvHoisted => unreachable!("handled above"),
             DecoderStyle::KvStacked => {
                 // Pre-#97 KV graph: feed only the newly emitted tag; the projected
                 // K/V for the whole prefix live in cache_k/cache_v and are fed
@@ -336,10 +345,10 @@ impl TableFormer {
                     .map_err(|e| format!("tableformer: tag: {e}"))?;
                 match (cache.a.as_ref(), cache.b.as_ref()) {
                     (Some(k), Some(v)) => self.decoder.run(ort::inputs![
-                        "tag" => tag_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                        "tag" => tag_t, "cross_k" => ck, "cross_v" => cv,
                         "cache_k" => k, "cache_v" => v]),
                     _ => self.decoder.run(ort::inputs![
-                        "tag" => tag_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                        "tag" => tag_t, "cross_k" => ck, "cross_v" => cv,
                         "cache_k" => &empty.0,
                         "cache_v" => empty.1.as_ref().expect("kv empty cache has both halves")]),
                 }
@@ -349,10 +358,10 @@ impl TableFormer {
                     .map_err(|e| format!("tableformer: tags: {e}"))?;
                 match cache.a.as_ref() {
                     None => self.decoder.run(ort::inputs![
-                        "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                        "tags" => tags_t, "cross_k" => ck, "cross_v" => cv,
                         "cache" => &empty.0]),
                     Some(c) => self.decoder.run(ort::inputs![
-                        "tags" => tags_t, "cross_k" => &enc.ck, "cross_v" => &enc.cv,
+                        "tags" => tags_t, "cross_k" => ck, "cross_v" => cv,
                         "cache" => c]),
                 }
             }
@@ -384,14 +393,161 @@ impl TableFormer {
         Ok((raw, hidden))
     }
 
-    /// The zero-`past` first-step cache(s), allocated through the session
-    /// allocator (ort's array constructors reject a 0-length dim; the C API does
-    /// allow it).
-    fn empty_cache(&self) -> Result<EmptyCache, String> {
+    /// One `KvHoisted` step over `tags.len()` rows — one table per row. `tags`
+    /// holds each row's last emitted tag, `per_layer` the cross tensors with a
+    /// matching leading batch axis (the encoder's own `[1,…]` outputs for a
+    /// single table, or [`Self::batch_cross`]'s concatenation), and the cache
+    /// grows `[N_LAYERS, rows, H, past, hd]` in lockstep. Returns each row's raw
+    /// argmax tag and the `[rows, EMBED_DIM]` hidden states, flattened.
+    fn step_kv_hoisted(
+        &mut self,
+        tags: &[i64],
+        per_layer: &[(String, DynValue)],
+        cache: &mut DecodeCache,
+        empty: &EmptyCache,
+    ) -> Result<(Vec<i64>, Vec<f32>), String> {
+        let rows = tags.len();
+        let tag_t = Tensor::from_array(([rows, 1usize], tags.to_vec()))
+            .map_err(|e| format!("tableformer: tag: {e}"))?;
+        let mut inputs: Vec<(
+            std::borrow::Cow<'_, str>,
+            ort::session::SessionInputValue<'_>,
+        )> = Vec::with_capacity(3 + per_layer.len());
+        inputs.push(("tag".into(), tag_t.into()));
+        match (cache.a.as_ref(), cache.b.as_ref()) {
+            (Some(k), Some(v)) => {
+                inputs.push(("cache_k".into(), k.into()));
+                inputs.push(("cache_v".into(), v.into()));
+            }
+            _ => {
+                inputs.push(("cache_k".into(), (&empty.0).into()));
+                inputs.push((
+                    "cache_v".into(),
+                    empty
+                        .1
+                        .as_ref()
+                        .expect("kv empty cache has both halves")
+                        .into(),
+                ));
+            }
+        }
+        for (name, v) in per_layer {
+            inputs.push((name.as_str().into(), v.into()));
+        }
+        let mut dout = self
+            .decoder
+            .run(inputs)
+            .map_err(|e| format!("tableformer: decode: {e}"))?;
+        let (_, logits) = dout["logits"]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("tableformer: logits: {e}"))?;
+        let vocab = logits.len() / rows;
+        let raws: Vec<i64> = logits
+            .chunks_exact(vocab)
+            .map(|row| argmax(row) as i64)
+            .collect();
+        let (_, hidden) = dout["hidden"]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("tableformer: hidden: {e}"))?;
+        let hidden = hidden.to_vec();
+        cache.a = Some(
+            dout.remove("out_cache_k")
+                .ok_or_else(|| "tableformer: out_cache_k missing".to_string())?,
+        );
+        cache.b = Some(
+            dout.remove("out_cache_v")
+                .ok_or_else(|| "tableformer: out_cache_v missing".to_string())?,
+        );
+        Ok((raws, hidden))
+    }
+
+    /// Stack the per-layer cross tensors of several encoded tables along the
+    /// batch axis (`[1,H,hd,S]` × B → `[B,H,hd,S]`, same for `cross_v`), index-
+    /// aligned with the decoder's input names. One copy per page — ~20 MB per
+    /// table, nothing next to the decode steps it lets the tables share.
+    fn batch_cross(encs: &[EncodeOut]) -> Result<Vec<(String, DynValue)>, String> {
+        let b = encs.len();
+        let mut out = Vec::with_capacity(encs[0].per_layer.len());
+        for j in 0..encs[0].per_layer.len() {
+            let name = encs[0].per_layer[j].0.clone();
+            let mut data: Vec<f32> = Vec::new();
+            let mut dims = [b, 0, 0, 0];
+            for enc in encs {
+                let (shape, v) = enc.per_layer[j]
+                    .1
+                    .try_extract_tensor::<f32>()
+                    .map_err(|e| format!("tableformer: {name}: {e}"))?;
+                if shape.len() != 4 || shape[0] != 1 {
+                    return Err(format!("tableformer: {name}: unexpected shape {shape:?}"));
+                }
+                dims[1..].copy_from_slice(&[
+                    shape[1] as usize,
+                    shape[2] as usize,
+                    shape[3] as usize,
+                ]);
+                data.reserve(v.len() * b);
+                data.extend_from_slice(v);
+            }
+            let t = Tensor::from_array((dims, data))
+                .map_err(|e| format!("tableformer: {name}: {e}"))?;
+            out.push((name, t.into_dyn()));
+        }
+        Ok(out)
+    }
+
+    /// Decode `encs.len()` tables in lockstep: every step runs the decoder once
+    /// over all of them (a step is 49 weight-streaming GEMMs over one token per
+    /// row — B rows cost about what one does). The caches start empty for
+    /// every row and grow together, so nothing is ever padded or masked; a
+    /// table that emits `<end>` simply keeps its row (fed `END`, output
+    /// ignored) until the last one finishes. Row b of every op is exactly the
+    /// single-table computation, so each table's tokens and hidden states are
+    /// bit-identical to decoding it alone (asserted by the export script's
+    /// batching gate; the corpus snapshots pin it end-to-end).
+    fn decode_batch(&mut self, encs: &[EncodeOut]) -> Result<Vec<BboxBook>, String> {
+        let b = encs.len();
+        let cross = Self::batch_cross(encs)?;
+        let mut books: Vec<BboxBook> = (0..b).map(|_| BboxBook::new()).collect();
+        let mut active = vec![true; b];
+        let mut last = vec![START; b];
+        let mut cache = DecodeCache::default();
+        let empty = self.empty_cache(b)?;
+        crate::timing::timed("tf.decode_loop", || -> Result<(), String> {
+            // Each active table's `otsl` grows by one per step, so a shared
+            // step counter is the per-table `otsl.len() < MAX_STEPS` bound.
+            for _ in 0..MAX_STEPS {
+                if !active.iter().any(|a| *a) {
+                    break;
+                }
+                let (raws, hidden) = crate::timing::timed("tf.decode_step", || {
+                    self.step_kv_hoisted(&last, &cross, &mut cache, &empty)
+                })?;
+                for t in 0..b {
+                    if !active[t] {
+                        continue;
+                    }
+                    let h = &hidden[t * EMBED_DIM..(t + 1) * EMBED_DIM];
+                    if books[t].step(raws[t], h) {
+                        last[t] = *books[t].tags.last().expect("step pushed a tag");
+                    } else {
+                        active[t] = false;
+                        last[t] = END;
+                    }
+                }
+            }
+            Ok(())
+        })?;
+        Ok(books)
+    }
+
+    /// The zero-`past` first-step cache(s) for `rows` tables, allocated through
+    /// the session allocator (ort's array constructors reject a 0-length dim;
+    /// the C API does allow it).
+    fn empty_cache(&self, rows: usize) -> Result<EmptyCache, String> {
         let alloc = self.decoder.allocator();
         if self.style != DecoderStyle::Legacy {
             let mk = || {
-                Tensor::<f32>::new(alloc, [N_LAYERS, 1, KV_HEADS, 0usize, KV_HEAD_DIM])
+                Tensor::<f32>::new(alloc, [N_LAYERS, rows, KV_HEADS, 0usize, KV_HEAD_DIM])
                     .map_err(|e| format!("tableformer: empty kv cache: {e}"))
             };
             Ok((mk()?, Some(mk()?)))
@@ -412,7 +568,7 @@ impl TableFormer {
         let mut out: Vec<i64> = Vec::new();
         let mut prev_ucel = false;
         let mut cache = DecodeCache::default();
-        let empty = self.empty_cache()?;
+        let empty = self.empty_cache(1)?;
         while out.len() < MAX_STEPS {
             let (raw, _hidden) = self.decode_step(&tags, &enc, &mut cache, &empty)?;
             let tag = correct(raw, prev_ucel);
@@ -438,7 +594,7 @@ impl TableFormer {
         // (shared with the wasm path); this loop only steps the decoder.
         let mut book = BboxBook::new();
         let mut cache = DecodeCache::default();
-        let empty = self.empty_cache()?;
+        let empty = self.empty_cache(1)?;
         crate::timing::timed("tf.decode_loop", || -> Result<(), String> {
             while book.otsl.len() < MAX_STEPS {
                 let (raw, hidden) = self.decode_step(&book.tags, &enc, &mut cache, &empty)?;
@@ -448,6 +604,17 @@ impl TableFormer {
             }
             Ok(())
         })?;
+        self.finish_table(book, &enc.eo)
+    }
+
+    /// The bbox stage after a table's decode loop: run the bbox decoder over
+    /// the collected per-cell hidden states, merge span boxes, lay the cells
+    /// onto the OTSL grid.
+    fn finish_table(
+        &mut self,
+        mut book: BboxBook,
+        eo: &DynValue,
+    ) -> Result<Vec<TableCell>, String> {
         if book.n == 0 {
             return Ok(Vec::new());
         }
@@ -455,7 +622,7 @@ impl TableFormer {
             .map_err(|e| format!("tableformer: tag_h: {e}"))?;
         let bout = crate::timing::timed("tf.bbox", || {
             self.bbox
-                .run(ort::inputs!["enc_out" => &enc.eo, "tag_h" => tag_h])
+                .run(ort::inputs!["enc_out" => eo, "tag_h" => tag_h])
                 .map_err(|e| format!("tableformer: bbox: {e}"))
         })?;
         let (_, raw) = bout["boxes"]
@@ -513,23 +680,7 @@ impl TableFormer {
         region: [f32; 4],
         words: &[TextCell],
     ) -> Option<crate::tf_core::TableGrid> {
-        // Crop the table bbox out of the 1024px frame. docling's coordinate
-        // chain, rounding included: the cluster bbox is rounded to integer page
-        // points *first* (`round(cluster.bbox.l) * scale`, banker's rounding),
-        // scaled by 2 (its table-structure page scale), then by `1024 / <2x
-        // page-image height>`, and the crop indices round again. Rounding after
-        // scaling instead shifts some crops by a pixel — enough to change
-        // TableFormer's cell boxes on tall tables (redp5110's TOC).
-        let k = 2.0 * 1024.0 / page_h as f64;
-        let px = |v: f32| (v as f64).round_ties_even() * k;
-        let x = (px(region[0]).round_ties_even()).max(0.0) as u32;
-        let y = (px(region[1]).round_ties_even()).max(0.0) as u32;
-        let x2 = (px(region[2]).round_ties_even() as u32).min(page1024.width());
-        let y2 = (px(region[3]).round_ties_even() as u32).min(page1024.height());
-        if x2 <= x || y2 <= y {
-            return None;
-        }
-        let crop = image::imageops::crop_imm(page1024, x, y, x2 - x, y2 - y).to_image();
+        let crop = Self::crop_region(page_h, page1024, region)?;
         let cells = crate::timing::timed("tableformer.structure", || {
             self.predict_table_structure(&crop)
         })
@@ -540,6 +691,98 @@ impl TableFormer {
         // The ort-free tail (word matching + grid assembly) is shared with the
         // browser path in tf_core.
         crate::tf_core::table_rows(&cells, region, words)
+    }
+
+    /// Every table of a page at once: [`predict_table_rows_on`](Self::predict_table_rows_on)
+    /// per region, except that with the dynamic-batch decoder the tables'
+    /// decode steps are shared — each table is encoded on its own, then one
+    /// decode loop steps all of them together ([`Self::decode_batch`]), then
+    /// each runs its own bbox head. Per table the result is bit-identical to
+    /// the one-at-a-time path; a page with a single table takes exactly that
+    /// path. Should the batched run fail (an ort error), the tables are
+    /// retried one by one so a page never loses all of its tables to one
+    /// shared step.
+    pub fn predict_tables_on(
+        &mut self,
+        page_h: u32,
+        page1024: &RgbImage,
+        regions: &[[f32; 4]],
+        words: &[TextCell],
+    ) -> Vec<Option<crate::tf_core::TableGrid>> {
+        let mut out: Vec<Option<crate::tf_core::TableGrid>> = vec![None; regions.len()];
+        let crops: Vec<(usize, RgbImage)> = regions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| Self::crop_region(page_h, page1024, *r).map(|c| (i, c)))
+            .collect();
+        if self.batched && crops.len() > 1 {
+            let batched = crate::timing::timed("tableformer.structure", || {
+                self.predict_structures_batched(crops.iter().map(|(_, c)| c))
+            });
+            match batched {
+                Ok(cells) => {
+                    for ((i, _), cells) in crops.iter().zip(cells) {
+                        if !cells.is_empty() {
+                            out[*i] = crate::tf_core::table_rows(&cells, regions[*i], words);
+                        }
+                    }
+                    return out;
+                }
+                Err(e) => docling_core::debug_log!(
+                    "docling-pdf: tableformer batched decode failed ({e}); decoding tables one by one"
+                ),
+            }
+        }
+        for (i, crop) in &crops {
+            let cells = crate::timing::timed("tableformer.structure", || {
+                self.predict_table_structure(crop)
+            });
+            if let Ok(cells) = cells {
+                if !cells.is_empty() {
+                    out[*i] = crate::tf_core::table_rows(&cells, regions[*i], words);
+                }
+            }
+        }
+        out
+    }
+
+    /// [`predict_table_structure`](Self::predict_table_structure) for several
+    /// crops with the decode steps shared across them.
+    fn predict_structures_batched<'a>(
+        &mut self,
+        crops: impl Iterator<Item = &'a RgbImage>,
+    ) -> Result<Vec<Vec<TableCell>>, String> {
+        let mut encs = Vec::new();
+        for crop in crops {
+            encs.push(self.encode(crop)?);
+        }
+        let books = self.decode_batch(&encs)?;
+        books
+            .into_iter()
+            .zip(&encs)
+            .map(|(book, enc)| self.finish_table(book, &enc.eo))
+            .collect()
+    }
+
+    /// Crop the table bbox out of the 1024px frame. docling's coordinate
+    /// chain, rounding included: the cluster bbox is rounded to integer page
+    /// points *first* (`round(cluster.bbox.l) * scale`, banker's rounding),
+    /// scaled by 2 (its table-structure page scale), then by `1024 / <2x
+    /// page-image height>`, and the crop indices round again. Rounding after
+    /// scaling instead shifts some crops by a pixel — enough to change
+    /// TableFormer's cell boxes on tall tables (redp5110's TOC). `None` for a
+    /// region that collapses to an empty crop.
+    fn crop_region(page_h: u32, page1024: &RgbImage, region: [f32; 4]) -> Option<RgbImage> {
+        let k = 2.0 * 1024.0 / page_h as f64;
+        let px = |v: f32| (v as f64).round_ties_even() * k;
+        let x = (px(region[0]).round_ties_even()).max(0.0) as u32;
+        let y = (px(region[1]).round_ties_even()).max(0.0) as u32;
+        let x2 = (px(region[2]).round_ties_even() as u32).min(page1024.width());
+        let y2 = (px(region[3]).round_ties_even() as u32).min(page1024.height());
+        if x2 <= x || y2 <= y {
+            return None;
+        }
+        Some(image::imageops::crop_imm(page1024, x, y, x2 - x, y2 - y).to_image())
     }
 }
 

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -702,6 +702,7 @@ better, byte-identical where the change is structural:
 | Single shared line/word contraction pass | `--no-ocr` conversion ~1.25× faster, identical output |
 | Per-document font + form caches in the text parser | 3–10% off `textparse` here; far more on CJK/form-heavy PDFs |
 | True-KV-cache decoder export (`decoder_kv.onnx`, optional) | parity at corpus table sizes; O(past)/step for very large tables |
+| Dynamic-batch `decoder_kv.onnx`: a page's tables decode in one lockstep loop | decode steps shared across tables; byte-identical (see round four below) |
 
 Cumulative head-to-head vs Python docling (measured on an 8-thread desktop,
 `scripts/test/performance.sh`): **4.3× faster warm conversion, 4.7× end-to-end,
@@ -1038,14 +1039,76 @@ bbox head 0.26 s, encoder 0.20 s, page→1024 resample 0.11 s, preprocessing
   weight streaming. Both move only with the model: INT8/fp16 weights for the
   step (the dynamic-INT8 `decoder_kv` was already tried and rejected — it
   flips near-tie tokens on redp5110's TOC), or batching several tables'
-  steps through one run so the weights stream once for all of them (needs a
-  dynamic-batch re-export and exact masking of the ragged KV caches). Neither
-  is byte-exact by construction, so neither is in this branch.
+  steps through one run so the weights stream once for all of them. The
+  first is not byte-exact by construction; the second turned out to be —
+  round four below.
 
 Back-to-back, same machine, default pool: `2206.01062` 9.4–9.6 → 8.8 s,
 `2203.01017v2` 8.0–8.1 → 7.9 s, `2305.03393v1-pg9` (one 55-step table on
 one page) 2.4 s. Output is byte-identical to the round-two references on the
 serial path and on a 2-worker pool over the same 32 documents.
+
+#### Round four (Sep 2026): a page's tables decode together
+
+The decode step streams ~70 MB of layer weights for one token, so the
+obvious lever left after round three was to push several tables' tokens
+through the same step. It needed a dynamic-batch `decoder_kv.onnx` and a
+loop that keeps the tables' KV caches aligned — and, unlike the earlier
+guess, no masking at all.
+
+- **The export** (`export_tableformer.py`, `DecodeKVHoistedBatched`): `tag`
+  is `[B,1]`, the caches `[L,B,H,past,hd]`, every cross tensor `[B,…]`; B=1
+  is the same graph, so the artifact stays a drop-in for a one-table loop.
+  Two things had to be exact. First, ORT must fuse the batched graph the
+  way it fuses the B=1 one: with a symbolic batch axis a 3-D activation
+  stays MatMul-then-Add (a different rounding of the bias, ~1e-6 in the
+  logits) while the B=1 graph gets MatMul+Add→Gemm through constant-shape
+  Reshapes, and a fully 2-D module loses the Add+LayerNorm→
+  SkipLayerNormalization fusion instead. The module therefore runs each
+  linear on an explicit 2-D view and keeps the residual stream 3-D — the
+  optimized graph then has the published one's kernel mix (49 Gemm, 18
+  SkipLayerNorm, 12 FusedMatMul), and B=1 reproduces the published
+  `decoder_kv.onnx` **bit for bit** over 3 random tables × 48 greedy steps.
+  Second, the script's batching gate asserts that two tables decoded in one
+  batch give, step by step, the logits and hidden states each gives alone
+  (row b of an `[B,K]·[K,N]` GEMM is the `[1,K]` result in MLAS).
+- **The loop** (`tableformer.rs::decode_batch`): every table of a page is
+  encoded, the per-layer cross tensors are stacked along the batch axis
+  (one ~20 MB copy per table per page), and one loop steps all of them. The
+  caches start at `past=0` for every row and grow in lockstep, so nothing
+  is padded or masked; a table that emits `<end>` keeps its row (fed `END`,
+  output ignored) until the last one finishes, and each table then runs its
+  own bbox head. Detected from the decoder's `tag` input having a symbolic
+  batch axis, so the older fixed-`[1,1]` export keeps decoding one table at
+  a time; a page with one table takes exactly that path; a failing batched
+  run falls back to it.
+- **What it buys, and what it can't.** Per-op profile of one step (1
+  thread, past=50): the 49 Gemm total **6.8 ms at B=1 and 6.8 ms at B=2** —
+  the weights do stream once for all rows — but each table brings its own
+  cross-attention: q·Kᵀ and softmax·V over 784 image positions × 6 layers
+  read ~19 MB of that table's `cross_kt`/`cross_v` per step (FusedMatMul
+  1.7 → 3.2 ms, MatMul 1.5 → 2.6 ms for B 1 → 2). So a step costs 10.5 ms
+  alone, 13.5 for two tables, 19.6 for four, 34 for eight: **−35% per table
+  at two tables per page, −55% at four**, and that is the bound — the
+  cross-attention reads are the model's, not the loop's.
+- **Measured** (`DOCLING_RS_TIMING=1`, same binary, published vs
+  dynamic-batch decoder): `2203.01017v2` (two tables on each of its pages)
+  decode loop 3.1 → 2.5 s (297 single steps → 178 shared ones), serial wall
+  25.2 → 24.6 s, default pool 10.0 → 9.4 s; `2206.01062` decode 5.6 →
+  4.7 s, pool 10.4 → 9.8 s; `redp5110_sampled` (one table per page) flat,
+  as it must be. Pool wall moves less than the decode does because the
+  deferral machinery of round two already overlaps a page's tables with
+  other pages' layout. Output byte-identical to the round-three references
+  on the serial path and on a 2-worker pool over the same 32 documents.
+- **Memory:** a page's tables are now all held encoded at once (per-layer
+  cross tensors ~19 MB each) plus their stacked copy, against which the
+  hoisted decoder's never-read stacked `cross_k`/`cross_v` (2×9.6 MB per
+  table) are dropped at encode time now instead of living for the table's
+  lifetime. Net on `2203.01017v2` (default pool): peak RSS 1.74 → 1.81 GB.
+
+The dynamic-batch `decoder_kv.onnx` reaches users through the models
+release (`publish-models.yml` re-run); until then the shipped decoder simply
+takes the one-table-at-a-time path.
 
 #### TableFormer decoder: dynamic INT8 (~10% faster tables, byte-identical)
 

--- a/scripts/install/export_tableformer.py
+++ b/scripts/install/export_tableformer.py
@@ -303,6 +303,72 @@ class DecodeKVHoisted(nn.Module):
         return tt._fc(last), last, out_cache_k, out_cache_v
 
 
+class DecodeKVHoistedBatched(nn.Module):
+    # DecodeKVHoisted over B tables at once: `tag` is [B,1], the caches
+    # [L,B,H,past,hd] and every cross tensor [B,...]. A decode step is 49
+    # small GEMMs over one token per table — it streams the layer weights
+    # rather than computing — so B tables per step cost about what one does;
+    # the Rust loop decodes all the tables of a page together (their caches
+    # grow in lockstep from past=0, so no padding or masking is ever needed:
+    # a finished table simply keeps its row until the last one ends). Per
+    # row this is exactly DecodeKVHoisted: the same ops with a leading batch
+    # axis instead of a hard-coded 1, and MLAS computes row b of an [B,K]·[K,N]
+    # GEMM bit-identically to the [1,K] case (checked below, step by step).
+    #
+    # Every linear runs on an explicit 2-D view ([B,e], `lin` below) while the
+    # residual stream stays 3-D ([B,1,e]). That reproduces the fusions ORT
+    # applies to the B=1 graph on its own — MatMul+Add→Gemm (which it only
+    # proves for a plain matrix; with a symbolic batch axis a 3-D activation
+    # stays MatMul then Add, a different rounding of the bias) and
+    # Add+LayerNorm→SkipLayerNormalization (which wants the 3-D shape). With
+    # the same kernels, B=1 reproduces the published `decoder_kv.onnx` bit
+    # for bit; the check below asserts it.
+    def forward(self, tag, cache_k, cache_v, *cross):
+        e = EMBED_DIM_
+        cross_kt, cross_v = cross[:N_LAYERS], cross[N_LAYERS:]
+        B = tag.shape[0]
+        pos = cache_k.shape[3]
+
+        def lin(x, w, bias):  # [B,1,K] → [B,1,N] through a 2-D Gemm
+            return F.linear(x.reshape(-1, x.shape[-1]), w, bias).reshape(B, 1, -1)
+
+        x = tt._embedding(tag)  # [B,1,e]
+        x = x + tt._positional_encoding.pe[pos]
+        out = x
+        new_ks, new_vs = [], []
+        for i, layer in enumerate(tt._decoder.layers):
+            sa = layer.self_attn
+            W, b = sa.in_proj_weight, sa.in_proj_bias
+            # [B,1,e] → [B,H,1,hd]; same element order as the B=1 module's
+            # reshape(1,H,hd).permute(1,0,2).unsqueeze(0).
+            q = lin(out, W[:e], b[:e]).reshape(B, N_HEADS, HEAD_DIM).unsqueeze(2)
+            k = lin(out, W[e : 2 * e], b[e : 2 * e]).reshape(B, N_HEADS, HEAD_DIM).unsqueeze(2)
+            v = lin(out, W[2 * e :], b[2 * e :]).reshape(B, N_HEADS, HEAD_DIM).unsqueeze(2)
+            new_ks.append(k)
+            new_vs.append(v)
+            kk = torch.cat([cache_k[i], k], dim=2)  # [B,H,past+1,hd]
+            vv = torch.cat([cache_v[i], v], dim=2)
+            t = F.scaled_dot_product_attention(q, kk, vv)  # [B,H,1,hd]
+            t = t.squeeze(2).reshape(B, 1, e)
+            t = lin(t, sa.out_proj.weight, sa.out_proj.bias)
+            tgt_last = layer.norm1(out + t)
+            mha = layer.multihead_attn
+            cq = lin(tgt_last, mha.in_proj_weight[:e], mha.in_proj_bias[:e])
+            cq = cq.reshape(B, N_HEADS, HEAD_DIM).unsqueeze(2)
+            scores = (cq * HEAD_DIM**-0.5) @ cross_kt[i]  # [B,H,1,S]
+            co = torch.softmax(scores, dim=-1) @ cross_v[i]  # [B,H,1,hd]
+            co = co.squeeze(2).reshape(B, 1, e)
+            t = lin(co, mha.out_proj.weight, mha.out_proj.bias)
+            tgt_last = layer.norm2(tgt_last + t)
+            t = lin(tgt_last, layer.linear1.weight, layer.linear1.bias)
+            t = lin(layer.activation(t), layer.linear2.weight, layer.linear2.bias)
+            out = layer.norm3(tgt_last + t)
+        out_cache_k = torch.cat([cache_k, torch.stack(new_ks, 0)], dim=3)
+        out_cache_v = torch.cat([cache_v, torch.stack(new_vs, 0)], dim=3)
+        last = out[:, 0]  # [B,e]
+        return tt._fc(last), last, out_cache_k, out_cache_v
+
+
 def check(name, a, b):
     import numpy as np
 
@@ -406,36 +472,83 @@ print(f"  64 steps argmax-identical, max|dlogits| = {max_dlogit:.2e}")
 
 tag1 = torch.tensor([[start]], dtype=torch.long)
 past_kv = Dim("past", min=0, max=1024)
+# The batch axis is dynamic too (the Rust loop decodes a page's tables
+# together); B=1 is the same graph, so the artifact stays a drop-in for a
+# loop that feeds one table at a time.
+batch = Dim("batch", min=1, max=64)
 cross_names = [f"cross_kt_{i}" for i in range(N_LAYERS)] + [
     f"cross_v_{i}" for i in range(N_LAYERS)
 ]
 # Export with the rollout's past=64 caches: a past=0 example lets the exporter
 # specialize `pe[cache_k.shape[3]]` to `pe[0]`, silently zeroing the positional
-# encoding for every later step (decode then never emits <end>).
+# encoding for every later step (decode then never emits <end>). The example
+# batch is 2 for the same reason — a size-1 example axis specializes to 1.
+tag2 = torch.tensor([[start], [start]], dtype=torch.long)
+kv_k2, kv_v2 = torch.cat([kv_k, kv_k], 1), torch.cat([kv_v, kv_v], 1)
+cross2 = [torch.cat([c, c], 0) for c in cross_per_layer]
 torch.onnx.export(
-    DecodeKVHoisted(), (tag1, kv_k, kv_v, *cross_per_layer),
+    DecodeKVHoistedBatched(), (tag2, kv_k2, kv_v2, *cross2),
     f"{OUT}/decoder_kv.onnx",
     input_names=["tag", "cache_k", "cache_v"] + cross_names,
     output_names=["logits", "hidden", "out_cache_k", "out_cache_v"],
     dynamo=True,
     dynamic_shapes=(
-        {},
-        {3: past_kv},
-        {3: past_kv},
-        tuple({} for _ in cross_names),
+        {0: batch},
+        {1: batch, 3: past_kv},
+        {1: batch, 3: past_kv},
+        tuple({0: batch} for _ in cross_names),
     ),
 )
-print("decoder_kv.onnx (hoisted true-KV-cache step):")
+print("decoder_kv.onnx (hoisted true-KV-cache step, dynamic batch):")
 empty_kv = torch.zeros((N_LAYERS, 1, nh, 0, HEAD_DIM))
 with torch.no_grad():
     kl, kh, kck, kcv = DecodeKVHoisted()(tag1, empty_kv, empty_kv, *cross_per_layer)
 feeds = {"tag": tag1.numpy(), "cache_k": empty_kv.numpy(), "cache_v": empty_kv.numpy()}
 feeds.update({n: t.numpy() for n, t in zip(cross_names, cross_per_layer)})
-ko = ort.InferenceSession(f"{OUT}/decoder_kv.onnx").run(None, feeds)
+kv_sess = ort.InferenceSession(f"{OUT}/decoder_kv.onnx")
+ko = kv_sess.run(None, feeds)
 check("logits", ko[0], kl.numpy())
 check("hidden", ko[1], kh.numpy())
 check("out_cache_k", ko[2], kck.numpy())
 check("out_cache_v", ko[3], kcv.numpy())
+
+# Batching gate: decoding two tables in one batch must reproduce, bit for bit,
+# what the same graph produces for each table alone — the Rust loop's output
+# may not depend on how many tables shared a step. Second table: a different
+# image through the encoder; 64 greedy steps each way.
+print("verifying batched decode == per-table decode (ORT, 64 steps, bit-exact):")
+img_b = torch.randn(1, 3, 448, 448)
+with torch.no_grad():
+    _, _, _, *cross_b = Encode()(img_b)
+enc_sess = ort.InferenceSession(f"{OUT}/encoder.onnx")
+mem_a = enc_sess.run(None, {"image": img.numpy()})[3:]
+mem_b = enc_sess.run(None, {"image": img_b.numpy()})[3:]
+import numpy as np  # noqa: E402
+
+
+def roll(mems, steps=64):
+    B = len(mems)
+    ck = np.zeros((N_LAYERS, B, nh, 0, HEAD_DIM), np.float32)
+    cv = ck.copy()
+    tag = np.full((B, 1), start, np.int64)
+    outs = []
+    for _ in range(steps):
+        f = {"tag": tag, "cache_k": ck, "cache_v": cv}
+        f.update({n: np.concatenate([m[j] for m in mems], 0) for j, n in enumerate(cross_names)})
+        lg, hd, ck, cv = kv_sess.run(None, f)
+        outs.append((lg.copy(), hd.copy()))
+        tag = lg.argmax(1)[:, None].astype(np.int64)
+    return outs
+
+
+solo = [roll([mem_a]), roll([mem_b])]
+both = roll([mem_a, mem_b])
+for step, (lg, hd) in enumerate(both):
+    for j in range(2):
+        assert np.array_equal(lg[j : j + 1], solo[j][step][0]) and np.array_equal(
+            hd[j : j + 1], solo[j][step][1]
+        ), f"step {step}, table {j}: batched decode differs from the solo decode"
+print("  64 steps × 2 tables bit-identical batched vs solo")
 
 # word map → tokens file for the Rust decode loop
 json.dump(


### PR DESCRIPTION
The TableFormer decode step streams ~70 MB of layer weights for a single token, so several tables' tokens can share one step. This adds the dynamic-batch `decoder_kv.onnx` export and the lockstep loop that uses it.

Export (`scripts/install/export_tableformer.py`, `DecodeKVHoistedBatched`): `tag` is `[B,1]`, the caches `[L,B,H,past,hd]`, every cross tensor `[B,…]`; B=1 is the same graph. Two exactness details: the module runs each linear on a 2-D view while the residual stream stays 3-D, so ORT applies the same fusions it applies to the B=1 graph (MatMul+Add→Gemm needs a plain matrix under a symbolic batch axis; Add+LayerNorm→SkipLayerNormalization wants the 3-D shape) — with the published kernel mix, B=1 reproduces the published decoder bit for bit (3 tables × 48 greedy steps). And the script's new batching gate asserts that two tables decoded together give, step by step, the logits and hidden states each gives alone.

Loop (`tableformer.rs`): `predict_tables_on` encodes every table of the page, stacks the per-layer cross tensors along the batch axis, runs one decode loop for all of them (`decode_batch`: caches grow from past=0 in lockstep, so nothing is padded or masked; a finished table keeps its row, fed END, until the last one ends) and then each table's own bbox head. Detected from the decoder's `tag` input having a symbolic batch axis, so the shipped fixed-`[1,1]` export keeps decoding one table at a time; a one-table page takes exactly that path; a failing batched run falls back to it. A page's tables are held encoded at once for the shared loop (~19 MB each plus their stacked copy); to offset that, the hoisted decoder's never-read stacked `cross_k`/`cross_v` (2×9.6 MB per table) are dropped at encode time. Net peak RSS on a two-table page: 1.74 → 1.81 GB.

Measured (1 thread, past=50): the 49 Gemm cost 6.8 ms at B=1 and at B=2 — the weights stream once — but each table adds its own cross-attention reads over 784 positions × 6 layers (~19 MB/step), so a step is 10.5 ms alone, 13.5 for two tables, 19.6 for four: −35% per table at two tables per page, −55% at four, which is the bound. `2203.01017v2` (two tables per page) decode loop 3.1 → 2.5 s, default pool 10.0 → 9.4 s; `2206.01062` 5.6 → 4.7 s / 10.4 → 9.8 s; single-table documents flat. Output is byte-identical to the round-three references over 32 documents on the serial path and on a 2-worker pool.

The new decoder ships through the models release (`publish-models.yml` re-run); an older `decoder_kv.onnx` keeps working, one table at a time.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT