### PR TITLE
chore(py): refresh the pyo3 binding's Cargo.lock to the workspace ver…

### DIFF
--- a/crates/docling-py/Cargo.lock
+++ b/crates/docling-py/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "docling"
-version = "1.36.0"
+version = "1.42.0"
 dependencies = [
  "calamine",
  "csv",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "docling-asr"
-version = "1.36.0"
+version = "1.42.0"
 dependencies = [
  "docling-core",
  "docling-onnx",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "docling-core"
-version = "1.36.0"
+version = "1.42.0"
 dependencies = [
  "pulldown-cmark",
  "serde_json",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "docling-onnx"
-version = "1.36.0"
+version = "1.42.0"
 dependencies = [
  "docling-core",
  "ort",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "docling-pdf"
-version = "1.36.0"
+version = "1.42.0"
 dependencies = [
  "docling-core",
  "docling-onnx",


### PR DESCRIPTION
…sion

`crates/docling-py` builds outside the workspace with its own lockfile, which still pinned the docling crates at 1.36.0 while the workspace is at 1.42.0. Regenerated with `cargo check` in the crate directory; no other dependency moved.



Claude-Session: https://claude.ai/code/session_01EY5KAiquN4YpVf2PXEQkVT