### PR TITLE
perf(pdf): on-demand row ring for the page→1024 INTER_AREA resample; …

### DIFF
--- a/crates/docling-onnx/src/lib.rs
+++ b/crates/docling-onnx/src/lib.rs
@@ -428,7 +428,22 @@ pub fn commit(builder: SessionBuilder, model_path: &str, variant: &str) -> Resul
         .and_then(plain);
     match built {
         Ok(session) => {
-            if std::fs::rename(&tmp, &cache).is_err() {
+            // ORT serializes the optimized graph as a side effect of session
+            // creation and does not fail the session when that write comes up
+            // short (a full disk truncates the file and the session still
+            // initializes from memory). Publishing such a prefix would poison
+            // the cache: every later process would try it, fail, remove it and
+            // rebuild — a ~50 s cold start for the TableFormer graphs, seen
+            // exactly once after a disk-full episode. So check the protobuf
+            // skeleton first: every top-level field's declared length must end
+            // within the file (a truncation cuts inside the graph field).
+            if !onnx_file_complete(&tmp) {
+                docling_core::debug_log!(
+                    "docling-onnx: graph cache write of {} incomplete (disk full?); not kept",
+                    cache.display()
+                );
+                let _ = std::fs::remove_file(&tmp);
+            } else if std::fs::rename(&tmp, &cache).is_err() {
                 let _ = std::fs::remove_file(&tmp);
             } else {
                 docling_core::debug_log!("docling-onnx: graph cache wrote {}", cache.display());
@@ -442,6 +457,69 @@ pub fn commit(builder: SessionBuilder, model_path: &str, variant: &str) -> Resul
             plain(builder)
         }
     }
+}
+
+/// Whether `path` holds a structurally complete protobuf message: walk the
+/// top-level fields of the serialized `ModelProto`, seeking over each
+/// length-delimited body, and require the walk to land exactly on EOF. A file
+/// cut short by a failed write (disk full) fails this — the truncation lands
+/// inside the multi-megabyte `graph` field, whose length prefix then promises
+/// more bytes than exist — while costing only a handful of reads, never a
+/// parse of the weights. Malformed wire types or zero length fail too.
+fn onnx_file_complete(path: &Path) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(len) = f.metadata().map(|m| m.len()) else {
+        return false;
+    };
+    if len == 0 {
+        return false;
+    }
+    let mut pos = 0u64;
+    let read_varint = |f: &mut std::fs::File, pos: &mut u64| -> Option<u64> {
+        let mut v = 0u64;
+        for shift in (0..64).step_by(7) {
+            let mut b = [0u8; 1];
+            f.read_exact(&mut b).ok()?;
+            *pos += 1;
+            v |= u64::from(b[0] & 0x7f) << shift;
+            if b[0] & 0x80 == 0 {
+                return Some(v);
+            }
+        }
+        None
+    };
+    while pos < len {
+        let Some(key) = read_varint(&mut f, &mut pos) else {
+            return false;
+        };
+        let skip = match key & 7 {
+            0 => {
+                // varint payload
+                if read_varint(&mut f, &mut pos).is_none() {
+                    return false;
+                }
+                0
+            }
+            1 => 8,
+            2 => match read_varint(&mut f, &mut pos) {
+                Some(n) => n,
+                None => return false,
+            },
+            5 => 4,
+            _ => return false,
+        };
+        if skip > len - pos {
+            return false;
+        }
+        if skip > 0 && f.seek(SeekFrom::Current(skip as i64)).is_err() {
+            return false;
+        }
+        pos += skip;
+    }
+    pos == len
 }
 
 /// Where the optimized graph for `model_path` + `variant` lives on this
@@ -573,5 +651,60 @@ mod tests {
             feature = "xnnpack"
         )))]
         assert_eq!(default_choice(), Ep::Cpu);
+    }
+}
+
+#[cfg(test)]
+mod cache_guard_tests {
+    use super::onnx_file_complete;
+
+    fn write(bytes: &[u8]) -> std::path::PathBuf {
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let p = std::env::temp_dir().join(format!(
+            "docling-onnx-guard-{}-{}.onnx",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    /// A ModelProto-shaped message: `ir_version = 7` (field 1, varint), then a
+    /// `graph` (field 7, length-delimited) of 300 bytes — long enough for a
+    /// two-byte length prefix like the real thing.
+    fn model_like() -> Vec<u8> {
+        let mut v = vec![0x08, 0x07, 0x3a, 0xac, 0x02];
+        v.extend(std::iter::repeat_n(0x55u8, 300));
+        v
+    }
+
+    #[test]
+    fn complete_file_passes_truncated_fails() {
+        let full = model_like();
+        assert!(onnx_file_complete(&write(&full)));
+        // cut inside the graph body — what a disk-full write leaves behind
+        assert!(!onnx_file_complete(&write(&full[..full.len() - 1])));
+        assert!(!onnx_file_complete(&write(&full[..40])));
+        // cut inside the length prefix itself
+        assert!(!onnx_file_complete(&write(&full[..4])));
+        assert!(!onnx_file_complete(&write(&[])));
+        // trailing garbage that is not a valid field key/wire type
+        let mut bad = full.clone();
+        bad.push(0x07);
+        assert!(!onnx_file_complete(&write(&bad)));
+    }
+
+    #[test]
+    fn real_optimized_graph_passes() {
+        // Any real ONNX file in the repo's model dir, when present.
+        for p in [
+            "../../.models/tableformer/bbox.onnx",
+            "../../.models/layout_heron_int8.onnx",
+        ] {
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(p);
+            if p.is_file() {
+                assert!(onnx_file_complete(&p), "{}", p.display());
+            }
+        }
     }
 }

--- a/crates/docling-pdf/src/resample.rs
+++ b/crates/docling-pdf/src/resample.rs
@@ -5,72 +5,99 @@
 
 use image::RgbImage;
 
-/// Per-output-pixel source spans + overlap weights for area resampling.
-fn area_weights(src: usize, dst: usize, scale: f64) -> Vec<Vec<(usize, f64)>> {
+/// Per-output-pixel source spans + overlap weights for area resampling:
+/// `(first source index, weights)`, the taps being the contiguous run of
+/// source pixels the output pixel covers, in increasing index order.
+fn area_weights(src: usize, dst: usize, scale: f64) -> Vec<(usize, Vec<f64>)> {
     (0..dst)
         .map(|d| {
             let f1 = d as f64 * scale;
             let f2 = (d + 1) as f64 * scale;
             let s1 = f1.floor() as usize;
             let s2 = (f2.ceil() as usize).min(src);
-            (s1..s2)
-                .map(|si| {
-                    let w = (((si + 1) as f64).min(f2) - (si as f64).max(f1)) / scale;
-                    (si, w)
-                })
-                .collect()
+            let ws = (s1..s2)
+                .map(|si| (((si + 1) as f64).min(f2) - (si as f64).max(f1)) / scale)
+                .collect();
+            (s1, ws)
         })
         .collect()
 }
 
 /// `cv2.resize(..., interpolation=INTER_AREA)` for shrinking — area-weighted
 /// averaging, separable (horizontal then vertical), f64 accumulation.
+///
+/// The per-pixel addition order is the naive form's — horizontal taps in
+/// increasing source column, then vertical taps in increasing source row — so
+/// the f64 sums, and the rounded bytes, are bit-identical to it (asserted by
+/// `area_tests`). Within that contract the work is arranged for the cache:
+/// a horizontally-shrunk source row is computed on demand as the vertical
+/// pass reaches it and kept only while an output row still needs it (a
+/// source row feeds at most two output rows, so a ring of a few `f64` rows
+/// replaces the 30 MB `sh × dw` intermediate a full first pass wrote and
+/// re-read), the horizontal taps run over the contiguous byte span they
+/// cover (no per-tap indexing), and the vertical pass is a flat `f64` axpy
+/// the compiler vectorizes. ~3× faster than the two-pass form on a page
+/// render (43 → 18 ms, 1224×1584 → 791×1024, release, one thread).
 pub fn inter_area(src: &RgbImage, dw: u32, dh: u32) -> RgbImage {
     let (sw, sh) = (src.width() as usize, src.height() as usize);
     let (dwu, dhu) = (dw as usize, dh as usize);
     let hw = area_weights(sw, dwu, sw as f64 / dw as f64);
     let vw = area_weights(sh, dhu, sh as f64 / dh as f64);
-
-    // Cache-friendly passes over the raw RGB buffer. The per-pixel addition
-    // order is exactly the loop-nest transpose of the naive form, so the f64
-    // accumulation — and thus the rounded output — stays bit-identical (the
-    // pixel-exactness contract above).
     let raw = src.as_raw();
-    let mut tmp = vec![[0f64; 3]; sh * dwu]; // (sh × dw)
-    for y in 0..sh {
-        let src_row = &raw[y * sw * 3..(y + 1) * sw * 3];
-        let dst_row = &mut tmp[y * dwu..(y + 1) * dwu];
-        for (acc, ws) in dst_row.iter_mut().zip(hw.iter()) {
-            for &(si, w) in ws {
-                let p = &src_row[si * 3..si * 3 + 3];
-                acc[0] += p[0] as f64 * w;
-                acc[1] += p[1] as f64 * w;
-                acc[2] += p[2] as f64 * w;
+    let stride = dwu * 3;
+
+    // Horizontal shrink of one source row into `dst` (dw × 3 f64).
+    let shrink_row = |sy: usize, dst: &mut [f64]| {
+        let src_row = &raw[sy * sw * 3..(sy + 1) * sw * 3];
+        for ((s1, ws), acc) in hw.iter().zip(dst.chunks_exact_mut(3)) {
+            let taps = &src_row[s1 * 3..(s1 + ws.len()) * 3];
+            let mut a = [0f64; 3];
+            for (p, &w) in taps.chunks_exact(3).zip(ws) {
+                a[0] += f64::from(p[0]) * w;
+                a[1] += f64::from(p[1]) * w;
+                a[2] += f64::from(p[2]) * w;
+            }
+            acc.copy_from_slice(&a);
+        }
+    };
+
+    // Ring of shrunk source rows keyed by source row index. Output rows walk
+    // the source monotonically, so a row older than the current window's
+    // first tap is never needed again and its buffer is recycled.
+    let mut ring: Vec<(usize, Vec<f64>)> = Vec::new();
+    let mut spare: Vec<Vec<f64>> = Vec::new();
+    let mut out = vec![0u8; stride * dhu];
+    let mut acc = vec![0f64; stride];
+    for ((s1, ws), out_row) in vw.iter().zip(out.chunks_exact_mut(stride)) {
+        let mut i = 0;
+        while i < ring.len() {
+            if ring[i].0 < *s1 {
+                spare.push(ring.swap_remove(i).1);
+            } else {
+                i += 1;
             }
         }
-    }
-    let mut out = RgbImage::new(dw, dh);
-    let mut acc_row = vec![[0f64; 3]; dwu];
-    for (dy, ws) in vw.iter().enumerate() {
-        acc_row.fill([0f64; 3]);
-        // Row-sequential accumulation: each source row streams once instead
-        // of striding column-wise through `tmp`.
-        for &(si, w) in ws {
-            let row = &tmp[si * dwu..(si + 1) * dwu];
-            for (acc, t) in acc_row.iter_mut().zip(row) {
-                acc[0] += t[0] * w;
-                acc[1] += t[1] * w;
-                acc[2] += t[2] * w;
+        acc.fill(0.0);
+        for (k, &w) in ws.iter().enumerate() {
+            let sy = s1 + k;
+            let row = match ring.iter().position(|(y, _)| *y == sy) {
+                Some(j) => &ring[j].1,
+                None => {
+                    let mut buf = spare.pop().unwrap_or_else(|| vec![0f64; stride]);
+                    shrink_row(sy, &mut buf);
+                    ring.push((sy, buf));
+                    &ring[ring.len() - 1].1
+                }
+            };
+            for (a, t) in acc.iter_mut().zip(row) {
+                *a += t * w;
             }
         }
-        let out_row = &mut (*out)[dy * dwu * 3..(dy + 1) * dwu * 3];
-        for (px, acc) in out_row.chunks_exact_mut(3).zip(&acc_row) {
-            px[0] = round_u8(acc[0]);
-            px[1] = round_u8(acc[1]);
-            px[2] = round_u8(acc[2]);
+        for (o, &a) in out_row.iter_mut().zip(&acc) {
+            *o = round_u8(a);
         }
     }
-    out
+    RgbImage::from_raw(dw, dh, out).expect("inter_area buffer sized dw×dh×3")
 }
 
 fn round_u8(v: f64) -> u8 {
@@ -312,4 +339,97 @@ mod pil_tests {
     const PIL_HASH_BICUBIC_DOWN: u64 = 0xb450da21946e06c3;
     const PIL_HASH_BICUBIC_UP: u64 = 0xc3134a9cff63718d;
     const PIL_HASH_BILINEAR_640: u64 = 0x967d65f732845b9f;
+}
+
+#[cfg(test)]
+mod area_tests {
+    use super::*;
+
+    fn lcg_image(w: u32, h: u32, seed: u64) -> RgbImage {
+        let mut state = seed;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as u8
+        };
+        let mut raw = vec![0u8; (w * h * 3) as usize];
+        for b in &mut raw {
+            *b = next();
+        }
+        RgbImage::from_raw(w, h, raw).unwrap()
+    }
+
+    /// Reference: the naive per-output-pixel form, taps in increasing source
+    /// index, horizontal then vertical — the addition order the fast path
+    /// must reproduce for bit-identical bytes.
+    fn inter_area_naive(src: &RgbImage, dw: u32, dh: u32) -> RgbImage {
+        let (sw, sh) = (src.width() as usize, src.height() as usize);
+        let hw = area_weights(sw, dw as usize, sw as f64 / dw as f64);
+        let vw = area_weights(sh, dh as usize, sh as f64 / dh as f64);
+        let mut out = RgbImage::new(dw, dh);
+        for (dy, vws) in vw.iter().enumerate() {
+            for (dx, hws) in hw.iter().enumerate() {
+                let mut acc = [0f64; 3];
+                for (ky, &wy) in vws.1.iter().enumerate() {
+                    let sy = vws.0 + ky;
+                    let mut t = [0f64; 3];
+                    for (kx, &wx) in hws.1.iter().enumerate() {
+                        let sx = hws.0 + kx;
+                        let p = src.get_pixel(sx as u32, sy as u32).0;
+                        for c in 0..3 {
+                            t[c] += p[c] as f64 * wx;
+                        }
+                    }
+                    for c in 0..3 {
+                        acc[c] += t[c] * wy;
+                    }
+                }
+                out.put_pixel(
+                    dx as u32,
+                    dy as u32,
+                    image::Rgb([round_u8(acc[0]), round_u8(acc[1]), round_u8(acc[2])]),
+                );
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn inter_area_matches_naive_order() {
+        for (i, (sw, sh, dw, dh)) in [
+            (1224u32, 1584u32, 791u32, 1024u32),
+            (1190, 1684, 723, 1024),
+            (1584, 1224, 1325, 1024),
+            (61, 47, 40, 30),
+            (100, 100, 100, 50),
+            (37, 91, 36, 90),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let img = lcg_image(sw, sh, 0x9e3779b97f4a7c15 ^ i as u64);
+            assert_eq!(
+                inter_area(&img, dw, dh).as_raw(),
+                inter_area_naive(&img, dw, dh).as_raw(),
+                "{sw}x{sh} -> {dw}x{dh}"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "timing only: cargo test --release -p docling-pdf --lib area_tests::bench -- --ignored --nocapture"]
+    fn bench_inter_area() {
+        let img = lcg_image(1224, 1584, 7);
+        let _ = inter_area(&img, 791, 1024);
+        let t = std::time::Instant::now();
+        let n = 20;
+        for _ in 0..n {
+            std::hint::black_box(inter_area(&img, 791, 1024));
+        }
+        eprintln!(
+            "inter_area 1224x1584 -> 791x1024: {:.1} ms",
+            t.elapsed().as_secs_f64() * 1e3 / n as f64
+        );
+    }
 }

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -1110,6 +1110,35 @@ The dynamic-batch `decoder_kv.onnx` reaches users through the models
 release (`publish-models.yml` re-run); until then the shipped decoder simply
 takes the one-table-at-a-time path.
 
+#### Round five (Sep 2026): the page→1024 resample, and a cache that cannot be poisoned
+
+Two small items left over from round four's profile of master.
+
+- **`inter_area`** (the page → 1024 px `cv2.INTER_AREA` box filter every
+  table crop is cut from; `tableformer.inter_area`, ~0.16 s per table page
+  in the pool, 43 ms in isolation) kept its addition order — horizontal
+  taps in increasing source column, then vertical taps in increasing source
+  row, f64 — and changed only its shape: the shrunk source rows are now
+  computed on demand as the vertical pass reaches them and kept in a ring
+  of a few rows (a source row feeds at most two output rows) instead of a
+  30 MB `sh × dw` intermediate written and re-read, the horizontal taps run
+  over the contiguous byte span they cover, and the vertical pass is a flat
+  `f64` axpy. **43 → 18 ms** per page render (1224×1584 → 791×1024, one
+  thread); a test asserts the bytes equal the naive per-pixel form on six
+  geometries, and the 32-document corpus is byte-identical on the serial
+  path and the 2-worker pool.
+- **Graph cache guard** (`docling_onnx::commit`). ONNX Runtime serializes
+  the optimized graph as a side effect of session creation and does not
+  fail the session when that write comes up short: a full disk truncates
+  the file and the session still initializes from memory. The cache then
+  published the prefix, and every later process tried it, failed, removed
+  it and rebuilt — a ~50 s cold start for the TableFormer graphs, seen once
+  right after a disk-full episode in the round-four session. The commit
+  path now checks the file's protobuf skeleton before renaming it into the
+  cache (each top-level field's declared length must end within the file;
+  a truncation lands inside the multi-megabyte `graph` field), a handful of
+  reads and seeks, never a parse of the weights.
+
 #### TableFormer decoder: dynamic INT8 (~10% faster tables, byte-identical)
 
 The autoregressive tag decoder is MatMul-only; weights-only dynamic INT8


### PR DESCRIPTION
…guard the graph cache against truncated writes

Two leftovers from the round-four profile of master.

`resample::inter_area` (the page → 1024 px box filter every TableFormer crop is cut from) keeps its addition order — horizontal taps in increasing source column, then vertical taps in increasing source row, f64 — so the bytes are unchanged, and only its shape changes: shrunk source rows are computed on demand as the vertical pass reaches them and kept in a ring of a few rows (a source row feeds at most two output rows) instead of a 30 MB sh×dw intermediate written and re-read; the horizontal taps run over the contiguous byte span they cover; the vertical pass is a flat f64 axpy. 43 → 18 ms per page render (1224×1584 → 791×1024, one thread). A test asserts equality with the naive per-pixel form on six geometries; the 32-document corpus is byte-identical on the serial path and a 2-worker pool.

`docling_onnx::commit`: ONNX Runtime writes the optimized graph as a side effect of session creation and does not fail the session when that write comes up short — a full disk leaves a truncated file and the session still initializes from memory. The cache then published the prefix, and every later process tried it, failed, removed it and rebuilt (a ~50 s cold start for the TableFormer graphs, seen once after a disk-full episode). The commit path now checks the file's protobuf skeleton before renaming it into the cache: every top-level field's declared length must end within the file, a few reads and seeks, never a parse of the weights.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT