### PR TITLE
feat(rag): tell the UI whether answers are possible — `llm` on /healt…

### DIFF
--- a/crates/docling-rag/README.md
+++ b/crates/docling-rag/README.md
@@ -72,7 +72,7 @@ it can be public like `/health`.
 | Method | Path                  | Description                                     |
 |--------|-----------------------|-------------------------------------------------|
 | GET    | `/`                   | built-in search UI (no auth; static HTML)       |
-| GET    | `/health`             | liveness probe (no auth)                        |
+| GET    | `/health`             | liveness probe (no auth); `llm: true/false` + `llm_model` say whether answer synthesis is configured (`OPENROUTER_API_KEY`) — the UI greys out "LLM answer" with that reason when it is not |
 | GET    | `/api/stats`          | document / chunk counts                         |
 | GET    | `/api/documents`      | all documents with metadata + processing metrics |
 | POST   | `/api/documents`      | `?name=file.pdf` (+ optional `enrich_pictures`/`enrich_code`/`enrich_formulas=true`), raw file bytes as the body → full ingest (convert, chunk, embed); dedups identical content |

--- a/crates/docling-rag/src/api.rs
+++ b/crates/docling-rag/src/api.rs
@@ -10,7 +10,7 @@
 //! | Method | Path                  | Description                                   |
 //! |--------|-----------------------|-----------------------------------------------|
 //! | GET    | `/`                   | built-in search UI (public; static HTML)      |
-//! | GET    | `/health`             | liveness probe (public)                       |
+//! | GET    | `/health`             | liveness probe (public); `llm`: answers configured |
 //! | GET    | `/api/stats`          | document / chunk counts                       |
 //! | GET    | `/api/documents`      | all documents with metadata + metrics         |
 //! | POST   | `/api/documents`      | `?name=file.pdf` + enrich flags, raw bytes body → ingest |
@@ -75,9 +75,22 @@ pub fn router(pipeline: Pipeline, keys: Vec<String>) -> Result<Router> {
         // Public like /health — the page itself holds no data; every API call
         // it makes carries the key the user stored in localStorage.
         .route("/", get(|| async { Html(include_str!("ui.html")) }))
-        .route("/health", get(|| async { Json(json!({"status": "ok"})) }))
+        .route("/health", get(health))
         .merge(protected)
         .with_state(state))
+}
+
+/// Liveness probe, plus what the deployment can do: `llm` says whether
+/// answer synthesis is configured (`OPENROUTER_API_KEY`), so the UI can grey
+/// out "LLM answer" with the reason instead of surfacing a 400 after the
+/// fact. Holds no data, so it stays public like `/`.
+async fn health(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+    let llm = state.pipeline.has_llm();
+    Json(json!({
+        "status": "ok",
+        "llm": llm,
+        "llm_model": llm.then(|| state.pipeline.config().llm_model.clone()),
+    }))
 }
 
 /// Bind `addr` and serve until the process is stopped.

--- a/crates/docling-rag/src/pipeline.rs
+++ b/crates/docling-rag/src/pipeline.rs
@@ -121,6 +121,14 @@ impl Pipeline {
     }
 
     /// The resolved configuration this pipeline was built from.
+    /// Whether answer synthesis (and the LLM-backed query rewrites) is
+    /// available — an `OPENROUTER_API_KEY` was configured. The UI reads this
+    /// from `/health` to explain a missing answer instead of offering a
+    /// checkbox that can only fail.
+    pub fn has_llm(&self) -> bool {
+        self.chat.is_some()
+    }
+
     pub fn config(&self) -> &RagConfig {
         &self.cfg
     }

--- a/crates/docling-rag/src/ui.html
+++ b/crates/docling-rag/src/ui.html
@@ -44,6 +44,8 @@
            color: var(--muted); padding-bottom: 8px; }
   #stats { font-size: 13px; color: var(--muted); }
   #error { color: var(--bad); font-size: 14px; margin-top: 12px; white-space: pre-wrap; }
+  .hint { color: var(--muted); font-size: 12px; }
+  input[type=checkbox]:disabled + label { color: var(--muted); }
   .answer { border-left: 3px solid var(--accent); }
   .answer h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em;
                color: var(--muted); margin: 0 0 6px; }
@@ -133,8 +135,9 @@
         <label for="k">Top-k</label>
         <input id="k" type="number" min="1" max="100" style="width:5.5em" placeholder="cfg">
       </div>
-      <div class="check">
+      <div class="check" id="answer-box">
         <input id="answer" type="checkbox"><label for="answer" style="margin:0">LLM answer</label>
+        <span id="llm-hint" class="hint" hidden></span>
       </div>
       <div class="check" title="Show each hit with one chunk before and one after it">
         <input id="extend" type="checkbox"><label for="extend" style="margin:0">extend context</label>
@@ -181,10 +184,26 @@ async function api(path, init) {
 async function refreshHealth() {
   const el = $("status");
   try {
-    await fetch("/health").then((r) => { if (!r.ok) throw 0; });
+    const h = await fetch("/health").then((r) => { if (!r.ok) throw 0; return r.json(); });
     el.className = "ok"; $("status-text").textContent = "online";
+    showLlm(h);
   } catch {
     el.className = "bad"; $("status-text").textContent = "offline";
+  }
+}
+
+// Answer synthesis needs an LLM on the server (OPENROUTER_API_KEY). Without
+// one the checkbox could only produce a 400 after the search, so say so up
+// front and keep it unchecked; with one, name the model in the tooltip.
+function showLlm(h) {
+  const box = $("answer"), hint = $("llm-hint");
+  if (h.llm) {
+    box.disabled = false; hint.hidden = true;
+    $("answer-box").title = `answers by ${h.llm_model || "the configured LLM"}`;
+  } else {
+    box.disabled = true; box.checked = false; hint.hidden = false;
+    hint.textContent = "no LLM configured — set OPENROUTER_API_KEY in .env to get answers";
+    $("answer-box").title = hint.textContent;
   }
 }
 

--- a/crates/docling-rag/tests/api.rs
+++ b/crates/docling-rag/tests/api.rs
@@ -49,9 +49,16 @@ async fn spawn_server() -> (String, reqwest::Client) {
 async fn rest_api_end_to_end() {
     let (base, client) = spawn_server().await;
 
-    // /health is public.
+    // /health is public, and tells the UI whether answers are possible.
     let r = client.get(format!("{base}/health")).send().await.unwrap();
     assert_eq!(r.status(), 200);
+    let h: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(h["status"], "ok");
+    assert!(
+        h["llm"].is_boolean(),
+        "health reports llm availability: {h}"
+    );
+    assert_eq!(h["llm_model"].is_null(), !h["llm"].as_bool().unwrap());
 
     // Everything under /api requires a key.
     let r = client


### PR DESCRIPTION
…h, greyed-out "LLM answer" with the reason

Answer synthesis needs an LLM on the server (OPENROUTER_API_KEY). Without one, the UI still offered the "LLM answer" checkbox, and a search with it ticked failed only afterwards with a 400 — or, unticked, silently returned chunks and left the user wondering where the answer was.

`/health` now reports `llm: true/false` and `llm_model` (from `Pipeline::has_llm`); it holds no data, so it stays public. The UI reads it on load: with no LLM the checkbox is disabled, unchecked and annotated "no LLM configured — set OPENROUTER_API_KEY in .env to get answers"; with one, the tooltip names the model. The REST test asserts the new fields.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT