### PR TITLE
TableFormer encoder — strip baked zero masks (bit-identical, 226 → 103 MB) + fp16-weight repack (54 MB, byte-identical corpus)

### DIFF
--- a/.github/workflows/publish-models.yml
+++ b/.github/workflows/publish-models.yml
@@ -112,6 +112,15 @@ jobs:
         continue-on-error: true
         run: python scripts/install/quantize_models.py tableformer-decoder
 
+      # fp16-weight repack of the encoder (#374): a size lever, not a
+      # quantization — fp32 compute, ~half the download. Self-gated on the
+      # calibration pages (deletes its output on a fidelity miss, so the
+      # release simply ships without it).
+      - name: Repack TableFormer encoder (fp16 weights)
+        if: steps.quant-deps.outcome == 'success' && steps.tf-export.outcome == 'success'
+        continue-on-error: true
+        run: python scripts/install/quantize_models.py tableformer-encoder-fp16
+
       # --- CodeFormula VLM (optional — the enrichment models are opt-in) ---
       # CodeFormulaV2 (Idefics3/SmolVLM-class, Apache-2.0) exported to the
       # three-graph ONNX set the Rust `--enrich-code`/`--enrich-formula`
@@ -200,6 +209,7 @@ jobs:
           stage .models/layout_heron.onnx layout_heron.onnx
           stage .models/layout_heron_int8.onnx layout_heron_int8.onnx
           stage .models/tableformer/encoder.onnx encoder.onnx
+          stage .models/tableformer/encoder_fp16.onnx encoder_fp16.onnx
           stage .models/tableformer/decoder.onnx decoder.onnx
           stage .models/tableformer/decoder_int8.onnx decoder_int8.onnx
           stage .models/tableformer/decoder_kv.onnx decoder_kv.onnx

--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ instead — same models plus `pdfium.dll` — and see
 | Whisper tiny (audio/ASR; skip with `--no-asr`) | `.models/asr/{encoder_model,decoder_model}.onnx`, `.models/asr/vocab.json` (+ `added_tokens.json` for language selection) |
 | Whisper presets (optional; `--asr-model=<preset>`, repeatable) | `.models/asr/<preset>/…` — English-only (`whisper_tiny_en`, `whisper_base_en`, `whisper_small_en`) and Distil-Whisper (`whisper_distil_small_en`) exports, fetched from Hugging Face |
 | INT8 CPU models (fetched by default; skip with `--no-int8`) | `.models/layout_heron_int8.onnx`, `.models/tableformer/decoder_int8.onnx` (+ `.models/code_formula/decoder_kv_int8.onnx` with `--enrich`) |
+| TableFormer encoder, fp16 weights (fetched by default; skip with `--no-int8`) | `.models/tableformer/encoder_fp16.onnx` — the same graph with fp16-stored weights cast back to fp32 at load (#374): half the download, fp32 compute; preferred when present, `DOCLING_RS_FP32=1` opts out |
 | DocumentFigureClassifier (picture classification) | `.models/picture_classifier.onnx` |
 | CodeFormulaV2 (code/formula enrichment, ~1.3 GB; fetch with `--enrich`) | `.models/code_formula/{vision,embed,decoder_kv}.onnx`, `.models/code_formula/tokenizer.json` |
 

--- a/crates/docling-node/deps.js
+++ b/crates/docling-node/deps.js
@@ -92,9 +92,23 @@ function homeDir(dir) {
  * `PDFIUM_DYNAMIC_LIB_PATH` environment variable wins (so a local Python export
  * is honored), else the path under the install home directory.
  */
+// `DOCLING_RS_FP32` truthiness, docling_core::env::flag's rule (anything but
+// empty / 0 / false / no / off).
+function fp32Forced() {
+  const v = (process.env.DOCLING_RS_FP32 || '').trim().toLowerCase()
+  return !['', '0', 'false', 'no', 'off'].includes(v)
+}
+
+// The first existing candidate, else the last one (the fp32 default, whose
+// absence the readiness check then reports).
+function firstExisting(candidates) {
+  return candidates.find((p) => fs.existsSync(p)) || candidates[candidates.length - 1]
+}
+
 function resolvePaths(dir) {
   const { home, dotModels } = homeDir(dir)
   const models = path.join(home, dotModels ? '.models' : 'models')
+  const tf = (name) => path.join(models, 'tableformer', name)
 
   const pdfiumLibDir = process.env.PDFIUM_DYNAMIC_LIB_PATH || path.join(home, '.pdfium', 'lib')
   return {
@@ -105,8 +119,12 @@ function resolvePaths(dir) {
     layout: process.env.DOCLING_LAYOUT_ONNX || path.join(models, 'layout_heron.onnx'),
     ocrRec: process.env.DOCLING_OCR_REC_ONNX || path.join(models, 'ocr_rec.onnx'),
     ocrDict: process.env.DOCLING_OCR_DICT || path.join(models, 'ppocr_keys_v1.txt'),
+    // The fp16-weight encoder repack (#374; fp32 compute, half the download)
+    // ranks ahead of the fp32 file, like the Rust pipeline's own chain,
+    // unless full precision is forced.
     tfEncoder:
-      process.env.DOCLING_TABLEFORMER_ENCODER || path.join(models, 'tableformer', 'encoder.onnx'),
+      process.env.DOCLING_TABLEFORMER_ENCODER ||
+      firstExisting(fp32Forced() ? [tf('encoder.onnx')] : [tf('encoder_fp16.onnx'), tf('encoder.onnx')]),
     tfDecoder:
       process.env.DOCLING_TABLEFORMER_DECODER || path.join(models, 'tableformer', 'decoder.onnx'),
     tfBbox: process.env.DOCLING_TABLEFORMER_BBOX || path.join(models, 'tableformer', 'bbox.onnx'),

--- a/crates/docling-pdf/src/tableformer.rs
+++ b/crates/docling-pdf/src/tableformer.rs
@@ -37,8 +37,25 @@ const N_LAYERS: usize = 6;
 /// measured, and it is byte-exact (its own int8 variant is not produced — see
 /// quantize_models.py).
 pub fn resolved_paths() -> (String, String, String) {
-    let enc = docling_core::env::nonempty("DOCLING_TABLEFORMER_ENCODER")
-        .unwrap_or_else(|| crate::resolve_asset(".models/tableformer/encoder.onnx"));
+    // The encoder ranks its fp16-weight repack (`encoder_fp16.onnx`, #374 —
+    // the same graph with the weights stored as fp16 and cast back to fp32
+    // at load, ~half the download, fp32 compute) ahead of the fp32 file
+    // unless `DOCLING_RS_FP32` opts out; an explicit override wins.
+    let enc = docling_core::env::nonempty("DOCLING_TABLEFORMER_ENCODER").unwrap_or_else(|| {
+        let candidates: &[&str] = if crate::prefer_fp32() {
+            &[".models/tableformer/encoder.onnx"]
+        } else {
+            &[
+                ".models/tableformer/encoder_fp16.onnx",
+                ".models/tableformer/encoder.onnx",
+            ]
+        };
+        candidates
+            .iter()
+            .map(|p| crate::resolve_asset(p))
+            .find(|p| std::path::Path::new(p).exists())
+            .unwrap_or_else(|| crate::resolve_asset(".models/tableformer/encoder.onnx"))
+    });
     let dec = docling_core::env::nonempty("DOCLING_TABLEFORMER_DECODER").unwrap_or_else(|| {
         let candidates: &[&str] = if crate::prefer_fp32() {
             &[

--- a/crates/docling-py/python/docling_rs/models.py
+++ b/crates/docling-py/python/docling_rs/models.py
@@ -62,6 +62,9 @@ _OPTIONAL = {
     "decoder_kv.onnx": "models/tableformer/decoder_kv.onnx",
     "decoder_kv.onnx.data": "models/tableformer/decoder_kv.onnx.data",
     "decoder_kv_int8.onnx": "models/tableformer/decoder_kv_int8.onnx",
+    # fp16-weight repack of the TableFormer encoder (#374): fp32 compute,
+    # half the download; the Rust pipeline prefers it unless fp32 is forced.
+    "encoder_fp16.onnx": "models/tableformer/encoder_fp16.onnx",
     # DocumentFigureClassifier-v2.5 (~17 MB) for do_picture_classification;
     # missing file just skips the enrichment with a one-time warning.
     "picture_classifier.onnx": "models/picture_classifier.onnx",
@@ -332,11 +335,12 @@ def ensure_env(dest: "str | Path | None" = None) -> Path:
     # to ch_; re-run download_models() to fetch it). The per-file vars stay
     # honored when the caller sets them — that is the pin-any-model hatch.
     _point_at("DOCLING_RS_MODELS_DIR", [".models"], m)
-    _point_at(
-        "DOCLING_TABLEFORMER_ENCODER",
-        _local(["models/tableformer/encoder.onnx"]),
-        m / "tableformer/encoder.onnx",
-    )
+    # Encoder: the fp16-weight repack (#374 — fp32 compute, half the download)
+    # ranks ahead of the fp32 file unless full precision is forced, mirroring
+    # tableformer.rs.
+    enc_chain = ["tableformer/encoder.onnx"] if fp32 else ["tableformer/encoder_fp16.onnx", "tableformer/encoder.onnx"]
+    encoder = next((p for rel in enc_chain if (p := m / rel).exists()), m / "tableformer/encoder.onnx")
+    _point_at("DOCLING_TABLEFORMER_ENCODER", _local([f"models/{rel}" for rel in enc_chain]), encoder)
     _point_at(
         "DOCLING_TABLEFORMER_BBOX",
         _local(["models/tableformer/bbox.onnx"]),

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -360,7 +360,9 @@ renderer-only/sandboxed setups.
   ~2.4× faster than fp32 at unchanged conformance). The TableFormer **encoder
   is fp32 (~103 MB since #374 stripped the exporter's six baked zero
   attention masks — the published 225 MB file was half `x + 0`; the stripped
-  graph is bit-identical) and runs once per table region** — it dominates wall time
+  graph is bit-identical; the native pipeline additionally prefers the 54 MB
+  `encoder_fp16.onnx` repack, byte-identical output on the snapshot corpus)
+  and runs once per table region** — it dominates wall time
   on mobile (a multi-table page can take minutes). An int8 encoder is *not* the
   easy win it looks like: it's a ResNet backbone (~20 Conv) feeding a 6-layer
   transformer, and the transformer Gemms — not the convs — are the cost.

--- a/crates/docling-wasm/README.md
+++ b/crates/docling-wasm/README.md
@@ -206,7 +206,7 @@ wasm output matching native — drift can only come from the runtime kernels.
 |---|---|---|
 | **1** — `ocr_image` | OCR a single scanned **image** | PP-OCRv3 recognition (~10 MB) |
 | **2** — `ScannedConverter` / `convert_scanned_image` | Scanned **PDF/image** → Markdown: layout + OCR + reading order, tables via geometric reconstruction | + RT-DETR layout (`layout_heron_int8.onnx`, ~68 MB) |
-| **3** — `ScannedConverter.addPageTf` | Real **TableFormer** table structure, on the tables that need it | + `tableformer/{encoder,decoder_kv,bbox}.onnx` (~380 MB) |
+| **3** — `ScannedConverter.addPageTf` | Real **TableFormer** table structure, on the tables that need it | + `tableformer/{encoder,decoder_kv,bbox}.onnx` (~260 MB; ~380 MB with the pre-#374 encoder) |
 
 Stage 3 is *selective*. TableFormer's encoder runs once per table region and
 costs seconds, so each table is first reconstructed geometrically (free, from
@@ -277,7 +277,7 @@ same-origin, from a CORS host, **or straight from files on your device**.
      images"* and select `layout_heron_int8.onnx` and, for TableFormer,
      `encoder.onnx`, `decoder_kv.onnx` (+`.data`), `bbox.onnx` (+`.data`). Each
      file is read to an `ArrayBuffer` on the client and used directly — no
-     download, and a single allocation per file (a 225 MB encoder over
+     download, and a single allocation per file (a 100+ MB encoder over
      `fetch` can OOM a mobile tab; a `File` read does not); or
    - **from a CORS mirror** — a Hugging Face model repo serves
      `Access-Control-Allow-Origin` (GitHub Release assets do not); point
@@ -358,7 +358,9 @@ renderer-only/sandboxed setups.
   browsers), and everything runs serially.
 - **int8.** The layout model is the conv-only static-INT8 export (~68 MB,
   ~2.4× faster than fp32 at unchanged conformance). The TableFormer **encoder
-  is fp32 (~225 MB) and runs once per table region** — it dominates wall time
+  is fp32 (~103 MB since #374 stripped the exporter's six baked zero
+  attention masks — the published 225 MB file was half `x + 0`; the stripped
+  graph is bit-identical) and runs once per table region** — it dominates wall time
   on mobile (a multi-table page can take minutes). An int8 encoder is *not* the
   easy win it looks like: it's a ResNet backbone (~20 Conv) feeding a 6-layer
   transformer, and the transformer Gemms — not the convs — are the cost.
@@ -368,7 +370,7 @@ renderer-only/sandboxed setups.
   cross-attention fidelity to ~0.85 (garbled structure) for no speed gain. So
   the encoder stays fp32; the real mobile levers are running heavy tables on a
   desktop and batching multi-table pages (below), not weight quantization.
-- **Where to run heavy tables.** TableFormer's 380 MB of models and per-region
+- **Where to run heavy tables.** TableFormer's ~260 MB of models and per-region
   encode make a desktop (more cores, more memory) far faster than a phone; the
   geometric table path (stage 2, no TableFormer) already captures all cell text
   and is the light option for mobile.

--- a/docs/MODELS_NOTICE.md
+++ b/docs/MODELS_NOTICE.md
@@ -10,7 +10,7 @@ tokenizer). All are licensed separately from docling.rs's own MIT code (see
 | Model | Source | License |
 |---|---|---|
 | RT-DETR layout model (`layout_heron.onnx`) | [`docling-project/docling-layout-heron`](https://huggingface.co/docling-project/docling-layout-heron) | Apache-2.0 |
-| TableFormer (`tableformer/{encoder,decoder,bbox}.onnx`) | [`docling-project/docling-models`](https://huggingface.co/docling-project/docling-models) (`model_artifacts/tableformer/accurate`) | CDLA-Permissive-2.0 / Apache-2.0 |
+| TableFormer (`tableformer/{encoder,decoder,bbox}.onnx`; `encoder_fp16.onnx` is the same export with fp16-stored weights, `*_int8` post-training quantizations) | [`docling-project/docling-models`](https://huggingface.co/docling-project/docling-models) (`model_artifacts/tableformer/accurate`) | CDLA-Permissive-2.0 / Apache-2.0 |
 | DocumentFigureClassifier (`picture_classifier.onnx`) | [`docling-project/DocumentFigureClassifier-v2.5`](https://huggingface.co/docling-project/DocumentFigureClassifier-v2.5) (upstream's own ONNX, re-hosted unmodified) | Apache-2.0 |
 | CodeFormulaV2 (`cf_{vision,embed,decoder_kv}.onnx` + `cf_tokenizer.json`; `cf_decoder_kv_int8.onnx` is a post-training quantization of the same export) | [`docling-project/CodeFormulaV2`](https://huggingface.co/docling-project/CodeFormulaV2) | Apache-2.0 |
 | PP-OCRv3 recognition model + dictionary, multilingual (`ocr_rec.onnx`, `ppocr_keys_v1.txt`) | [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)'s `ch_PP-OCRv3_rec_infer`, taken as the ready ONNX conversion re-hosted by [`SWHL/RapidOCR`](https://huggingface.co/SWHL/RapidOCR) (unmodified) | Apache-2.0 |

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -767,6 +767,26 @@ models at the default paths, the pipeline loads them automatically.
 conformance/groundtruth scripts pin fp32 explicitly, so snapshots stay
 deterministic).
 
+#### TableFormer encoder: not quantized, but half its size (#374)
+
+The encoder is a ~20-Conv ResNet backbone feeding a 6-layer transformer, and
+the transformer Gemms — not the convs — are its cost. INT8 was measured and
+rejected: conv-only static QDQ keeps fidelity (enc_out / cross-K/V cosine
+≥ 0.995) but is not faster than ORT's fp32 conv kernels, and quantizing the
+attention MatMuls collapses cross-attention fidelity to ~0.85 (garbled table
+structure). What *was* wrong with the published 215 MiB `encoder.onnx` is
+exporter waste: the explicit all-false attention mask handed to the
+transformer encoder was materialized as a zero `[1,8,784,784]` fp32 constant
+(18.8 MiB) baked into each of the six layers — 112.6 MiB of `x + 0` around
+103 MiB of real weights (42.6 MiB Conv, 60 MiB MatMul/Gemm).
+`scripts/install/strip_zero_masks.py` (run by the export) removes those `Add`
+nodes; the stripped graph's outputs are bit-identical to the original's
+(onnxruntime, max |diff| = 0), so the republished encoder changes nothing but
+the download. An fp16-weight / fp32-compute variant (~52 MiB, cosine 1.000000
+and max relative error 1.4e-3 against fp32 on synthetic input) is the next
+size lever if a package needs it; it would ship as a separate file behind the
+conformance gate, never as the default.
+
 #### Layout: static QDQ INT8, **Conv ops only** (~2.4× faster layout)
 
 Calibrated on 42 real corpus pages preprocessed exactly like

--- a/docs/PDF_CONFORMANCE.md
+++ b/docs/PDF_CONFORMANCE.md
@@ -782,10 +782,17 @@ transformer encoder was materialized as a zero `[1,8,784,784]` fp32 constant
 `scripts/install/strip_zero_masks.py` (run by the export) removes those `Add`
 nodes; the stripped graph's outputs are bit-identical to the original's
 (onnxruntime, max |diff| = 0), so the republished encoder changes nothing but
-the download. An fp16-weight / fp32-compute variant (~52 MiB, cosine 1.000000
-and max relative error 1.4e-3 against fp32 on synthetic input) is the next
-size lever if a package needs it; it would ship as a separate file behind the
-conformance gate, never as the default.
+the download. On top of that, `encoder_fp16.onnx` (`quantize_models.py
+tableformer-encoder-fp16`) stores the same graph's weights as fp16 behind a
+`Cast` back to fp32 — ORT folds the cast at load, so compute, speed and
+memory are those of the fp32 encoder and only the file shrinks, 103 → 54 MB
+(4.2× below the original 226 MB). Fidelity gate on the 54 calibration inputs:
+cosine ≥ 0.999999, relative L2 error ≤ 1.5e-3 per output tensor; and over the
+full 101-file snapshot corpus the fp16 encoder's Markdown is **byte-identical**
+to the fp32 encoder's (same machine, same binary, `diff -rq` empty). It is
+therefore preferred when present, like the INT8 decoder; `DOCLING_RS_FP32=1`
+or an explicit `DOCLING_TABLEFORMER_ENCODER` keeps the fp32 file. INT8 for
+the encoder stays off the table.
 
 #### Layout: static QDQ INT8, **Conv ops only** (~2.4× faster layout)
 

--- a/scripts/install/download_dependencies.sh
+++ b/scripts/install/download_dependencies.sh
@@ -52,6 +52,7 @@
 # docs/PDF_CONFORMANCE.md — ~2.4x faster layout inference at unchanged conformance):
 #   .models/layout_heron_int8.onnx
 #   .models/tableformer/decoder_int8.onnx
+#   .models/tableformer/encoder_fp16.onnx   (fp16-weight repack, fp32 compute; #374)
 # The pipeline picks these up automatically when they sit next to the fp32
 # files (no env vars needed); set DOCLING_RS_FP32=1 at runtime to force full
 # precision, or skip fetching them entirely with --no-int8. If the release
@@ -345,6 +346,9 @@ if [ "$WITH_INT8" = true ]; then
   fetch_optional "$BASE_URL/decoder_int8.onnx" .models/tableformer/decoder_int8.onnx
   fetch_optional "$BASE_URL/decoder_kv_int8.onnx" .models/tableformer/decoder_kv_int8.onnx
   fetch_optional "$BASE_URL/decoder_kv_int8.onnx.data" .models/tableformer/decoder_kv_int8.onnx.data
+  # fp16-weight repack of the TableFormer encoder (#374): fp32 compute, half
+  # the download; preferred when present, DOCLING_RS_FP32=1 opts out.
+  fetch_optional "$BASE_URL/encoder_fp16.onnx" .models/tableformer/encoder_fp16.onnx
   if [ -f .models/layout_heron_int8.onnx ]; then
     echo "int8 models present — used by default (DOCLING_RS_FP32=1 forces full precision)"
   else

--- a/scripts/install/export_tableformer.py
+++ b/scripts/install/export_tableformer.py
@@ -9,7 +9,9 @@ We export three graphs and drive the loop from Rust:
   encoder.onnx : image[1,3,448,448]
                    -> cross_k/cross_v[L,1,H,784,head_dim], enc_out[1,28,28,512]
                  (the per-layer cross-attention K/V, projected from the image
-                  memory once so the decoder never re-projects it)
+                  memory once so the decoder never re-projects it; ~103 MiB
+                  once strip_zero_masks.py has dropped the exporter's baked
+                  zero attention masks, #374)
   decoder.onnx : tags[seq,1] + cross_k + cross_v + cache[L,past,1,512]
                    -> logits[1,V], hidden[1,512], out_cache[L,past+1,1,512]
                  (doubly-cached step: self-attn state cache + precomputed cross K/V;
@@ -390,6 +392,18 @@ torch.onnx.export(
     + [f"cross_v_{i}" for i in range(N_LAYERS)],
     opset_version=17, dynamo=False,
 )
+# The explicit all-false `mask` handed to `tt._encoder` (kept so the module
+# runs docling's own code path, not nn.TransformerEncoder's fused fast path)
+# is materialized by the legacy exporter as a float additive mask — a zero
+# [1,8,784,784] constant, 18.8 MiB, baked into every encoder layer: 112.6 MiB
+# of `x + 0` in a 215 MiB file whose real weights are 103 MiB (#374). Adding
+# zero is the identity, so the dead Adds are dropped here; the ORT check below
+# then verifies the stripped graph against the PyTorch outputs like before.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from strip_zero_masks import strip_zero_mask_adds  # noqa: E402
+
+_removed, _freed = strip_zero_mask_adds(f"{OUT}/encoder.onnx")
+print(f"encoder.onnx: stripped {_removed} zero-mask Add nodes ({_freed / 2**20:.1f} MiB)")
 tags = torch.full((3, 1), start, dtype=torch.long)
 cache0 = torch.zeros((N_LAYERS, 2, 1, EMBED_DIM))  # trace with past>0 → symbolic
 with torch.no_grad():

--- a/scripts/install/quantize_models.py
+++ b/scripts/install/quantize_models.py
@@ -19,6 +19,15 @@ docs/PDF_CONFORMANCE.md for the measured speed/quality numbers):
   stem convs stay fp32 (`stem_convs`), and activation ranges come from a
   per-page moving average (`CalibMovingAverage`).
 
+* **tableformer-encoder-fp16** — the TableFormer encoder with its weights
+  stored as fp16 and cast back to fp32 at load (`encoder_fp16.onnx`, #374).
+  Compute stays fp32, so this is a *size* lever (~103 → ~52 MiB after the
+  export's zero attention masks are stripped), not a speed one; the only
+  numeric change is fp16 rounding of the weights. Self-validates against the
+  fp32 encoder on the calibration pages (cross-K/V and enc_out cosine ≥
+  0.9999, relative L2 error ≤ 0.5 %) and deletes its output on failure; the real
+  gate is the PDF snapshot corpus (`scripts/conformance/pdf_conformance.sh`
+  with `DOCLING_TABLEFORMER_ENCODER` pointed at it).
 * **tableformer-decoder** — dynamic INT8 (weights-only MatMul) of the
   legacy autoregressive tag decoder (~10% faster than its fp32 file,
   78 -> 50 MB). Byte-exactness is quantizer-environment-sensitive:
@@ -72,9 +81,10 @@ CALIB = os.environ.get("DOCLING_RS_CALIBRATION_DIR")
 SIDE = 640  # layout model input side (layout.rs)
 
 
-def calibration_pages():
+def calibration_pages(side=SIDE):
     """Render up to 3 pages of every calibration PDF the way layout.rs
-    preprocesses: pdfium at scale 2.0, resize to 640x640 bilinear, /255, CHW
+    preprocesses: pdfium at scale 2.0, resize to `side`×`side` bilinear (640
+    for the layout model, 448 for the TableFormer encoder), /255, CHW
     float32."""
     import pypdfium2 as pdfium
     from PIL import Image
@@ -94,7 +104,7 @@ def calibration_pages():
             continue
         for i in range(min(3, len(doc))):
             bmp = doc[i].render(scale=2.0)
-            img = bmp.to_pil().convert("RGB").resize((SIDE, SIDE), Image.BILINEAR)
+            img = bmp.to_pil().convert("RGB").resize((side, side), Image.BILINEAR)
             arr = np.asarray(img, dtype=np.float32) / 255.0
             yield np.transpose(arr, (2, 0, 1))[None, ...]
         doc.close()
@@ -460,6 +470,101 @@ def quantize_tableformer_decoder():
         print(f"tableformer-decoder: done -> {dst} ({os.path.getsize(dst) / 1e6:.1f} MB)")
 
 
+def repack_tableformer_encoder_fp16():
+    """`encoder.onnx` → `encoder_fp16.onnx`: every fp32 weight tensor of at
+    least 4096 elements is stored as fp16 behind a `Cast(to=FLOAT)`, so ORT
+    folds it back to fp32 at session creation and the graph computes exactly
+    as before — only the file (and the download) shrinks, ~2×. Small tensors
+    (biases, LayerNorm scales) stay fp32: they cost nothing and their rounding
+    would be pure noise. The exporter's baked zero attention masks are
+    stripped first (strip_zero_masks.py), so the result is small even from a
+    pre-#374 encoder."""
+    import onnx
+    import onnxruntime as ort
+    from onnx import helper, numpy_helper
+
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from strip_zero_masks import strip_zero_mask_adds
+
+    src = f"{MODELS}/tableformer/encoder.onnx"
+    dst = f"{MODELS}/tableformer/encoder_fp16.onnx"
+    if not os.path.exists(src):
+        sys.exit(f"tableformer-encoder-fp16: {src} not found")
+    removed, freed = strip_zero_mask_adds(src, dst)
+    if removed:
+        print(f"tableformer-encoder-fp16: stripped {removed} zero-mask Add(s), {freed / 2**20:.1f} MiB", flush=True)
+
+    MIN_ELEMS = 4096
+    model = onnx.load(dst)
+    g = model.graph
+    converted = 0
+    nodes = []
+    for n in g.node:
+        if n.op_type == "Constant":
+            attr = next((a for a in n.attribute if a.name == "value"), None)
+            if attr is not None and attr.t.data_type == onnx.TensorProto.FLOAT:
+                arr = numpy_helper.to_array(attr.t)
+                if arr.size >= MIN_ELEMS:
+                    half = n.output[0] + "_fp16"
+                    nodes.append(helper.make_node("Constant", [], [half], value=numpy_helper.from_array(arr.astype(np.float16), half)))
+                    nodes.append(helper.make_node("Cast", [half], [n.output[0]], to=onnx.TensorProto.FLOAT))
+                    converted += arr.nbytes // 2
+                    continue
+        nodes.append(n)
+    casts = []
+    for t in list(g.initializer):
+        if t.data_type == onnx.TensorProto.FLOAT:
+            arr = numpy_helper.to_array(t)
+            if arr.size >= MIN_ELEMS:
+                half = t.name + "_fp16"
+                g.initializer.remove(t)
+                g.initializer.append(numpy_helper.from_array(arr.astype(np.float16), half))
+                casts.append(helper.make_node("Cast", [half], [t.name], to=onnx.TensorProto.FLOAT))
+                converted += arr.nbytes // 2
+    del g.node[:]
+    g.node.extend(casts + nodes)
+    onnx.checker.check_model(model)
+    onnx.save(model, dst)
+    print(
+        f"tableformer-encoder-fp16: {converted / 2**20:.1f} MiB of weights halved -> {dst} "
+        f"({os.path.getsize(dst) / 1e6:.1f} MB vs {os.path.getsize(src) / 1e6:.1f} MB)",
+        flush=True,
+    )
+
+    # Fidelity gate against the fp32 encoder: the calibration pages resized
+    # to the encoder's 448×448 input plus two synthetic inputs. Cosine and
+    # relative error over every output (cross K/V per layer, enc_out).
+    so = ort.SessionOptions()
+    so.intra_op_num_threads = max(1, (os.cpu_count() or 2) // 2)
+    ref = ort.InferenceSession(src, so, providers=["CPUExecutionProvider"])
+    out = ort.InferenceSession(dst, so, providers=["CPUExecutionProvider"])
+    rng = np.random.default_rng(0)
+    inputs = [rng.standard_normal((1, 3, 448, 448), dtype=np.float32) for _ in range(2)]
+    inputs += list(calibration_pages(side=448))
+    # Gate on the relative L2 error per output tensor (‖a−b‖/‖a‖, the metric
+    # that tracks how far the decoder's attention inputs moved) plus cosine;
+    # the worst single element is reported for information only — fp16
+    # rounding of one weight can move one element of a 3.2M-element tensor
+    # by ~1 % of its range without the tensor moving at all.
+    min_cos, max_rel_l2, max_elem = 1.0, 0.0, 0.0
+    for x in inputs:
+        for a, b in zip(ref.run(None, {"image": x}), out.run(None, {"image": x})):
+            a = a.ravel().astype(np.float64)
+            b = b.ravel().astype(np.float64)
+            na = np.linalg.norm(a) + 1e-30
+            min_cos = min(min_cos, float(a @ b / (na * (np.linalg.norm(b) + 1e-30))))
+            max_rel_l2 = max(max_rel_l2, float(np.linalg.norm(a - b) / na))
+            max_elem = max(max_elem, float(np.abs(a - b).max() / (np.abs(a).max() + 1e-30)))
+    print(
+        f"tableformer-encoder-fp16: {len(inputs)} inputs, min cosine {min_cos:.6f}, "
+        f"max relative L2 error {max_rel_l2:.3g}, worst element {max_elem:.3g} of the tensor's range",
+        flush=True,
+    )
+    if min_cos < 0.9999 or max_rel_l2 > 0.005:
+        os.remove(dst)
+        sys.exit("tableformer-encoder-fp16: fidelity gate FAILED — output deleted")
+
+
 def quantize_code_formula_decoder():
     """Dynamic INT8 (weights-only MatMul) of the CodeFormulaV2 KV-cache decoder
     step — the autoregressive stage that dominates enrichment latency. Same
@@ -514,12 +619,15 @@ def main():
             validate_layout(f"{MODELS}/layout_heron.onnx", f"{MODELS}/layout_heron_int8.onnx")
         elif t == "tableformer-decoder":
             quantize_tableformer_decoder()
+        elif t == "tableformer-encoder-fp16":
+            repack_tableformer_encoder_fp16()
         elif t == "code-formula-decoder":
             quantize_code_formula_decoder()
         else:
             sys.exit(
                 f"unknown target {t!r} "
-                "(expected: layout, validate-layout, tableformer-decoder, code-formula-decoder)"
+                "(expected: layout, validate-layout, tableformer-decoder, "
+                "tableformer-encoder-fp16, code-formula-decoder)"
             )
 
 

--- a/scripts/install/strip_zero_masks.py
+++ b/scripts/install/strip_zero_masks.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Drop the all-zero attention masks the TableFormer encoder export bakes in (#374).
+
+`export_tableformer.py` calls the tag-transformer encoder with the explicit
+`mask=torch.zeros((heads, 784, 784), dtype=torch.bool)` docling's module
+expects. The legacy ONNX exporter turns that bool mask into the additive
+float mask nn.MultiheadAttention adds to the attention scores — a constant
+`[1, 8, 784, 784]` fp32 tensor of zeros, 18.8 MiB, materialized once per
+encoder layer. Six layers → 112.6 MiB of `x + 0` in a 215 MiB file whose real
+weights are 103 MiB (42.6 MiB of ResNet convs, 60 MiB of transformer
+MatMul/Gemm).
+
+Adding a zero tensor is the identity, so removing those `Add` nodes and
+re-wiring their consumers to the other operand is exact: the stripped graph's
+outputs are bit-identical to the original's (checked with onnxruntime on the
+published models-v1 encoder, max |diff| = 0). The mask stays explicit in the
+export itself so the PyTorch module runs the same code path docling runs
+(`mask=None` could route nn.TransformerEncoder onto its fused fast path and
+change the numerics the byte-exact OTSL verification depends on).
+
+Usage — in place, or into a second file:
+
+    python scripts/install/strip_zero_masks.py .models/tableformer/encoder.onnx [out.onnx]
+
+Only `Add` nodes whose one operand is a *constant that is entirely zero* and at
+least 1 MiB are touched; anything else in the graph is left as it is. The
+script refuses (non-zero exit) when such an operand turns out not to be
+all-zero, so a future export that carries a real mask cannot be silently
+broken.
+"""
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import numpy_helper
+
+MIN_BYTES = 1 << 20  # only the mask-sized constants; small biases stay
+
+
+def strip_zero_mask_adds(src, dst=None):
+    """Remove `Add(x, zeros)` nodes fed by a large all-zero constant; returns
+    (nodes removed, bytes freed). Saves to `dst` (default: over `src`)."""
+    dst = dst or src
+    model = onnx.load(src)
+    g = model.graph
+    const_nodes = {n.output[0]: n for n in g.node if n.op_type == "Constant"}
+    inits = {t.name: t for t in g.initializer}
+
+    def constant_value(name):
+        if name in inits:
+            return numpy_helper.to_array(inits[name])
+        node = const_nodes.get(name)
+        if node is None:
+            return None
+        for attr in node.attribute:
+            if attr.name == "value":
+                return numpy_helper.to_array(attr.t)
+        return None
+
+    rewired = {}
+    kept = []
+    removed = freed = 0
+    for n in g.node:
+        if n.op_type == "Add" and len(n.input) == 2:
+            big = None
+            for i in n.input:
+                v = constant_value(i)
+                if v is not None and v.nbytes >= MIN_BYTES:
+                    big = (i, v)
+                    break
+            if big is not None:
+                name, v = big
+                if v.dtype.kind not in "fiu" or v.any():
+                    raise SystemExit(
+                        f"{src}: Add operand {name} ({v.shape}, {v.dtype}) is not "
+                        "all-zero — refusing to strip a real mask"
+                    )
+                other = [i for i in n.input if i != name][0]
+                rewired[n.output[0]] = other
+                removed += 1
+                freed += v.nbytes
+                continue
+        kept.append(n)
+    # Re-wire consumers (chains resolve transitively) and drop the now-dead
+    # constants; graph outputs that pointed at a removed Add keep their names
+    # through an Identity so the exported signature does not change.
+    for n in kept:
+        for k, i in enumerate(n.input):
+            while i in rewired:
+                i = rewired[i]
+            n.input[k] = i
+    for out in g.output:
+        if out.name in rewired:
+            src_name = out.name
+            while src_name in rewired:
+                src_name = rewired[src_name]
+            kept.append(onnx.helper.make_node("Identity", [src_name], [out.name]))
+    used = {i for n in kept for i in n.input} | {o.name for o in g.output}
+    kept = [n for n in kept if n.op_type != "Constant" or n.output[0] in used]
+    for t in [t for t in g.initializer if t.name not in used]:
+        g.initializer.remove(t)
+    del g.node[:]
+    g.node.extend(kept)
+    onnx.checker.check_model(model)
+    onnx.save(model, dst)
+    return removed, freed
+
+
+def main(argv):
+    if len(argv) not in (2, 3):
+        sys.exit(__doc__)
+    src = argv[1]
+    dst = argv[2] if len(argv) == 3 else None
+    before = os.path.getsize(src)
+    removed, freed = strip_zero_mask_adds(src, dst)
+    after = os.path.getsize(dst or src)
+    print(
+        f"{os.path.basename(src)}: removed {removed} zero-mask Add node(s) "
+        f"({freed / 2**20:.1f} MiB of constants); {before / 2**20:.1f} → {after / 2**20:.1f} MiB"
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Refs #374 — the encoder was the largest asset in models-v1 (226 MB) with no reduced-size variant.

## What was wrong with the file

A census of the published `encoder.onnx` (215 MiB):

| | |
|---|---:|
| Conv weights (ResNet backbone, 20 convs) | 42.6 MiB |
| MatMul/Gemm weights (6-layer transformer + hoisted cross-K/V projections) | 60.0 MiB |
| six identical **all-zero** attention masks, `[1,8,784,784]` fp32, one per encoder layer | **112.6 MiB** |

The export hands the tag-transformer encoder an explicit all-false `mask`; the legacy ONNX exporter materializes it as a float additive mask and bakes it into every layer as an `Add` constant. Half the file is `x + 0`.

## Commit 1 — `fix(models)`: strip the zero masks at export

- `scripts/install/strip_zero_masks.py` removes `Add(x, zeros)` nodes fed by a ≥ 1 MiB all-zero constant and re-wires their consumers; it refuses when such an operand is not all-zero, so a real mask can never be stripped by accident. Usable standalone on an already-published file.
- `export_tableformer.py` runs it right after the encoder export, before the existing ORT-vs-PyTorch check. The mask itself stays explicit in the export so the module keeps docling's code path (`mask=None` could route `nn.TransformerEncoder` onto its fused fast path).
- Verified on the published models-v1 encoder: outputs **bit-identical** on random inputs (`max |diff| = 0`), same output names, idempotent, 215.4 → 102.8 MiB.

## Commit 2 — `perf(models)`: `encoder_fp16.onnx`

- `quantize_models.py tableformer-encoder-fp16`: the stripped graph with every fp32 weight tensor of ≥ 4096 elements stored as fp16 behind a `Cast(to=FLOAT)`. ORT folds the cast at session creation, so compute, speed and runtime memory are the fp32 encoder's; only the file shrinks, 103 → 54 MB. Small tensors (biases, LayerNorm) stay fp32.
- Self-gate against the fp32 encoder on 54 calibration inputs (448×448 renders of the corpus): cosine ≥ 0.9999 and relative L2 error ≤ 0.5 % per output tensor (measured 0.999999 / 1.5e-3); the output is deleted on a miss, so a release simply ships without it.
- **Corpus verification:** the full 101-file PDF snapshot corpus regenerated with `DOCLING_TABLEFORMER_ENCODER` pointed at the fp16 file is byte-identical to the fp32 encoder's output (same machine, same binary, `diff -rq` empty).
- Preferred when present, like the INT8 decoder: `tableformer.rs` ranks `encoder_fp16.onnx` ahead of `encoder.onnx` unless `DOCLING_RS_FP32` is set or `DOCLING_TABLEFORMER_ENCODER` names a file; the Python (`ensure_env`) and Node (`deps.js`) bindings mirror the chain. `download_dependencies.sh` fetches it with the other reduced-size assets (`--no-int8` skips it); the publish-models workflow produces and stages it after the decoder quantization.

## INT8 for the encoder

Measured earlier and documented in the wasm README: conv-only static QDQ keeps fidelity but is not faster than ORT's fp32 conv kernels, and quantizing the attention MatMuls collapses cross-attention fidelity to ~0.85. With the convs at 43 MiB there is also little size to gain. It stays off the table; the notes are now in `docs/PDF_CONFORMANCE.md` too.

## After merge

Re-run the `publish models` workflow with the `models-v1` tag: it re-exports the stripped `encoder.onnx` and adds `encoder_fp16.onnx`. Nothing downstream changes but the download; `download_dependencies.sh` picks both up as-is. Only `fix:`/`perf:` commits, so the merge cuts a patch release.

Docs: README asset table, MODELS_NOTICE, PDF_CONFORMANCE (new encoder section), wasm README sizes.